### PR TITLE
[DOC] Fixed @ricky-lim's syntax

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -29,6 +29,6 @@ With thanks to the following contributors:
 - `@jack-kessler-88 <https://github.com/jack-kessler-88>`_
 - `@NapsterInBlue <https://github.com/NapsterInBlue>`_
 - `@jk3587 <https://github.com/jk3587>`_
-- `@ricky-lim<https://github.com/ricky-lim>`_
+- `@ricky-lim <https://github.com/ricky-lim>`_
 - `@catherinedevlin <https://github.com/catherinedevlin>`_
 - `@StephenSchroed <https://github.com/StephenSchroeder>`_


### PR DESCRIPTION
Just fixes @ricky-lim's github handle on the AUTHORS.rst document so that it is displayed correctly.