### PR TITLE
[ENH] Issue 707 test for monotonicity in timestamps

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -90,5 +90,4 @@ Contributors
 - `@evan-anderson <https://github.com/evan-anderson>`_ | `contributions <https://github.com/ericmjl/pyjanitor/pulls?utf8=%E2%9C%93&q=is%3Aclosed+mentions%3evan-anderson>`_
 - `@smu095 <https://github.com/smu095>`_ | `contributions <https://github.com/ericmjl/pyjanitor/issues?q=is%3Aclosed+mentions%3smu095>`_
 - `@VPerrollaz <https://github.com/VPerrollaz>`_ | `contributions <https://github.com/ericmjl/pyjanitor/issues?q=is%3Aclosed+mentions%3AVPerrollaz>`_
-- `@UGuntupalli <https://github.com/UGuntupalli>`_ | `contributions <https://github.com/UGuntupalli/pyjanitor/tree/issue_705_flag_and_fill_timestamps>`_
-    - Introducing data checking and data cleaning functions for timeseries data 
+- `@UGuntupalli <https://github.com/UGuntupalli>`_ | `contributions < https://github.com/ericmjl/pyjanitor/issues?q=is%3Aclosed+mentions%3AUGuntupalli >`_

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -90,3 +90,5 @@ Contributors
 - `@evan-anderson <https://github.com/evan-anderson>`_ | `contributions <https://github.com/ericmjl/pyjanitor/pulls?utf8=%E2%9C%93&q=is%3Aclosed+mentions%3evan-anderson>`_
 - `@smu095 <https://github.com/smu095>`_ | `contributions <https://github.com/ericmjl/pyjanitor/issues?q=is%3Aclosed+mentions%3smu095>`_
 - `@VPerrollaz <https://github.com/VPerrollaz>`_ | `contributions <https://github.com/ericmjl/pyjanitor/issues?q=is%3Aclosed+mentions%3AVPerrollaz>`_
+- `@UGuntupalli <https://github.com/UGuntupalli>`_ | `contributions <https://github.com/UGuntupalli/pyjanitor/tree/issue_705_flag_and_fill_timestamps>`_
+    - Introducing data checking and data cleaning functions for timeseries data 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ new version (on deck)
 - [ENH] Added ``process_text`` wrapper function for all Pandas string methods. @samukweku
 - [TST] Only skip tests for non-installed libraries on local machine. @hectormz
 - [DOC] Fix minor issues in documentation. @hectormz
+- [ENH] Introducing timeseries module. Adding ```fill_missing_timestamps``` function @UGuntupalli 
 
 
 v0.20.7

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@ new version (on deck)
 =====================
 - [ENH] Updated groupby_agg function to account for null entries in the ``by`` argument. @samukweku
 - [ENH] Added function ``groupby_topk`` to janitor functions @mphirke
+- [ENH] Added function ```sort_timestamps_monotonically```. @UGuntupalli
 
 
 v0.20.8

