### PR TITLE
[INF] Restrict python version to 3.8 for now

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -3,7 +3,7 @@ channels:
 - conda-forge
 - rdkit
 dependencies:
-- python>=3.6
+- python>=3.6, <3.9
 - biopython
 - black
 - bumpversion


### PR DESCRIPTION
<!-- Thank you for your PR!

BEFORE YOU CONTINUE! Please add the appropriate three-letter abbreviation to your title.

The abbreviations can be:
- [DOC]: Documentation fixes.
- [ENH]: Code contributions and new features.
- [TST]: Test-related contributions.
- [INF]: Infrastructure-related contributions.

Also, do not forget to tag the relevant issue here as well.

Finally, as commits come in, don't forget to regularly rebase!
-->

# PR Description

Please describe the changes proposed in the pull request:

- **This is a potentially test PR that might not be used**
- CI currently uses python 3.9 and a test fails that relates to `pandas` (`xlrd`) reading an `.xlsx` file
- This PR verifies that using python 3.9 is the culprit, which occurs because the CI actually uses the `environment.yml` file to set the python version, instead of `pipeline-master.yml`

# Relevant Reviewers

<!-- Finally, please tag relevant maintainers to review. -->

Please tag maintainers to review.

- @ericmjl
