### PR TITLE
[ENH] Add sort_timestamps_monotonically

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,6 @@
 new version (on deck)
 =====================
-
+- [ENH] Added function ``sort_timestamps_monotonically`` to timeseries functions @UGuntupalli
 
 v0.20.9
 =======

--- a/janitor/timeseries.py
+++ b/janitor/timeseries.py
@@ -91,17 +91,18 @@ def _get_missing_timestamps(
 
 @pf.register_dataframe_method
 def sort_timestamps_monotonically(
-    df: pd.DataFrame,
-    direction: str = "increasing"
+    df: pd.DataFrame, direction: str = "increasing", strict: bool = False
 ) -> pd.DataFrame:
     """
-    Sort dataframe to be monotonic.
+    Sort dataframe such that index is monotonic.
 
     If timestamps are monotonic,
     this function will return the dataframe unmodified.
     If timestamps are not monotonic,
     then the function will sort the dataframe.
+
     Example usage:
+
     .. code-block:: python
 
         df = (
@@ -114,11 +115,24 @@ def sort_timestamps_monotonically(
         Acceptable arguments are:
             1. increasing
             2. decreasing
-    :returns: dataframe that has monotonic timestamps.
+    :param strict: flag to enable/disable strict monotonicity.
+        If set to True,
+        will remove duplicates in the index,
+        by retaining first occurrence of value in index.
+        If set to False,
+        will not test for duplicates in the index.
+        Defaults to False.
+    :returns: Dataframe that has monotonically increasing
+        (or decreasing) timestamps.
     """
     # Check all the inputs are the correct data type
     check("df", df, [pd.DataFrame])
     check("direction", direction, [str])
+    check("strict", strict, [bool])
+
+    # Remove duplicates if requested
+    if strict:
+        df = df[~df.index.duplicated(keep="first")]
 
     # Sort timestamps
     if direction == "increasing":

--- a/janitor/timeseries.py
+++ b/janitor/timeseries.py
@@ -87,3 +87,44 @@ def _get_missing_timestamps(
     missing_timestamps = expected_df.index.difference(df.index)
 
     return expected_df.loc[missing_timestamps]
+
+
+@pf.register_dataframe_method
+def sort_timestamps_monotonically(
+    df: pd.DataFrame,
+    direction: str = "increasing"
+) -> pd.DataFrame:
+    """
+    Sort dataframe to be monotonic.
+
+    If timestamps are monotonic,
+    this function will return the dataframe unmodified.
+    If timestamps are not monotonic,
+    then the function will sort the dataframe.
+    Example usage:
+    .. code-block:: python
+
+        df = (
+            pd.DataFrame(...)
+            .sort_timestamps_monotonically(direction='increasing')
+        )
+
+    :param df: Dataframe which needs to be tested for monotonicity
+    :param direction: type of monotonicity desired.
+        Acceptable arguments are:
+            1. increasing
+            2. decreasing
+    :returns: dataframe that has monotonic timestamps.
+    """
+    # Check all the inputs are the correct data type
+    check("df", df, [pd.DataFrame])
+    check("direction", direction, [str])
+
+    # Sort timestamps
+    if direction == "increasing":
+        df = df.sort_index()
+    else:
+        df = df.sort_index(ascending=False)
+
+    # Return the dataframe
+    return df

--- a/tests/timeseries/test_sort_timestamps_monotonically.py
+++ b/tests/timeseries/test_sort_timestamps_monotonically.py
@@ -18,6 +18,10 @@ def timeseries_dataframe() -> pd.DataFrame:
 
 # NOTE: The tests possibly can be merged back together later
 # if they are parametrized properly.
+# NOTE: These tests use `df.equals(other_df)`,
+# because the desired `pd.assert_frame_equal(df, other_df)`
+# constantly failed on the CI systems.
+# It's a task for later to fix.
 
 
 @pytest.mark.timeseries

--- a/tests/timeseries/test_sort_timestamps_monotonically.py
+++ b/tests/timeseries/test_sort_timestamps_monotonically.py
@@ -1,0 +1,32 @@
+import pytest
+import pandas as pd
+from random import randint
+from janitor.timeseries import sort_timestamps_monotonically
+
+
+# Random data for testing
+@pytest.fixture
+def timeseries_dataframe() -> pd.DataFrame:
+    """
+    Returns a time series dataframe
+    """
+    ts_index = pd.date_range("1/1/2019", periods=1000, freq="1H")
+    v1 = [randint(1, 2000) for i in range(1000)]
+    test_df = pd.DataFrame({"v1": v1}, index=ts_index)
+    return test_df
+
+
+@pytest.mark.timeseries
+def test_sort_timestamps_monotonically(timeseries_dataframe):
+    """Test that sort_timestamps_monotonically works as expected."""
+    from sklearn.utils import shuffle
+
+    # Increasing direction
+    df = shuffle(timeseries_dataframe)
+    df1 = sort_timestamps_monotonically(df)
+    assert df1.equals(timeseries_dataframe)
+
+    # Decreasing direction
+    df2 = timeseries_dataframe.sort_index(ascending=False)
+    df3 = sort_timestamps_monotonically(df2, "decreasing")
+    assert df3.equals(df2)


### PR DESCRIPTION
# PR Description

This PR adds back the `sort_timestamps_monotonically` functionality from PR #720. In that PR, the source branch was removed, so to salvage the PR, I manually added back the functions in this PR.

To fix the failing tests on #720, I also reverted the `pd.assert_frame_equal` to `assert df.equals(other_df)`. Better this than letting the PR linger in limbo.

**This PR resolves #707 and closes #720.**