### PR TITLE
[ENH] Refactor label_encode to use multiple dispatch.

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -21,6 +21,7 @@ dependencies:
 - lxml
 - make
 - missingno
+- multipledispatch
 - mypy
 - natsort
 - nbsphinx

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -794,7 +794,7 @@ def _label_encode(df, column_names):
 
 
 @dispatch(pd.DataFrame, str)
-def _label_encode(df, column_names):
+def _label_encode(df, column_names):  # noqa: F811
     le = LabelEncoder()
     check_column(df, column_names=column_names, present=True)
     df[f"{column_names}_enc"] = le.fit_transform(df[column_names])

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -1529,7 +1529,7 @@ def filter_date(
     months: Optional[List] = None,
     days: Optional[List] = None,
     column_date_options: Optional[Dict] = None,
-    format: Optional[str] = None,
+    format: Optional[str] = None,  # skipcq: PYL-W0622
 ) -> pd.DataFrame:
     """Filter a date-based column based on certain criteria.
 

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -102,7 +102,7 @@ def unionize_dataframe_categories(
     if any(not isinstance(df, pd.DataFrame) for df in dataframes):
         raise TypeError("Inputs must all be dataframes.")
 
-    elif column_names is None:
+    if column_names is None:
         # Find all columns across all dataframes that are categorical
 
         column_names = set()
@@ -307,7 +307,7 @@ def clean_names(
     original_column_names = list(df.columns)
 
     if enforce_string:
-        df = df.rename(columns=lambda x: str(x))
+        df = df.rename(columns=str)
 
     df = df.rename(columns=lambda x: _change_case(x, case_type))
 
@@ -1132,7 +1132,7 @@ def fill_empty(
     :raises JanitorError: if a column specified within ``column_names``
         is not found in the DataFrame.
     """
-    if isinstance(column_names, list) or isinstance(column_names, tuple):
+    if isinstance(column_names, (list, tuple)):
         for col in column_names:
             if col not in df.columns:
                 raise JanitorError(f"{col} missing from DataFrame columns!")