--- a/janitor/timeseries.py
+++ b/janitor/timeseries.py
@@ -57,10 +57,10 @@ def _flag_missing_timestamps(
     # Check if they are the same
     comparison_index = expected_timestamps.difference(actual_timestamps)
     if comparison_index.empty:
+        result['flag'] = False
+    else:
         result['flag'] = True
         result['new_index'] = expected_timestamps
-    else:
-        result['flag'] = False
 
     # Return the result as a Named Tuple
     return MissingTimeStampFlag._make(result)

--- a/janitor/timeseries.py
+++ b/janitor/timeseries.py
@@ -19,18 +19,22 @@ def _flag_missing_timestamps(
     """
     Test if timestamps are missing
 
-    Utility function to test if input data frame is missing any timestamps relative to expected timestamps.
-    They are generated based on the first_time_stamp, last_time_stamp and frequency.
+    Utility function to test if input data frame
+    is missing timestamps relative to expected timestamps.
+    They are generated based on the first_time_stamp,
+    last_time_stamp
+    and frequency.
 
-    :param df: data frame which needs to be tested for missing timestamps
-    :param frequency: frequency i.e. sampling frequency of the data.
-        A list of acceptable frequency strings are available here:
-        (https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases)
-    :param column_name: name of the column which has time series if not the index.
-    :param first_time_stamp: timestamp at which the time_series is expected to start from.
-    :param last_time_stamp: timestamp at which the time_series is expected to end with.
+    :param df: data frame to test for missing timestamps
+    :param frequency: frequency i.e. sampling frequency
+        Acceptable frequency strings are available
+        [Reference](https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases/):
+    :param column_name: name of the column which has time series if not the index
+    :param first_time_stamp: timestamp the time_series is expected to start from
+    :param last_time_stamp: timestamp the time_series is expected to end with
     :return: namedtuple with 3 attributes namely flag, raw_data and new_index
-        1. flag - boolean set to True if there are missing timestamps, else set to False
+        1. flag - boolean set to True if there are missing timestamps,
+            else set to False
         2. raw_data - input data frame as is without any modifications
         3. new_index - pd.DateTimeIndex that can be used to set the new index.
             Defaults to None.
@@ -49,10 +53,10 @@ def _flag_missing_timestamps(
 
     # Get actual timestamps
     if column_name:
-        df = df.set_index(column_name, inplace=True)
+        df = df.set_index(column_name)
 
     df = df.sort_index(inplace=True)
-    actual_timestamps = df.index.values
+    actual_timestamps = df.index.array
 
     # Check if they are the same
     comparison_index = expected_timestamps.difference(actual_timestamps)
@@ -74,16 +78,16 @@ def fill_missing_timestamps(
     last_time_stamp: pd.Timestamp = None,
 ) -> pd.DataFrame:
     """
-    Fills data frame with missing timestamps if found to be missing.
+    Fills data frame with missing timestamps if missing
 
-    Test the data frame for missing timestamps.
-    If timestamps are missing, then Re-indexes the data frame.
-    If timestamps are not missing, original data frame will be returned.
+    Test the data frame for missing timestamps
+    If timestamps are missing, Re-indexes the data frame
+    If timestamps are not missing, returns original data frame
 
     :param df: data frame which needs to be tested for missing timestamps
     :param frequency: frequency i.e. sampling frequency of the data.
-        A list of acceptable frequency strings are available here:
-        (https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases)
+        Acceptable frequency strings are available
+        [Reference](https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases/):
     :param column_name: name of the column which has time series if not the index.
         Defaults to None.
         By default the index is used for checking for the timestamps,
@@ -123,6 +127,6 @@ def fill_missing_timestamps(
 
     # Return result based on whether timestamps are missing or not
     if timestamps_missing_flag["flag"]:
-        df = df.set_index(timestamps_missing_flag["new_index"], inplace=True)
+        df = df.set_index(timestamps_missing_flag["new_index"])
         return df
     return timestamps_missing_flag["raw_data"]

--- a/janitor/timeseries.py
+++ b/janitor/timeseries.py
@@ -67,7 +67,8 @@ def _flag_missing_timestamps(
     result["new_index"] = expected_timestamps
 
     # Return the result as a Named Tuple
-    return MissingTimeStampFlag._make(list(result.values()))
+    values = [v for k, v in result.items()]
+    return MissingTimeStampFlag._make(values)
 
 
 @pf.register_dataframe_method

--- a/janitor/timeseries.py
+++ b/janitor/timeseries.py
@@ -37,15 +37,15 @@ def _flag_missing_timestamps(
             Assigned a value only when flag is set to True
     """
     # Declare a named tuple to hold results
-    MissingTimeStampFlag = namedtuple('MissingTimeStampFlag', ['flag', 'raw_data', 'new_index'])
-    result = {
-        'flag': None,
-        'raw_data': df.copy(deep=True),
-        'new_index': None
-    }
+    MissingTimeStampFlag = namedtuple(
+        "MissingTimeStampFlag", ["flag", "raw_data", "new_index"]
+    )
+    result = {"flag": None, "raw_data": df.copy(deep=True), "new_index": None}
 
     # Generate expected timestamps
-    expected_timestamps = pd.date_range(start=first_time_stamp, end=last_time_stamp, frequency=frequency)
+    expected_timestamps = pd.date_range(
+        start=first_time_stamp, end=last_time_stamp, frequency=frequency
+    )
 
     # Get actual timestamps
     if column_name:
@@ -57,10 +57,9 @@ def _flag_missing_timestamps(
     # Check if they are the same
     comparison_index = expected_timestamps.difference(actual_timestamps)
     if comparison_index.empty:
-        result['flag'] = False
-    else:
-        result['flag'] = True
-        result['new_index'] = expected_timestamps
+        result["flag"] = False
+    result["flag"] = True
+    result["new_index"] = expected_timestamps
 
     # Return the result as a Named Tuple
     return MissingTimeStampFlag._make(result)
@@ -109,7 +108,9 @@ def fill_missing_timestamps(
     if column_name:
         test_new_index_data_type = is_datetime(df[column_name])
         if not test_new_index_data_type:
-            raise TypeError("\n column_name should refer to a column whose data type is datetime")
+            raise TypeError(
+                "\n column_name should refer to a column whose data type is datetime"
+            )
     if not first_time_stamp:
         first_time_stamp = df.index.min()
     if not last_time_stamp:
@@ -117,16 +118,11 @@ def fill_missing_timestamps(
 
     # Test if there are any timestamps missing
     timestamps_missing_flag = _flag_missing_timestamps(
-        df,
-        frequency,
-        column_name,
-        first_time_stamp,
-        last_time_stamp
+        df, frequency, column_name, first_time_stamp, last_time_stamp
     )
 
     # Return result based on whether timestamps are missing or not
-    if timestamps_missing_flag['flag']:
-        df = df.set_index(timestamps_missing_flag['new_index'], inplace=True)
+    if timestamps_missing_flag["flag"]:
+        df = df.set_index(timestamps_missing_flag["new_index"], inplace=True)
         return df
-    else:
-        return timestamps_missing_flag['raw_data']
+    return timestamps_missing_flag["raw_data"]

--- a/janitor/timeseries.py
+++ b/janitor/timeseries.py
@@ -23,6 +23,15 @@ def fill_missing_timestamps(
     this function will reindex the dataframe.
     If timestamps are not missing,
     then the function will return the dataframe unmodified.
+    
+    Example usage:
+    
+    .. code-block:: python
+
+        df = (
+            pd.DataFrame(...)
+            .fill_missing_timestamps(frequency="1H")
+        )
 
     :param df: Dataframe which needs to be tested for missing timestamps
     :param frequency: frequency i.e. sampling frequency of the data.

--- a/janitor/timeseries.py
+++ b/janitor/timeseries.py
@@ -69,7 +69,7 @@ def _get_missing_timestamps(
     frequency: str,
     first_time_stamp: pd.Timestamp = None,
     last_time_stamp: pd.Timestamp = None,
-):
+) -> pd.DataFrame:
     """
     Return the timestamps that are missing in a dataframe.
 

--- a/janitor/timeseries.py
+++ b/janitor/timeseries.py
@@ -4,8 +4,6 @@ Time series-specific data testing and cleaning functions.
 
 import pandas as pd
 import pandas_flavor as pf
-from pandas.api.types import is_datetime64_any_dtype as is_datetime
-from collections import namedtuple
 from janitor import check
 
 

--- a/janitor/timeseries.py
+++ b/janitor/timeseries.py
@@ -29,9 +29,9 @@ def _flag_missing_timestamps(
     :param frequency: frequency i.e. sampling frequency
         Acceptable frequency strings are available
         `Reference <https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases/>`_
-    :param column_name: name of the column which has time series if not the index
-    :param first_time_stamp: timestamp the time_series is expected to start from
-    :param last_time_stamp: timestamp the time_series is expected to end with
+    :param column_name: column which has time series if not the index
+    :param first_time_stamp: timestamp expected to start from
+    :param last_time_stamp: timestamp expected to end with
     :return: namedtuple with 3 attributes namely flag, raw_data and new_index
         1. flag - boolean set to True if there are missing timestamps,
             else set to False
@@ -88,14 +88,14 @@ def fill_missing_timestamps(
     :param frequency: frequency i.e. sampling frequency of the data.
         Acceptable frequency strings are available
         `Reference <https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases/>`_
-    :param column_name: name of the column which has time series if not the index.
+    :param column_name: column which has time series if not index
         Defaults to None.
         By default the index is used for checking for the timestamps,
         unless a value other than None is assigned to column_name
-    :param first_time_stamp: timestamp at which the time_series is expected to start from.
+    :param first_time_stamp: timestamp expected to start from
         Defaults to None.
         If no input is provided assumes the minimum value in time_series
-    :param last_time_stamp: timestamp at which the time_series is expected to end with.
+    :param last_time_stamp: timestamp expected to end with.
         Defaults to None.
         If no input is provided, assumes the maximum value in time_series
     :return: reindexed data frame if it turns out to have missing timestamps,
@@ -113,7 +113,7 @@ def fill_missing_timestamps(
         test_new_index_data_type = is_datetime(df[column_name])
         if not test_new_index_data_type:
             raise TypeError(
-                "\n column_name should refer to a column whose data type is datetime"
+                f""" \n {column_name} data type must be datetime"""
             )
     if not first_time_stamp:
         first_time_stamp = df.index.min()

--- a/janitor/timeseries.py
+++ b/janitor/timeseries.py
@@ -28,7 +28,7 @@ def _flag_missing_timestamps(
     :param df: data frame to test for missing timestamps
     :param frequency: frequency i.e. sampling frequency
         Acceptable frequency strings are available
-        [Reference](https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases/):
+        `Reference <https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases/>`_
     :param column_name: name of the column which has time series if not the index
     :param first_time_stamp: timestamp the time_series is expected to start from
     :param last_time_stamp: timestamp the time_series is expected to end with
@@ -87,7 +87,7 @@ def fill_missing_timestamps(
     :param df: data frame which needs to be tested for missing timestamps
     :param frequency: frequency i.e. sampling frequency of the data.
         Acceptable frequency strings are available
-        [Reference](https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases/):
+        `Reference <https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases/>`_
     :param column_name: name of the column which has time series if not the index.
         Defaults to None.
         By default the index is used for checking for the timestamps,

--- a/janitor/timeseries.py
+++ b/janitor/timeseries.py
@@ -28,7 +28,8 @@ def _flag_missing_timestamps(
     :param df: data frame to test for missing timestamps
     :param frequency: frequency i.e. sampling frequency
         Acceptable frequency strings are available
-        `Reference <https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases/>`_
+        `Reference <https://pandas.pydata.org/pandas-docs/stable/>`_
+        Check offset aliases under time series in user guide
     :param column_name: column which has time series if not the index
     :param first_time_stamp: timestamp expected to start from
     :param last_time_stamp: timestamp expected to end with
@@ -55,7 +56,7 @@ def _flag_missing_timestamps(
     if column_name:
         df = df.set_index(column_name)
 
-    df = df.sort_index(inplace=True)
+    df = df.sort_index()
     actual_timestamps = df.index.array
 
     # Check if they are the same
@@ -87,7 +88,8 @@ def fill_missing_timestamps(
     :param df: data frame which needs to be tested for missing timestamps
     :param frequency: frequency i.e. sampling frequency of the data.
         Acceptable frequency strings are available
-        `Reference <https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases/>`_
+        `Reference <https://pandas.pydata.org/pandas-docs/stable/>`_
+        Check offset aliases under time series in user guide
     :param column_name: column which has time series if not index
         Defaults to None.
         By default the index is used for checking for the timestamps,

--- a/janitor/timeseries.py
+++ b/janitor/timeseries.py
@@ -87,3 +87,43 @@ def _get_missing_timestamps(
     missing_timestamps = expected_df.index.difference(df.index)
 
     return expected_df.loc[missing_timestamps]
+
+
+@pf.register_dataframe_method
+def sort_timestamps_monotonically(
+    df: pd.DataFrame, direction: str = "increasing"
+) -> pd.DataFrame:
+    """
+    Sort dataframe to be monotonic.
+
+    If timestamps are monotonic,
+    this function will return the dataframe unmodified.
+    If timestamps are not monotonic,
+    then the function will sort the dataframe.
+    Example usage:
+    .. code-block:: python
+
+        df = (
+            pd.DataFrame(...)
+            .sort_timestamps_monotonically(direction='increasing')
+        )
+
+    :param df: Dataframe which needs to be tested for monotonicity
+    :param direction: type of monotonicity desired.
+        Acceptable arguments are:
+            1. increasing
+            2. decreasing
+    :returns: dataframe that has monotonic timestamps.
+    """
+    # Check all the inputs are the correct data type
+    check("df", df, [pd.DataFrame])
+    check("direction", direction, [str])
+
+    # Sort timestamps
+    if direction == "increasing":
+        df = df.sort_index()
+    else:
+        df = df.sort_index(ascending=False)
+
+    # Return the dataframe
+    return df

--- a/janitor/timeseries.py
+++ b/janitor/timeseries.py
@@ -21,9 +21,7 @@ def fill_missing_timestamps(
     this function will reindex the dataframe.
     If timestamps are not missing,
     then the function will return the dataframe unmodified.
-    
     Example usage:
-    
     .. code-block:: python
 
         df = (

--- a/janitor/timeseries.py
+++ b/janitor/timeseries.py
@@ -1,5 +1,5 @@
 """
-Time series-specific data cleaning functions.
+Time series-specific data testing and cleaning functions.
 """
 
 import pandas as pd
@@ -17,22 +17,24 @@ def _flag_missing_timestamps(
     last_time_stamp: pd.Timestamp,
 ) -> namedtuple:
     """
-    Utility function to test if input data frame is missing any timestamps relative to expected timestamps
-    generated based on the first_time_stamp, last_time_stamp and frequency.
+    Test if timestamps are missing
 
-    :param pd.DataFrame df: data frame which needs to be tested for missing timestamps
-    :param str frequency: frequency i.e. sampling frequency of the data, expressed in seconds. A list of acceptable
-    frequency strings are available here
-    (https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases)
-    :param str column_name: name of the column which has time series if not the index.
-    :param pd.Timestamp first_time_stamp: timestamp at which the time_series is expected to start from.
-    :param pd.Timestamp last_time_stamp: timestamp at which the time_series is expected to end with.
+    Utility function to test if input data frame is missing any timestamps relative to expected timestamps.
+    They are generated based on the first_time_stamp, last_time_stamp and frequency.
+
+    :param df: data frame which needs to be tested for missing timestamps
+    :param frequency: frequency i.e. sampling frequency of the data.
+        A list of acceptable frequency strings are available here:
+        (https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases)
+    :param column_name: name of the column which has time series if not the index.
+    :param first_time_stamp: timestamp at which the time_series is expected to start from.
+    :param last_time_stamp: timestamp at which the time_series is expected to end with.
     :return: namedtuple with 3 attributes namely flag, raw_data and new_index
         1. flag - boolean set to True if there are missing timestamps, else set to False
         2. raw_data - input data frame as is without any modifications
-        3. new_index - pd.DateTimeIndex that can be used to set the new index, defaults to None, assigned a value only
-        when flag is set to True
-    :rtype: namedtuple
+        3. new_index - pd.DateTimeIndex that can be used to set the new index.
+            Defaults to None.
+            Assigned a value only when flag is set to True
     """
     # Declare a named tuple to hold results
     MissingTimeStampFlag = namedtuple('MissingTimeStampFlag', ['flag', 'raw_data', 'new_index'])
@@ -47,9 +49,9 @@ def _flag_missing_timestamps(
 
     # Get actual timestamps
     if column_name:
-        df.set_index(column_name, inplace=True)
+        df = df.set_index(column_name, inplace=True)
 
-    df.sort_index(inplace=True)
+    df = df.sort_index(inplace=True)
     actual_timestamps = df.index.values
 
     # Check if they are the same
@@ -73,21 +75,28 @@ def fill_missing_timestamps(
     last_time_stamp: pd.Timestamp = None,
 ) -> pd.DataFrame:
     """
-    Fills data frame with missing timestamps if found to be missing. Re-index the data frame if there are missing
-    timestamps else no changes wil be made and the original data frame will be returned.
+    Fills data frame with missing timestamps if found to be missing.
 
-    :param pd.DataFrame df: data frame which needs to be tested for missing timestamps
-    :param str frequency: frequency i.e. sampling frequency of the data, expressed in seconds. A list of acceptable
-    frequency strings are available here
-    (https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases)
-    :param str column_name: name of the column which has time series if not the index. Defaults to None. By default, the
-    index is used for checking for the timestamps, unless a value other than None is assigned to column_name
-    :param pd.Timestamp first_time_stamp: timestamp at which the time_series is expected to start from. Defaults to None
-    If no input is provided, assumes the minimum value in time_series
-    :param pd.Timestamp last_time_stamp: timestamp at which the time_series is expected to end with. Defaults to None
-    If no input is provided, assumes the maximum value in time_series
-    :return: reindexed data frame if it turns out to have missing timestamps, else returns the input data frame as is
-    :rtype: pd.DataFrame
+    Test the data frame for missing timestamps.
+    If timestamps are missing, then Re-indexes the data frame.
+    If timestamps are not missing, original data frame will be returned.
+
+    :param df: data frame which needs to be tested for missing timestamps
+    :param frequency: frequency i.e. sampling frequency of the data.
+        A list of acceptable frequency strings are available here:
+        (https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases)
+    :param column_name: name of the column which has time series if not the index.
+        Defaults to None.
+        By default the index is used for checking for the timestamps,
+        unless a value other than None is assigned to column_name
+    :param first_time_stamp: timestamp at which the time_series is expected to start from.
+        Defaults to None.
+        If no input is provided assumes the minimum value in time_series
+    :param last_time_stamp: timestamp at which the time_series is expected to end with.
+        Defaults to None.
+        If no input is provided, assumes the maximum value in time_series
+    :return: reindexed data frame if it turns out to have missing timestamps,
+        else returns the input data frame as is
     """
     # Check all the inputs are the correct data type
     check("df", df, [pd.DataFrame])
@@ -117,7 +126,7 @@ def fill_missing_timestamps(
 
     # Return result based on whether timestamps are missing or not
     if timestamps_missing_flag['flag']:
-        df.set_index(timestamps_missing_flag['new_index'], inplace=True)
+        df = df.set_index(timestamps_missing_flag['new_index'], inplace=True)
         return df
     else:
         return timestamps_missing_flag['raw_data']

--- a/janitor/timeseries.py
+++ b/janitor/timeseries.py
@@ -49,7 +49,7 @@ def _flag_missing_timestamps(
 
     # Generate expected timestamps
     expected_timestamps = pd.date_range(
-        start=first_time_stamp, end=last_time_stamp, frequency=frequency
+        start=first_time_stamp, end=last_time_stamp, freq=frequency
     )
 
     # Get actual timestamps
@@ -67,7 +67,7 @@ def _flag_missing_timestamps(
     result["new_index"] = expected_timestamps
 
     # Return the result as a Named Tuple
-    return MissingTimeStampFlag._make(result)
+    return MissingTimeStampFlag._make(result.values())
 
 
 @pf.register_dataframe_method
@@ -106,9 +106,9 @@ def fill_missing_timestamps(
     # Check all the inputs are the correct data type
     check("df", df, [pd.DataFrame])
     check("frequency", frequency, [str])
-    check("column_name", column_name, [str, None])
-    check("first_time_stamp", first_time_stamp, [pd.Timestamp, None])
-    check("last_time_stamp", last_time_stamp, [pd.Timestamp, None])
+    check("column_name", column_name, [str, type(None)])
+    check("first_time_stamp", first_time_stamp, [pd.Timestamp, type(None)])
+    check("last_time_stamp", last_time_stamp, [pd.Timestamp, type(None)])
 
     # Assign inputs if not provided
     if column_name:
@@ -128,7 +128,7 @@ def fill_missing_timestamps(
     )
 
     # Return result based on whether timestamps are missing or not
-    if timestamps_missing_flag["flag"]:
-        df = df.set_index(timestamps_missing_flag["new_index"])
+    if timestamps_missing_flag.flag:
+        df = df.reindex(timestamps_missing_flag.new_index)
         return df
-    return timestamps_missing_flag["raw_data"]
+    return timestamps_missing_flag.raw_data

--- a/janitor/timeseries.py
+++ b/janitor/timeseries.py
@@ -1,0 +1,123 @@
+"""
+Time series-specific data cleaning functions.
+"""
+
+import pandas as pd
+import pandas_flavor as pf
+from pandas.api.types import is_datetime64_any_dtype as is_datetime
+from collections import namedtuple
+from janitor import check
+
+
+def _flag_missing_timestamps(
+    df: pd.DataFrame,
+    frequency: str,
+    column_name: str,
+    first_time_stamp: pd.Timestamp,
+    last_time_stamp: pd.Timestamp,
+) -> namedtuple:
+    """
+    Utility function to test if input data frame is missing any timestamps relative to expected timestamps
+    generated based on the first_time_stamp, last_time_stamp and frequency.
+
+    :param pd.DataFrame df: data frame which needs to be tested for missing timestamps
+    :param str frequency: frequency i.e. sampling frequency of the data, expressed in seconds. A list of acceptable
+    frequency strings are available here
+    (https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases)
+    :param str column_name: name of the column which has time series if not the index.
+    :param pd.Timestamp first_time_stamp: timestamp at which the time_series is expected to start from.
+    :param pd.Timestamp last_time_stamp: timestamp at which the time_series is expected to end with.
+    :return: namedtuple with 3 attributes namely flag, raw_data and new_index
+        1. flag - boolean set to True if there are missing timestamps, else set to False
+        2. raw_data - input data frame as is without any modifications
+        3. new_index - pd.DateTimeIndex that can be used to set the new index, defaults to None, assigned a value only
+        when flag is set to True
+    :rtype: namedtuple
+    """
+    # Declare a named tuple to hold results
+    MissingTimeStampFlag = namedtuple('MissingTimeStampFlag', ['flag', 'raw_data', 'new_index'])
+    result = {
+        'flag': None,
+        'raw_data': df.copy(deep=True),
+        'new_index': None
+    }
+
+    # Generate expected timestamps
+    expected_timestamps = pd.date_range(start=first_time_stamp, end=last_time_stamp, frequency=frequency)
+
+    # Get actual timestamps
+    if column_name:
+        df.set_index(column_name, inplace=True)
+
+    df.sort_index(inplace=True)
+    actual_timestamps = df.index.values
+
+    # Check if they are the same
+    comparison_index = expected_timestamps.difference(actual_timestamps)
+    if comparison_index.empty:
+        result['flag'] = True
+        result['new_index'] = expected_timestamps
+    else:
+        result['flag'] = False
+
+    # Return the result as a Named Tuple
+    return MissingTimeStampFlag._make(result)
+
+
+@pf.register_dataframe_method
+def fill_missing_timestamps(
+    df: pd.DataFrame,
+    frequency: str,
+    column_name: str = None,
+    first_time_stamp: pd.Timestamp = None,
+    last_time_stamp: pd.Timestamp = None,
+) -> pd.DataFrame:
+    """
+    Fills data frame with missing timestamps if found to be missing. Re-index the data frame if there are missing
+    timestamps else no changes wil be made and the original data frame will be returned.
+
+    :param pd.DataFrame df: data frame which needs to be tested for missing timestamps
+    :param str frequency: frequency i.e. sampling frequency of the data, expressed in seconds. A list of acceptable
+    frequency strings are available here
+    (https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases)
+    :param str column_name: name of the column which has time series if not the index. Defaults to None. By default, the
+    index is used for checking for the timestamps, unless a value other than None is assigned to column_name
+    :param pd.Timestamp first_time_stamp: timestamp at which the time_series is expected to start from. Defaults to None
+    If no input is provided, assumes the minimum value in time_series
+    :param pd.Timestamp last_time_stamp: timestamp at which the time_series is expected to end with. Defaults to None
+    If no input is provided, assumes the maximum value in time_series
+    :return: reindexed data frame if it turns out to have missing timestamps, else returns the input data frame as is
+    :rtype: pd.DataFrame
+    """
+    # Check all the inputs are the correct data type
+    check("df", df, [pd.DataFrame])
+    check("frequency", frequency, [str])
+    check("column_name", column_name, [str, None])
+    check("first_time_stamp", first_time_stamp, [pd.Timestamp, None])
+    check("last_time_stamp", last_time_stamp, [pd.Timestamp, None])
+
+    # Assign inputs if not provided
+    if column_name:
+        test_new_index_data_type = is_datetime(df[column_name])
+        if not test_new_index_data_type:
+            raise TypeError("\n column_name should refer to a column whose data type is datetime")
+    if not first_time_stamp:
+        first_time_stamp = df.index.min()
+    if not last_time_stamp:
+        last_time_stamp = df.index.max()
+
+    # Test if there are any timestamps missing
+    timestamps_missing_flag = _flag_missing_timestamps(
+        df,
+        frequency,
+        column_name,
+        first_time_stamp,
+        last_time_stamp
+    )
+
+    # Return result based on whether timestamps are missing or not
+    if timestamps_missing_flag['flag']:
+        df.set_index(timestamps_missing_flag['new_index'], inplace=True)
+        return df
+    else:
+        return timestamps_missing_flag['raw_data']

--- a/janitor/timeseries.py
+++ b/janitor/timeseries.py
@@ -67,7 +67,7 @@ def _flag_missing_timestamps(
     result["new_index"] = expected_timestamps
 
     # Return the result as a Named Tuple
-    return MissingTimeStampFlag._make(result.values())
+    return MissingTimeStampFlag._make(list(result.values()))
 
 
 @pf.register_dataframe_method

--- a/tests/timeseries/test_fill_missing_timestamps.py
+++ b/tests/timeseries/test_fill_missing_timestamps.py
@@ -2,6 +2,7 @@ import pytest
 import pandas as pd
 from random import randint
 from janitor.timeseries import fill_missing_timestamps, _get_missing_timestamps
+from janitor.timeseries import sort_timestamps_monotonically
 
 
 # Random data for testing
@@ -46,3 +47,19 @@ def test__get_missing_timestamps(timeseries_dataframe):
     df = timeseries_dataframe.drop(index=timestamps_to_drop)
     missing_timestamps = _get_missing_timestamps(df, "1H")
     assert set(missing_timestamps.index) == set(timestamps_to_drop)
+
+
+@pytest.mark.timeseries
+def test_sort_timestamps_monotonically(timeseries_dataframe):
+    """Test that sort_timestamps_monotonically works as expected."""
+    from sklearn.utils import shuffle
+
+    # Increasing direction
+    df = shuffle(timeseries_dataframe)
+    df1 = sort_timestamps_monotonically(df)
+    assert df1.equals(timeseries_dataframe)
+
+    # Decreasing direction
+    df2 = timeseries_dataframe.sort_index(ascending=False)
+    df3 = sort_timestamps_monotonically(df2, "decreasing")
+    assert df3.equals(df2)

--- a/tests/timeseries/test_fill_missing_timestamps.py
+++ b/tests/timeseries/test_fill_missing_timestamps.py
@@ -3,39 +3,49 @@ import pandas as pd
 from random import randint
 from janitor.timeseries import fill_missing_timestamps
 
-# Random data for testing 
-ts_index = pd.date_range('1/1/2019', periods=1000, freq='1H')
-v1 = [randint(1, 2000) for i in range(1000)]
-test_df = pd.DataFrame({'v1': v1}, index=ts_index)
+
+# Random data for testing
+@pytest.fixture
+def my_dataframe() -> pd.DataFrame:
+    """
+    Returns a time series dataframe
+    """
+    ts_index = pd.date_range("1/1/2019", periods=1000, freq="1H")
+    v1 = [randint(1, 2000) for i in range(1000)]
+    test_df = pd.DataFrame({"v1": v1}, index=ts_index)
+    return test_df
 
 
 @pytest.mark.parametrize(
     "df,frequency,column_name,first_time_stamp,last_time_stamp",
     [
-        (4, '1T', None, None, None),
+        (4, "1T", None, None, None),
         (pd.DataFrame([]), 2, None, None, None),
-        (pd.DataFrame([]), '1B', 1, None, None),
-        (pd.DataFrame([]), '1B', 'DateTime', '2020-01-01', None),
-        (pd.DataFrame([]), '1B', 'DateTime', pd.Timestamp(2020, 1, 1), '2020-02-01'),
-    ]
+        (pd.DataFrame([]), "1B", 1, None, None),
+        (pd.DataFrame([]), "1B", "DateTime", "2020-01-01", None),
+        (
+            pd.DataFrame([]),
+            "1B",
+            "DateTime",
+            pd.Timestamp(2020, 1, 1),
+            "2020-02-01",
+        ),
+    ],
 )
-def test_datatypes_check(df, frequency, column_name, first_time_stamp, last_time_stamp):
+def test_datatypes_check(
+    df, frequency, column_name, first_time_stamp, last_time_stamp
+):
     with pytest.raises(TypeError):
-        fill_missing_timestamps(df, frequency, column_name, first_time_stamp, last_time_stamp)
+        fill_missing_timestamps(
+            df, frequency, column_name, first_time_stamp, last_time_stamp
+        )
 
 
 @pytest.mark.timeseries
-def test_fill_missing_timestamps():
+def test_fill_missing_timestamps(my_dataframe):
     # Remove random row from the data frame
-    df1 = test_df.drop(test_df.sample())
+    df1 = my_dataframe.drop(my_dataframe.sample())
 
-    result = fill_missing_timestamps(
-        df1,
-        frequency='1H'
-    )
+    result = fill_missing_timestamps(df1, frequency="1H")
 
-    assert result == test_df
-
-
-
-
+    assert result == my_dataframe

--- a/tests/timeseries/test_fill_missing_timestamps.py
+++ b/tests/timeseries/test_fill_missing_timestamps.py
@@ -1,6 +1,12 @@
 import pytest
 import pandas as pd
+from random import randint
 from janitor.timeseries import fill_missing_timestamps
+
+# Random data for testing 
+ts_index = pd.date_range('1/1/2019', periods=1000, freq='1H')
+v1 = [randint(1, 2000) for i in range(1000)]
+test_df = pd.DataFrame({'v1': v1}, index=ts_index)
 
 
 @pytest.mark.parametrize(
@@ -20,6 +26,16 @@ def test_datatypes_check(df, frequency, column_name, first_time_stamp, last_time
 
 @pytest.mark.timeseries
 def test_fill_missing_timestamps():
-    assert fill_missing_timestamps(
-        pd.DataFrame([]), '1B', 'DateTime', pd.Timestamp(2020, 1, 1), pd.Timestamp(2020, 2, 1)
+    # Remove random row from the data frame
+    df1 = test_df.drop(test_df.sample())
+
+    result = fill_missing_timestamps(
+        df1,
+        frequency='1H'
     )
+
+    assert result == test_df
+
+
+
+

--- a/tests/timeseries/test_fill_missing_timestamps.py
+++ b/tests/timeseries/test_fill_missing_timestamps.py
@@ -1,0 +1,24 @@
+import pytest
+import pandas as pd
+from janitor.timeseries import fill_missing_timestamps
+
+
+@pytest.mark.timeseries
+def test_datatypes_check():
+    with pytest.raises(TypeError):
+        assert fill_missing_timestamps(
+            4, '1T', None, None, None
+        )
+        assert fill_missing_timestamps(
+            pd.DataFrame([]), 2, None, None, None
+        )
+        assert fill_missing_timestamps(
+            pd.DataFrame([]), '1B', 1, None, None
+        )
+        assert fill_missing_timestamps(
+            pd.DataFrame([]), '1B', 'DateTime', '2020-01-01', None
+        )
+        assert fill_missing_timestamps(
+            pd.DataFrame([]), '1B', 'DateTime', pd.Timestamp(2020, 1, 1), '2020-02-01'
+        )
+

--- a/tests/timeseries/test_fill_missing_timestamps.py
+++ b/tests/timeseries/test_fill_missing_timestamps.py
@@ -3,22 +3,23 @@ import pandas as pd
 from janitor.timeseries import fill_missing_timestamps
 
 
-@pytest.mark.timeseries
-def test_datatypes_check():
+@pytest.mark.parametrize(
+    "df,frequency,column_name,first_time_stamp,last_time_stamp",
+    [
+        (4, '1T', None, None, None),
+        (pd.DataFrame([]), 2, None, None, None),
+        (pd.DataFrame([]), '1B', 1, None, None),
+        (pd.DataFrame([]), '1B', 'DateTime', '2020-01-01', None),
+        (pd.DataFrame([]), '1B', 'DateTime', pd.Timestamp(2020, 1, 1), '2020-02-01'),
+    ]
+)
+def test_datatypes_check(df, frequency, column_name, first_time_stamp, last_time_stamp):
     with pytest.raises(TypeError):
-        assert fill_missing_timestamps(
-            4, '1T', None, None, None
-        )
-        assert fill_missing_timestamps(
-            pd.DataFrame([]), 2, None, None, None
-        )
-        assert fill_missing_timestamps(
-            pd.DataFrame([]), '1B', 1, None, None
-        )
-        assert fill_missing_timestamps(
-            pd.DataFrame([]), '1B', 'DateTime', '2020-01-01', None
-        )
-        assert fill_missing_timestamps(
-            pd.DataFrame([]), '1B', 'DateTime', pd.Timestamp(2020, 1, 1), '2020-02-01'
-        )
+        fill_missing_timestamps(df, frequency, column_name, first_time_stamp, last_time_stamp)
 
+
+@pytest.mark.timeseries
+def test_fill_missing_timestamps():
+    assert fill_missing_timestamps(
+        pd.DataFrame([]), '1B', 'DateTime', pd.Timestamp(2020, 1, 1), pd.Timestamp(2020, 2, 1)
+    )

--- a/tests/timeseries/test_fill_missing_timestamps.py
+++ b/tests/timeseries/test_fill_missing_timestamps.py
@@ -44,8 +44,20 @@ def test_datatypes_check(
 @pytest.mark.timeseries
 def test_fill_missing_timestamps(my_dataframe):
     # Remove random row from the data frame
-    df1 = my_dataframe.drop(my_dataframe.sample())
+    random_number = randint(1, len(my_dataframe))
+    df1 = my_dataframe.drop(my_dataframe.index[random_number])
 
+    # Fill missing timestamps
     result = fill_missing_timestamps(df1, frequency="1H")
 
-    assert result == my_dataframe
+    # Testing if the missing timestamp has been filled
+    assert len(result) == len(my_dataframe)
+
+    # Testing if indices are exactly the same after filling
+    original_index = my_dataframe.index
+    new_index = result.index
+    delta = original_index.difference(new_index)
+
+    assert delta.empty is True
+
+

--- a/tests/timeseries/test_fill_missing_timestamps.py
+++ b/tests/timeseries/test_fill_missing_timestamps.py
@@ -59,5 +59,3 @@ def test_fill_missing_timestamps(my_dataframe):
     delta = original_index.difference(new_index)
 
     assert delta.empty is True
-
-


### PR DESCRIPTION
Closes #707 .

Please describe the changes proposed in the pull request:

- Added a function ```sort_timestamps_monotonically``` that sorts timestamps to be monotonic 
- Added the corresponding unit tests

**This PR resolves #707.**

# PR Checklist

<!-- This checklist exists for newcomers who are not yet familiar with our requirements. If you are experienced with the project, please feel free to delete this section. -->

Please ensure that you have done the following:

1. [x] PR in from a fork off your branch. Do not PR from `<your_username>`:`dev`, but rather from `<your_username>`:`<feature-branch_name>`.
2. [x] If you're not on the contributors list, add yourself to `AUTHORS.rst`.
3. [x] Add a line to `CHANGELOG.rst` under the latest version header (i.e. the one that is "on deck") describing the contribution.

## Quick Check

To do a very quick check that everything is correct, follow these steps below:

- [x] Run the command `make check` from pyjanitor's top-level directory. This will automatically run:
    - black formatting
    - flake8 checking
    - running the test suite
    - docs build

Once done, please check off the check-box above.

If `make check` does not work for you, you can execute the commands listed in the Makefile individually.

## Code Changes

If you are adding code changes, please ensure the following:

- [x] Ensure that you have added tests.
- [x] Run all tests (`$ pytest .`) locally on your machine.
    - [x] Check to ensure that test coverage covers the lines of code that you have added.
    - [x] Ensure that all tests pass.

## Documentation Changes
If you are adding documentation changes, please ensure the following:

- [x] Build the docs locally.
- [x] View the docs to check that it renders correctly.

# Relevant Reviewers
@ericmjl  / @samukweku 
<!-- Finally, please tag relevant maintainers to review. -->

Please tag maintainers to review.

- @ericmjl
