### PR TITLE
[ENH] Adding ability to sort timestamps monotonically

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@ new version (on deck)
 =====================
 - [ENH] Updated groupby_agg function to account for null entries in the ``by`` argument. @samukweku
 - [ENH] Added function ``groupby_topk`` to janitor functions @mphirke
+- [ENH] Added function ``sort_timestamps_monotonically`` to timeseries functions @UGuntupalli
 
 
 v0.20.8

--- a/janitor/timeseries.py
+++ b/janitor/timeseries.py
@@ -92,16 +92,19 @@ def _get_missing_timestamps(
 @pf.register_dataframe_method
 def sort_timestamps_monotonically(
     df: pd.DataFrame,
-    direction: str = "increasing"
+    direction: str = "increasing",
+    strict: bool = False
 ) -> pd.DataFrame:
     """
-    Sort dataframe to be monotonic.
+    Sort dataframe such that index is monotonic.
 
     If timestamps are monotonic,
     this function will return the dataframe unmodified.
     If timestamps are not monotonic,
     then the function will sort the dataframe.
+
     Example usage:
+
     .. code-block:: python
 
         df = (
@@ -114,11 +117,24 @@ def sort_timestamps_monotonically(
         Acceptable arguments are:
             1. increasing
             2. decreasing
-    :returns: dataframe that has monotonic timestamps.
+    :param strict: flag to enable/disable strict monotonicity.
+        If set to True,
+        will remove duplicates in the index,
+        by retaining first occurrence of value in index.
+        If set to False,
+        will not test for duplicates in the index.
+        Defaults to False.
+    :returns: Dataframe that has monotonically increasing
+        (or decreasing) timestamps.
     """
     # Check all the inputs are the correct data type
     check("df", df, [pd.DataFrame])
     check("direction", direction, [str])
+    check("strict", strict, [bool])
+
+    # Remove duplicates if requested
+    if strict:
+        df = df[~df.index.duplicated(keep='first')]
 
     # Sort timestamps
     if direction == "increasing":

--- a/janitor/timeseries.py
+++ b/janitor/timeseries.py
@@ -87,3 +87,44 @@ def _get_missing_timestamps(
     missing_timestamps = expected_df.index.difference(df.index)
 
     return expected_df.loc[missing_timestamps]
+
+
+@pf.register_dataframe_method
+def sort_timestamps_monotonically(
+    df: pd.DataFrame,
+    direction: str = "increasing"
+) -> pd.DataFrame:
+    """
+    Sort dataframe to be monotonic.
+
+    If timestamps are monotonic,
+    this function will return the dataframe unmodified.
+    If timestamps are not monotonic,
+    then the function will sort the dataframe.
+    Example usage:
+    .. code-block:: python
+
+        df = (
+            pd.DataFrame(...)
+            .sort_timestamps_monotonically(direction='increasing')
+        )
+
+    :param df: Dataframe which needs to be tested for monotonicity
+    :param direction: type of monotonicity desired.
+        Acceptable arguments are:
+            1. increasing
+            2. decreasing
+    :returns: dataframe that has monotonic timestamps.
+    """
+    # Check all the inputs are the correct data type
+    check("df", df, [pd.DataFrame])
+    check("direction", direction, [str])
+
+    # Sort timestamps
+    if direction == "increasing":
+        df = df.sort_index()
+    else:
+        df = df.sort_index(ascending=False)
+
+    # Return the dataframe
+    return df

--- a/janitor/timeseries.py
+++ b/janitor/timeseries.py
@@ -91,9 +91,7 @@ def _get_missing_timestamps(
 
 @pf.register_dataframe_method
 def sort_timestamps_monotonically(
-    df: pd.DataFrame,
-    direction: str = "increasing",
-    strict: bool = False
+    df: pd.DataFrame, direction: str = "increasing", strict: bool = False
 ) -> pd.DataFrame:
     """
     Sort dataframe such that index is monotonic.
@@ -134,7 +132,7 @@ def sort_timestamps_monotonically(
 
     # Remove duplicates if requested
     if strict:
-        df = df[~df.index.duplicated(keep='first')]
+        df = df[~df.index.duplicated(keep="first")]
 
     # Sort timestamps
     if direction == "increasing":

--- a/tests/timeseries/test_sort_timestamps_monotonically.py
+++ b/tests/timeseries/test_sort_timestamps_monotonically.py
@@ -1,7 +1,7 @@
 import pytest
 import pandas as pd
 from random import randint
-import janitor
+import janitor  # noqa: F401
 import janitor.timeseries  # noqa: F401
 
 

--- a/tests/timeseries/test_sort_timestamps_monotonically.py
+++ b/tests/timeseries/test_sort_timestamps_monotonically.py
@@ -26,7 +26,7 @@ def test_sort_timestamps_monotonically(timeseries_dataframe):
 
 
 @pytest.mark.timeseries
-def test_sort_timestamps_monotonically(timeseries_dataframe):
+def test_sort_timestamps_monotonically_decreasing(timeseries_dataframe):
     """Test sort_timestamps_monotonically for descending order"""
     df2 = timeseries_dataframe.sort_index(ascending=False)
     df3 = sort_timestamps_monotonically(df2, "decreasing")
@@ -41,4 +41,3 @@ def test_sort_timestamps_monotonically_strict(timeseries_dataframe):
     df4 = df.append(df.loc[df.index[random_number], :])
     df5 = sort_timestamps_monotonically(df4, "increasing", True)
     pd.testing.assert_frame_equal(df5, timeseries_dataframe)
-

--- a/tests/timeseries/test_sort_timestamps_monotonically.py
+++ b/tests/timeseries/test_sort_timestamps_monotonically.py
@@ -30,3 +30,9 @@ def test_sort_timestamps_monotonically(timeseries_dataframe):
     df2 = timeseries_dataframe.sort_index(ascending=False)
     df3 = sort_timestamps_monotonically(df2, "decreasing")
     assert df3.equals(df2)
+
+    # Test for strictness
+    random_number = randint(1, len(timeseries_dataframe))
+    df4 = df.append(df.loc[df.index[random_number], :])
+    df5 = sort_timestamps_monotonically(df4, "increasing", True)
+    assert df5.equals(timeseries_dataframe)

--- a/tests/timeseries/test_sort_timestamps_monotonically.py
+++ b/tests/timeseries/test_sort_timestamps_monotonically.py
@@ -1,8 +1,8 @@
 import pytest
 import pandas as pd
 from random import randint
-from janitor.timeseries import sort_timestamps_monotonically
-
+import janitor
+import janitor.timeseries
 
 # Random data for testing
 @pytest.fixture

--- a/tests/timeseries/test_sort_timestamps_monotonically.py
+++ b/tests/timeseries/test_sort_timestamps_monotonically.py
@@ -2,9 +2,9 @@ import pytest
 import pandas as pd
 from random import randint
 import janitor
-import janitor.timeseries
+import janitor.timeseries  # noqa: F401
 
-# Random data for testing
+
 @pytest.fixture
 def timeseries_dataframe() -> pd.DataFrame:
     """

--- a/tests/timeseries/test_sort_timestamps_monotonically.py
+++ b/tests/timeseries/test_sort_timestamps_monotonically.py
@@ -17,6 +17,8 @@ def timeseries_dataframe() -> pd.DataFrame:
     return test_df
 
 
+# NOTE: The tests possibly can be merged back together later if they are parametrized properly.
+
 @pytest.mark.timeseries
 def test_sort_timestamps_monotonically(timeseries_dataframe):
     """Test sort_timestamps_monotonically for ascending order"""

--- a/tests/timeseries/test_sort_timestamps_monotonically.py
+++ b/tests/timeseries/test_sort_timestamps_monotonically.py
@@ -1,0 +1,32 @@
+import pytest
+import pandas as pd
+from random import randint
+from janitor.timeseries import sort_timestamps_monotonically
+
+
+# Random data for testing
+@pytest.fixture
+def timeseries_dataframe() -> pd.DataFrame:
+    """
+    Returns a time series dataframe
+    """
+    ts_index = pd.date_range("1/1/2019", periods=1000, freq="1H")
+    v1 = [randint(1, 2000) for i in range(1000)]
+    test_df = pd.DataFrame({"v1": v1}, index=ts_index)
+    return test_df
+
+
+@pytest.mark.timeseries
+def test_sort_timestamps_monotonically(timeseries_dataframe):
+    """Test that sort_timestamps_monotonically works as expected."""
+    from sklearn.utils import shuffle
+
+    # Increasing direction
+    df = shuffle(timeseries_dataframe)
+    df1 = sort_timestamps_monotonically(df)
+    assert df1.equals(timeseries_dataframe)
+
+    # Decreasing direction
+    df2 = timeseries_dataframe.sort_index(ascending=False)
+    df3 = sort_timestamps_monotonically(df2, "decreasing")
+    assert df3.equals(df2)

--- a/tests/timeseries/test_sort_timestamps_monotonically.py
+++ b/tests/timeseries/test_sort_timestamps_monotonically.py
@@ -17,7 +17,9 @@ def timeseries_dataframe() -> pd.DataFrame:
     return test_df
 
 
-# NOTE: The tests possibly can be merged back together later if they are parametrized properly.
+# NOTE: The tests possibly can be merged back together later
+# if they are parametrized properly.
+
 
 @pytest.mark.timeseries
 def test_sort_timestamps_monotonically(timeseries_dataframe):

--- a/tests/timeseries/test_sort_timestamps_monotonically.py
+++ b/tests/timeseries/test_sort_timestamps_monotonically.py
@@ -42,6 +42,3 @@ def test_sort_timestamps_monotonically_strict(timeseries_dataframe):
     df5 = sort_timestamps_monotonically(df4, "increasing", True)
     pd.testing.assert_frame_equal(df5, timeseries_dataframe)
 
-
-if __name__ == '__main__':
-    pytest.main()

--- a/tests/timeseries/test_sort_timestamps_monotonically.py
+++ b/tests/timeseries/test_sort_timestamps_monotonically.py
@@ -2,6 +2,7 @@ import pytest
 import pandas as pd
 from random import randint
 from janitor.timeseries import sort_timestamps_monotonically
+from janitor.functions import shuffle
 
 
 # Random data for testing
@@ -18,21 +19,29 @@ def timeseries_dataframe() -> pd.DataFrame:
 
 @pytest.mark.timeseries
 def test_sort_timestamps_monotonically(timeseries_dataframe):
-    """Test that sort_timestamps_monotonically works as expected."""
-    from sklearn.utils import shuffle
-
-    # Increasing direction
-    df = shuffle(timeseries_dataframe)
+    """Test sort_timestamps_monotonically for ascending order"""
+    df = shuffle(timeseries_dataframe, reset_index=False)
     df1 = sort_timestamps_monotonically(df)
-    assert df1.equals(timeseries_dataframe)
+    pd.testing.assert_frame_equal(df1, timeseries_dataframe)
 
-    # Decreasing direction
+
+@pytest.mark.timeseries
+def test_sort_timestamps_monotonically(timeseries_dataframe):
+    """Test sort_timestamps_monotonically for descending order"""
     df2 = timeseries_dataframe.sort_index(ascending=False)
     df3 = sort_timestamps_monotonically(df2, "decreasing")
-    assert df3.equals(df2)
+    pd.testing.assert_frame_equal(df3, df2)
 
-    # Test for strictness
+
+@pytest.mark.timeseries
+def test_sort_timestamps_monotonically_strict(timeseries_dataframe):
+    """Test sort_timestamps_monotonically for index duplication handling"""
+    df = shuffle(timeseries_dataframe, reset_index=False)
     random_number = randint(1, len(timeseries_dataframe))
     df4 = df.append(df.loc[df.index[random_number], :])
     df5 = sort_timestamps_monotonically(df4, "increasing", True)
-    assert df5.equals(timeseries_dataframe)
+    pd.testing.assert_frame_equal(df5, timeseries_dataframe)
+
+
+if __name__ == '__main__':
+    pytest.main()

--- a/tests/timeseries/test_sort_timestamps_monotonically.py
+++ b/tests/timeseries/test_sort_timestamps_monotonically.py
@@ -2,7 +2,6 @@ import pytest
 import pandas as pd
 from random import randint
 from janitor.timeseries import sort_timestamps_monotonically
-from janitor.functions import shuffle
 
 
 # Random data for testing
@@ -24,24 +23,26 @@ def timeseries_dataframe() -> pd.DataFrame:
 @pytest.mark.timeseries
 def test_sort_timestamps_monotonically(timeseries_dataframe):
     """Test sort_timestamps_monotonically for ascending order"""
-    df = shuffle(timeseries_dataframe, reset_index=False)
-    df1 = sort_timestamps_monotonically(df)
-    pd.testing.assert_frame_equal(df1, timeseries_dataframe)
+    df = timeseries_dataframe.shuffle(
+        reset_index=False
+    ).sort_timestamps_monotonically()
+    pd.testing.assert_frame_equal(df, timeseries_dataframe)
 
 
 @pytest.mark.timeseries
 def test_sort_timestamps_monotonically_decreasing(timeseries_dataframe):
     """Test sort_timestamps_monotonically for descending order"""
     df2 = timeseries_dataframe.sort_index(ascending=False)
-    df3 = sort_timestamps_monotonically(df2, "decreasing")
+    df3 = df2.sort_timestamps_monotonically("decreasing")
     pd.testing.assert_frame_equal(df3, df2)
 
 
 @pytest.mark.timeseries
 def test_sort_timestamps_monotonically_strict(timeseries_dataframe):
     """Test sort_timestamps_monotonically for index duplication handling"""
-    df = shuffle(timeseries_dataframe, reset_index=False)
+    df = timeseries_dataframe.shuffle(reset_index=False)
     random_number = randint(1, len(timeseries_dataframe))
-    df4 = df.append(df.loc[df.index[random_number], :])
-    df5 = sort_timestamps_monotonically(df4, "increasing", True)
-    pd.testing.assert_frame_equal(df5, timeseries_dataframe)
+    df = df.append(
+        df.loc[df.index[random_number], :]
+    ).sort_timestamps_monotonically(direction="increasing", strict=True)
+    pd.testing.assert_frame_equal(df, timeseries_dataframe)


### PR DESCRIPTION
Closes #707 

# PR Description

Please describe the changes proposed in the pull request:

- Adding a function that allows monotonic sorting of timestamps in data frame 

**This PR resolves #707 **

# PR Checklist
Please ensure that you have done the following:

1. [x] PR in from a fork off your branch. Do not PR from `<your_username>`:`dev`, but rather from `<your_username>`:`<feature-branch_name>`.
2. [x] If you're not on the contributors list, add yourself to `AUTHORS.rst`.
3. [x] Add a line to `CHANGELOG.rst` under the latest version header (i.e. the one that is "on deck") describing the contribution.
    - Do use some discretion here; if there are multiple PRs that are related, keep them in a single line.

## Quick Check

To do a very quick check that everything is correct, follow these steps below:

- [x] Run the command `make check` from pyjanitor's top-level directory. This will automatically run:
    - black formatting
    - flake8 checking
    - running the test suite
    - docs build

Once done, please check off the check-box above.

If `make check` does not work for you, you can execute the commands listed in the Makefile individually.

## Code Changes

<!-- If you have not made code changes, please feel free to delete this section. -->

If you are adding code changes, please ensure the following:

- [x] Ensure that you have added tests.
- [x] Run all tests (`$ pytest .`) locally on your machine.
    - [x] Check to ensure that test coverage covers the lines of code that you have added.
    - [x] Ensure that all tests pass.

## Documentation Changes
If you are adding documentation changes, please ensure the following:

- [x] Build the docs locally.
- [ ] View the docs to check that it renders correctly.

# Relevant Reviewers
- @ericmjl 
- @samukweku 

Please tag maintainers to review.

- @ericmjl