@@ -1187,8 +1187,7 @@ def expand_column(
     if concat:
         df = df.join(expanded_df)
         return df
-    else:
-        return expanded_df
+    return expanded_df
 
 
 @pf.register_dataframe_method
@@ -1455,8 +1454,7 @@ def filter_string(
     criteria = df[column_name].str.contains(search_string)
     if complement:
         return df[~criteria]
-    else:
-        return df[criteria]
+    return df[criteria]
 
 
 @pf.register_dataframe_method
@@ -1517,8 +1515,7 @@ def filter_on(
     """
     if complement:
         return df.query("not " + criteria)
-    else:
-        return df.query(criteria)
+    return df.query(criteria)
 
 
 @pf.register_dataframe_method
@@ -1788,8 +1785,7 @@ def filter_column_isin(
 
     if complement:
         return df[~criteria]
-    else:
-        return df[criteria]
+    return df[criteria]
 
 
 @pf.register_dataframe_method

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -1722,12 +1722,11 @@ def filter_date(
     if days:
         _filter_list.append(df.loc[:, column_name].dt.day.isin(days))
 
-    if start_date and end_date:
-        if start_date > end_date:
-            warnings.warn(
-                f"Your start date of {start_date} is after your end date of "
-                f"{end_date}. Is this intended?"
-            )
+    if start_date and end_date and start_date > end_date:
+        warnings.warn(
+            f"Your start date of {start_date} is after your end date of "
+            f"{end_date}. Is this intended?"
+        )
 
     return df.loc[_date_filter_conditions(_filter_list), :]
 

--- a/janitor/utils.py
+++ b/janitor/utils.py
@@ -348,11 +348,10 @@ def check_column(
             raise ValueError(
                 f"{column_name} not present in dataframe columns!"
             )
-        else:  # Tests for exclusion
-            if column_name in df.columns:
-                raise ValueError(
-                    f"{column_name} already present in dataframe columns!"
-                )
+        if column_name in df.columns:
+            raise ValueError(
+                f"{column_name} already present in dataframe columns!"
+            )
 
 
 def skipna(f: Callable) -> Callable:

--- a/janitor/utils.py
+++ b/janitor/utils.py
@@ -329,7 +329,7 @@ def check_column(
     df: pd.DataFrame, column_names: Union[Iterable, str], present: bool = True
 ):
     """
-    One-liner syntactic sugar for checking the presence or absence columns.
+    One-liner syntactic sugar for checking the presence or absence of columns.
 
     Should be used like this::
 

--- a/janitor/utils.py
+++ b/janitor/utils.py
@@ -386,7 +386,7 @@ def skiperror(
     f: Callable, return_x: bool = False, return_val=np.nan
 ) -> Callable:
     """
-    Decorator for escaping errors in a function
+    Decorator for escaping any error in a function.
 
     Should be used like this::
 
@@ -410,7 +410,7 @@ def skiperror(
     def _wrapped(x, *args, **kwargs):
         try:
             return f(x, *args, **kwargs)
-        except Exception:
+        except Exception:  # skipcq: PYL-W0703
             if return_x:
                 return x
             return return_val

--- a/janitor/utils.py
+++ b/janitor/utils.py
@@ -329,11 +329,16 @@ def check_column(
     df: pd.DataFrame, column_names: Union[Iterable, str], present: bool = True
 ):
     """
-    One-liner syntactic sugar for checking the presence or absence of a column.
+    One-liner syntactic sugar for checking the presence or absence of (a) column(s).
 
     Should be used like this::
 
         check(df, ['a', 'b'], present=True)
+
+    This will check whether columns "a" and "b" are present in df's columns.
+
+    One can also guarantee that "a" and "b" are not present
+    by switching to ``present = False``.
 
     :param df: The name of the variable.
     :param column_names: A list of column names we want to check to see if
@@ -344,7 +349,7 @@ def check_column(
     :raises ValueError: if data is not the expected type.
     """
     for column_name in column_names:
-        if present and column_name not in df.columns:
+        if present and column_name not in df.columns:  # skipcq: PYL-R1720
             raise ValueError(
                 f"{column_name} not present in dataframe columns!"
             )

--- a/janitor/utils.py
+++ b/janitor/utils.py
@@ -344,11 +344,10 @@ def check_column(
     :raises ValueError: if data is not the expected type.
     """
     for column_name in column_names:
-        if present:
-            if column_name not in df.columns:
-                raise ValueError(
-                    f"{column_name} not present in dataframe columns!"
-                )
+        if present and column_name not in df.columns:
+            raise ValueError(
+                f"{column_name} not present in dataframe columns!"
+            )
         else:  # Tests for exclusion
             if column_name in df.columns:
                 raise ValueError(
@@ -445,13 +444,11 @@ def _check_instance(entry: Dict):
                     "expand_grid works only on 1D and 2D structures."
                 )
 
-        if isinstance(value, (pd.DataFrame, pd.Series)):
-            if value.empty:
-                raise ValueError("passed DataFrame cannot be empty")
+        if isinstance(value, (pd.DataFrame, pd.Series)) and value.empty:
+            raise ValueError("passed DataFrame cannot be empty")
 
-        if isinstance(value, (list, tuple, set, dict)):
-            if not value:
-                raise ValueError("passed data cannot be empty")
+        if isinstance(value, (list, tuple, set, dict)) and not value:
+            raise ValueError("passed data cannot be empty")
 
     entry = {
         # If it is a scalar value, then wrap in a list
@@ -637,9 +634,11 @@ def _computations_complete(
             for _, value in group.items():
                 group_value = common.apply_if_callable(value, df)
                 # safe assumption to get unique values
-                if isinstance(group_value, pd.Series):
-                    if not group_value.is_unique:
-                        group_value = group_value.unique()
+                if (
+                    isinstance(group_value, pd.Series)
+                    and not group_value.is_unique
+                ):
+                    group_value = group_value.unique()
                 else:
                     group_value = set(group_value)
                 group_collection.append(group_value)
@@ -721,21 +720,17 @@ def _data_checks_pivot_longer(
                     """
             )
 
-        if ".value" in names_to:
-            if names_to.count(".value") > 1:
-                raise ValueError(
-                    "There can be only one `.value` in `names_to`."
-                )
-    if len(names_to) == 1:
-        # names_sep creates more than one column
-        # whereas regex with names_pattern can be limited to one column
-        if names_sep is not None:
-            raise ValueError(
-                """
+        if ".value" in names_to and names_to.count(".value") > 1:
+            raise ValueError("There can be only one `.value` in `names_to`.")
+    # names_sep creates more than one column
+    # whereas regex with names_pattern can be limited to one column
+    if len(names_to) == 1 and names_sep is not None:
+        raise ValueError(
+            """
                     For a single `names_to` value,
                     `names_sep` is not required.
                     """
-            )
+        )
     if names_pattern is not None:
         check("names_pattern", names_pattern, [str, Pattern, List, Tuple])
 
@@ -771,59 +766,61 @@ def _data_checks_pivot_longer(
 
     check("values_to", values_to, [str])
 
-    if values_to in df.columns:
-        if any(
-            (
-                ".value" not in names_to,
-                not isinstance(names_pattern, (list, tuple)),
-            )
-        ):
-            # copied from pandas' melt source code
-            # with a minor tweak
-            raise ValueError(
-                """
+    if values_to in df.columns and any(
+        (
+            ".value" not in names_to,
+            not isinstance(names_pattern, (list, tuple)),
+        )
+    ):
+        # copied from pandas' melt source code
+        # with a minor tweak
+        raise ValueError(
+            """
                 This dataframe has a column name that matches the
                 'values_to' column name of the resulting Dataframe.
                 Kindly set the 'values_to' parameter to a unique name.
                 """
-            )
+        )
 
     if column_level is not None:
         check("column_level", column_level, [int, str])
 
-    if any((names_sep, names_pattern)):
-        if isinstance(df.columns, pd.MultiIndex):
-            raise ValueError(
-                """
+    if any((names_sep, names_pattern)) and isinstance(
+        df.columns, pd.MultiIndex
+    ):
+        raise ValueError(
+            """
                 Unpivoting a MultiIndex column dataframe when
                 `names_sep` or `names_pattern` is supplied is
                 not supported.
                 """
-            )
+        )
 
     if all((names_sep is None, names_pattern is None)):
         # adapted from pandas' melt source code
-        if index is not None:
-            if isinstance(df.columns, pd.MultiIndex) and not isinstance(
-                index, list
-            ):
-                raise ValueError(
-                    """
+        if (
+            index is not None
+            and isinstance(df.columns, pd.MultiIndex)
+            and not isinstance(index, list)
+        ):
+            raise ValueError(
+                """
                     index must be a list of tuples
                     when columns are a MultiIndex.
                     """
-                )
+            )
 
-        if column_names is not None:
-            if isinstance(df.columns, pd.MultiIndex) and not isinstance(
-                column_names, list
-            ):
-                raise ValueError(
-                    """
+        if (
+            column_names is not None
+            and isinstance(df.columns, pd.MultiIndex)
+            and not isinstance(column_names, list)
+        ):
+            raise ValueError(
+                """
                     column_names must be a list of tuples
                     when columns are a MultiIndex.
                     """
-                )
+            )
 
     check("sort_by_appearance", sort_by_appearance, [bool])
 
@@ -1062,18 +1059,17 @@ def _pivot_longer_extractions(
     category_dtypes = None
     category_keys = None
     reindex_columns = None
-    if not dot_value:
-        if index:
-            # more efficient to do this, than having to
-            # set the index and resetting.
-            # This puts the index(or indices) into the first
-            # column and set the remaining columns to empty string
-            # on the same row(s). When melting, pd.melt will
-            # gracefully handle the empty cells and replicate the
-            # `index` values accordingly.
-            positions = df.columns.get_indexer(index)
-            mapping.iloc[positions, 0] = index
-            mapping.iloc[positions, 1:] = ""
+    if not dot_value and index:
+        # more efficient to do this, than having to
+        # set the index and resetting.
+        # This puts the index(or indices) into the first
+        # column and set the remaining columns to empty string
+        # on the same row(s). When melting, pd.melt will
+        # gracefully handle the empty cells and replicate the
+        # `index` values accordingly.
+        positions = df.columns.get_indexer(index)
+        mapping.iloc[positions, 0] = index
+        mapping.iloc[positions, 1:] = ""
 
     else:
         # this gets the complete pairings of all labels in `mapping`
@@ -1205,13 +1201,16 @@ def _computations_pivot_longer(
     if column_names is not None:
         check_column(df, column_names, present=True)
 
-    if (index is None) and column_names:
-        if len(df.columns) > len(column_names):
-            index = [
-                column_name
-                for column_name in df
-                if column_name not in column_names
-            ]
+    if (
+        (index is None)
+        and column_names
+        and len(df.columns) > len(column_names)
+    ):
+        index = [
+            column_name
+            for column_name in df
+            if column_name not in column_names
+        ]
 
     df_index = df.index
 
@@ -1379,18 +1378,17 @@ def _data_checks_pivot_wider(
     if names_sep is not None:
         check("names_sep", names_sep, [str])
 
-    if aggfunc is not None:
-        # cant apply the `check` function here
-        # because of the callable type
-        if not any(
-            (isinstance(aggfunc, (str, list, dict)), callable(aggfunc))
-        ):
-            raise TypeError(
-                """
-                aggfunc should be either a function,
-                string, list, or a dictionary.
-                """
-            )
+    # cant apply the `check` function here
+    # because of the callable type
+    if aggfunc is not None and not any(
+        (isinstance(aggfunc, (str, list, dict)), callable(aggfunc))
+    ):
+        raise TypeError(
+            """
+            aggfunc should be either a function,
+            string, list, or a dictionary.
+            """
+        )
 
     if fill_value is not None:
         check("fill_value", fill_value, [int, float, str])
@@ -1518,12 +1516,14 @@ def _computations_pivot_wider(
             df = df.droplevel("aggfunc", axis="columns")
 
     new_order_level = None
-    if df.columns.nlevels != len(names_from):
-        if names_from_position == "first":
-            new_order_level = pd.Index(names_from).union(
-                df.columns.names, sort=False
-            )
-            df = df.reorder_levels(order=new_order_level, axis="columns")
+    if (
+        df.columns.nlevels != len(names_from)
+        and names_from_position == "first"
+    ):
+        new_order_level = pd.Index(names_from).union(
+            df.columns.names, sort=False
+        )
+        df = df.reorder_levels(order=new_order_level, axis="columns")
 
     if names_sort:
         df = df.sort_index(axis="columns", level=names_from)

--- a/janitor/utils.py
+++ b/janitor/utils.py
@@ -329,7 +329,7 @@ def check_column(
     df: pd.DataFrame, column_names: Union[Iterable, str], present: bool = True
 ):
     """
-    One-liner syntactic sugar for checking the presence or absence of (a) column(s).
+    One-liner syntactic sugar for checking the presence or absence columns.
 
     Should be used like this::
 

--- a/janitor/utils.py
+++ b/janitor/utils.py
@@ -107,8 +107,7 @@ def _currency_column_to_numeric(x, cast_non_numeric=None) -> str:
                 [int, float],
             )
             return cast_non_numeric[x]
-        else:
-            return "".join(i for i in x if i in acceptable_currency_characters)
+        return "".join(i for i in x if i in acceptable_currency_characters)
     else:
         return "".join(i for i in x if i in acceptable_currency_characters)
 
@@ -379,8 +378,7 @@ def skipna(f: Callable) -> Callable:
     def _wrapped(x, *args, **kwargs):
         if (type(x) is float and np.isnan(x)) or x is None:
             return np.nan
-        else:
-            return f(x, *args, **kwargs)
+        return f(x, *args, **kwargs)
 
     return _wrapped
 

--- a/janitor/utils.py
+++ b/janitor/utils.py
@@ -108,8 +108,7 @@ def _currency_column_to_numeric(x, cast_non_numeric=None) -> str:
             )
             return cast_non_numeric[x]
         return "".join(i for i in x if i in acceptable_currency_characters)
-    else:
-        return "".join(i for i in x if i in acceptable_currency_characters)
+    return "".join(i for i in x if i in acceptable_currency_characters)
 
 
 def _replace_empty_string_with_none(column_series):

--- a/janitor/utils.py
+++ b/janitor/utils.py
@@ -348,7 +348,7 @@ def check_column(
             raise ValueError(
                 f"{column_name} not present in dataframe columns!"
             )
-        if column_name in df.columns:
+        elif not present and column_name in df.columns:
             raise ValueError(
                 f"{column_name} already present in dataframe columns!"
             )

--- a/janitor/utils.py
+++ b/janitor/utils.py
@@ -6,7 +6,16 @@ import sys
 import warnings
 from collections import namedtuple
 from itertools import chain, product
-from typing import Callable, Dict, List, Optional, Pattern, Tuple, Union
+from typing import (
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Pattern,
+    Tuple,
+    Union,
+)
 
 import numpy as np
 import pandas as pd
@@ -319,7 +328,7 @@ def rename_kwargs(func_name: str, kwargs: Dict, aliases: Dict):
 
 
 def check_column(
-    df: pd.DataFrame, old_column_names: List, present: bool = True
+    df: pd.DataFrame, column_names: Union[Iterable, str], present: bool = True
 ):
     """
     One-liner syntactic sugar for checking the presence or absence of a column.
@@ -329,14 +338,14 @@ def check_column(
         check(df, ['a', 'b'], present=True)
 
     :param df: The name of the variable.
-    :param old_column_names: A list of column names we want to check to see if
+    :param column_names: A list of column names we want to check to see if
         present (or absent) in df.
-    :param present: If True (default), checks to see if all of old_column_names
-        are in df.columns. If False, checks that none of old_column_names are
+    :param present: If True (default), checks to see if all of column_names
+        are in df.columns. If False, checks that none of column_names are
         in df.columns.
     :raises ValueError: if data is not the expected type.
     """
-    for column_name in old_column_names:
+    for column_name in column_names:
         if present:
             if column_name not in df.columns:
                 raise ValueError(
@@ -1655,8 +1664,7 @@ def _computations_as_categorical(df: pd.DataFrame, **kwargs) -> pd.DataFrame:
 
             if categories_order_tuple.order is None:
                 categories_dtypes[column_name] = CategoricalDtype(
-                    categories=categories_order_tuple.categories,
-                    ordered=False,
+                    categories=categories_order_tuple.categories, ordered=False
                 )
             elif categories_order_tuple.order == "sort":
                 categories_dtypes[column_name] = CategoricalDtype(
@@ -1665,7 +1673,7 @@ def _computations_as_categorical(df: pd.DataFrame, **kwargs) -> pd.DataFrame:
                 )
             else:  # appearance
                 categories_dtypes[column_name] = CategoricalDtype(
-                    categories=categories_order_tuple.categories, ordered=True,
+                    categories=categories_order_tuple.categories, ordered=True
                 )
 
     df = df.astype(categories_dtypes)

--- a/tests/functions/test_label_encode.py
+++ b/tests/functions/test_label_encode.py
@@ -14,7 +14,7 @@ def test_single_column_label_encode():
 
 @pytest.mark.functions
 def test_single_column_fail_label_encode():
-    with pytest.raises(JanitorError):
+    with pytest.raises(ValueError):
         pd.DataFrame(
             {"a": ["hello", "hello", "sup"], "b": [1, 2, 3]}
         ).label_encode(
@@ -37,5 +37,5 @@ def test_multicolumn_label_encode():
 
 @pytest.mark.functions
 def test_label_encode_invalid_input(dataframe):
-    with pytest.raises(JanitorError):
+    with pytest.raises(NotImplementedError):
         dataframe.label_encode(1)

--- a/tests/functions/test_label_encode.py
+++ b/tests/functions/test_label_encode.py
@@ -1,8 +1,6 @@
 import pandas as pd
 import pytest
 
-from janitor.errors import JanitorError
-
 
 @pytest.mark.functions
 def test_single_column_label_encode():


### PR DESCRIPTION
By using multiple dispatch, we can have a single function name that behaves correctly based on the data types of the input functions. This beats out checking types inside a function in order to determine that function's behaviour. Apparently, [PEP443](https://www.python.org/dev/peps/pep-0443/) says checking types inside a function to determine behaviour is a bit of an anti-pattern. I've led countless people down the wrong path :joy_cat:.

@samukweku using single/multiple dispatching might be a better way to approach type-specific behaviour because we can get an automatically-raised `NotImplementedError` for things not implemented. I should have realized this programming behaviour earlier on.