### PR TITLE
Expand_grid refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
   to allow for flexible columns selection. @samukweku
 - [ENH] `pivot_longer` and `pivot_wider` now support `janitor.select_columns` syntax,
   allowing for more flexible and dynamic column selection. @samukweku
+- [ENH] Performance improvements to `expand_grid`. @samukweku
 
 
 ## v0.20.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - [ENH] Modified the `check` function in utils to verify if a value is a callable. @samukweku
 - [ENH] Add a base `_select_column` function, using ``functools.singledispatch``,
   to allow for flexible columns selection. @samukweku
-- [ENH] pivot_longer and pivot_wider now support janitor.select_columns syntax,
+- [ENH] `pivot_longer` and `pivot_wider` now support `janitor.select_columns` syntax,
   allowing for more flexible and dynamic column selection. @samukweku
 
 

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -4372,8 +4372,14 @@ def expand_grid(
     """
     Creates a dataframe from a combination of all inputs.
 
+    It creates a cartesian product of all the inputs.
+
     This works with a dictionary of name value pairs,
-    and will work with structures that are not dataframes.
+    or keyword arguments (`kwargs`); it is also not restricted
+    to dataframes; it can work with any list-like structure
+    that is 1 or 2 dimensional.
+    MultiIndex objects are not supported though.
+
     If method-chaining to a dataframe,
     a key to represent the column name in the output must be provided.
 
@@ -4446,7 +4452,7 @@ def expand_grid(
 
     :param df: A pandas dataframe.
     :param df_key: name of key for the dataframe.
-        It becomes the column name of the dataframe.
+        It becomes part of the column names of the dataframe.
     :param others: A dictionary that contains the data
         to be combined with the dataframe.
         If no dataframe exists, all inputs

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -4991,23 +4991,33 @@ def complete(
 ) -> pd.DataFrame:
     """
     This function turns implicit missing values into explicit missing values.
+
     It is modeled after tidyr's `complete` function, and is a wrapper around
     `pd.DataFrame.merge` and `pd.DataFrame.fillna`.
+
     Combinations of column names or a list/tuple of column names, or even a
-    dictionary of column names and new values are possible. It can also handle
-    duplicated data.
+    dictionary of column names and new values are possible. 
+    
+    It can also handle duplicated data.
+
     `Source <https://tidyr.tidyverse.org/reference/complete.html#examples>`_
+
     .. code-block:: python
+
         import pandas as pd
         import janitor as jn
+
             group	item_id	    item_name	value1	value2
         0	1	    1	        a	1	4
         1	2	    2	        b	2	5
         2	1	    2	        b	3	6
+
     To find all the unique combinations of `group`, `item_id`, and `item_name`,
     including combinations not present in the data, each variable should be
     passed in a list to the `columns` parameter::
+
         df.complete(columns = ['group', 'item_id', 'item_name'])
+
               group	item_id	    item_name	value1	value2
         0	1	    1	        a	1.0	4.0
         1	1	    1	        b	NaN	NaN
@@ -5017,27 +5027,36 @@ def complete(
         5	2	    1	        b	NaN	NaN
         6	2	    2	        a	NaN	NaN
         7	2	    2	        b	2.0	5.0
+
     To expose just the missing values based only on the existing data,
     `item_id` and `item_name` can be wrapped in a tuple, while `group`
     is passed in as a separate variable::
+
         df.complete(columns = ["group", ("item_id", "item_name")])
             group	item_id	    item_name	value1	   value2
         0	1	    1	        a	  1.0	    4.0
         1	1	    2	        b	  3.0	    6.0
         2	2	    1	        a	  NaN 	    NaN
         3	2	    2	        b	  2.0	    5.0
+
     Let's look at another example:
+
     `Source Data <http://imachordata.com/2016/02/05/you-complete-me/>`_
+
     .. code-block:: python
+
             Year      Taxon         Abundance
         0   1999    Saccharina         4
         1   2000    Saccharina         5
         2   2004    Saccharina         2
         3   1999     Agarum            1
         4   2004     Agarum            8
+
     Note that Year 2000 and Agarum pairing is missing. Let's make it
     explicit::
+
         df.complete(columns = ['Year', 'Taxon'])
+
            Year      Taxon     Abundance
         0  1999     Agarum         1.0
         1  1999     Saccharina     4.0
@@ -5045,9 +5064,12 @@ def complete(
         3  2000     Saccharina     5.0
         4  2004     Agarum         8.0
         5  2004     Saccharina     2.0
+
     The null value can be replaced with the fill_value argument::
+
         df.complete(columns = ['Year', 'Taxon'],
                     fill_value = {"Abundance" : 0})
+
            Year      Taxon     Abundance
         0  1999     Agarum         1.0
         1  1999     Saccharina     4.0
@@ -5055,13 +5077,16 @@ def complete(
         3  2000     Saccharina     5.0
         4  2004     Agarum         8.0
         5  2004     Saccharina     2.0
+
     What if we wanted the explicit missing values for all the years from
     1999 to 2004? Easy - simply pass a dictionary pairing the column name
     with the new values::
+
         df.complete(columns = [{"Year": lambda x : range(x.Year.min(),
                                                          x.Year.max() + 1)},
                                 "Taxon"],
                     fill_value={"Abundance" : 0})
+
             Year      Taxon     Abundance
         0   1999     Agarum         1.0
         1   1999    Saccharina      4.0
@@ -5075,12 +5100,18 @@ def complete(
         9   2003     Saccharina     0.0
         10  2004     Agarum         8.0
         11  2004    Saccharina      2.0
+
     .. note:: MultiIndex columns are not supported.
+
     Functional usage syntax:
+
     .. code-block:: python
+
         import pandas as pd
         import janitor as jn
+
         df = pd.DataFrame(...)
+
         df = jn.complete(
             df = df,
             columns= [
@@ -5090,8 +5121,11 @@ def complete(
             ],
             fill_value = None
         )
+
     Method chaining syntax:
+
     .. code-block:: python
+
         df = (
             pd.DataFrame(...)
             .complete(columns=[
@@ -5101,6 +5135,7 @@ def complete(
             ],
             fill_value=None,
         )
+
     :param df: A pandas dataframe.
     :param columns: This is a list containing the columns to be
         completed. It could be column labels (string type),
@@ -5115,8 +5150,10 @@ def complete(
         str/dict/list/tuple.
     :raises ValueError: if entry in `columns` is a dict/list/tuple
         and is empty.
+
     .. # noqa: DAR402
     """
+    
     df = df.copy()
 
     df = _computations_complete(df, columns, fill_value)

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -4996,8 +4996,8 @@ def complete(
     `pd.DataFrame.merge` and `pd.DataFrame.fillna`.
 
     Combinations of column names or a list/tuple of column names, or even a
-    dictionary of column names and new values are possible. 
-    
+    dictionary of column names and new values are possible.
+
     It can also handle duplicated data.
 
     `Source <https://tidyr.tidyverse.org/reference/complete.html#examples>`_
@@ -5153,7 +5153,7 @@ def complete(
 
     .. # noqa: DAR402
     """
-    
+
     df = df.copy()
 
     df = _computations_complete(df, columns, fill_value)

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -4389,7 +4389,7 @@ def sort_naturally(
 def expand_grid(
     df: Optional[pd.DataFrame] = None,
     df_key: Optional[str] = None,
-    others: Dict = {},
+    others: Optional[Dict] = None,
     **kwargs,
 ) -> pd.DataFrame:
     """

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -34,7 +34,7 @@ from sklearn.preprocessing import LabelEncoder
 
 from .errors import JanitorError
 from .utils import (
-    _check_instance,
+    _computations_expand_grid,
     _clean_accounting_column,
     _computations_as_categorical,
     _computations_complete,
@@ -43,7 +43,6 @@ from .utils import (
     _currency_column_to_numeric,
     _data_checks_pivot_longer,
     _data_checks_pivot_wider,
-    _grid_computation,
     _process_text,
     _replace_empty_string_with_none,
     _replace_original_empty_string_with_none,
@@ -4455,19 +4454,14 @@ def expand_grid(
     :raises TypeError: if others is not a dictionary
     :raises KeyError: if there is a dataframe and no key is provided.
     """
-    # check if others is a dictionary
-    if not isinstance(others, dict):
-        # strictly name value pairs
-        # same idea as in R and tidyverse implementation
-        raise TypeError("others must be a dictionary")
+
+    check("others", others, [dict])
+
     # if there is a dataframe, for the method chaining,
     # it must have a key, to create a name value pair
     if df is not None:
         df = df.copy()
-        if isinstance(df.index, pd.MultiIndex) or isinstance(
-            df.columns, pd.MultiIndex
-        ):
-            raise TypeError("`expand_grid` does not work with pd.MultiIndex")
+
         if not df_key:
             raise KeyError(
                 """
@@ -4475,10 +4469,15 @@ def expand_grid(
                 requires that a string `df_key` be passed in.
                 """
             )
-        others = {**{df_key: df}, **others}
-    entry = _check_instance(others)
 
-    return _grid_computation(entry)
+        check("df_key", df_key, [str])
+
+        others = {**{df_key: df}, **others}
+
+    if not others:
+        raise ValueError("""`others` cannot be empty.""")
+
+    return _computations_expand_grid(others)
 
 
 @pf.register_dataframe_method

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -4386,6 +4386,9 @@ def expand_grid(
     Note that if a MultiIndex dataframe or series is passed, the index/columns
     will be discarded, and a single indexed dataframe will be returned.
 
+    Existing data types are preserved in this function. 
+    This includes Pandas' extension array dtypes.
+
     The output will always be a dataframe.
 
     Example:
@@ -4964,33 +4967,23 @@ def complete(
 ) -> pd.DataFrame:
     """
     This function turns implicit missing values into explicit missing values.
-
     It is modeled after tidyr's `complete` function, and is a wrapper around
     `pd.DataFrame.merge` and `pd.DataFrame.fillna`.
-
     Combinations of column names or a list/tuple of column names, or even a
     dictionary of column names and new values are possible. It can also handle
     duplicated data.
-
-
     `Source <https://tidyr.tidyverse.org/reference/complete.html#examples>`_
-
     .. code-block:: python
-
         import pandas as pd
         import janitor as jn
-
             group	item_id	    item_name	value1	value2
         0	1	    1	        a	1	4
         1	2	    2	        b	2	5
         2	1	    2	        b	3	6
-
     To find all the unique combinations of `group`, `item_id`, and `item_name`,
     including combinations not present in the data, each variable should be
     passed in a list to the `columns` parameter::
-
         df.complete(columns = ['group', 'item_id', 'item_name'])
-
               group	item_id	    item_name	value1	value2
         0	1	    1	        a	1.0	4.0
         1	1	    1	        b	NaN	NaN
@@ -5000,37 +4993,27 @@ def complete(
         5	2	    1	        b	NaN	NaN
         6	2	    2	        a	NaN	NaN
         7	2	    2	        b	2.0	5.0
-
     To expose just the missing values based only on the existing data,
     `item_id` and `item_name` can be wrapped in a tuple, while `group`
     is passed in as a separate variable::
-
         df.complete(columns = ["group", ("item_id", "item_name")])
-
             group	item_id	    item_name	value1	   value2
         0	1	    1	        a	  1.0	    4.0
         1	1	    2	        b	  3.0	    6.0
         2	2	    1	        a	  NaN 	    NaN
         3	2	    2	        b	  2.0	    5.0
-
     Let's look at another example:
-
     `Source Data <http://imachordata.com/2016/02/05/you-complete-me/>`_
-
     .. code-block:: python
-
             Year      Taxon         Abundance
         0   1999    Saccharina         4
         1   2000    Saccharina         5
         2   2004    Saccharina         2
         3   1999     Agarum            1
         4   2004     Agarum            8
-
     Note that Year 2000 and Agarum pairing is missing. Let's make it
     explicit::
-
         df.complete(columns = ['Year', 'Taxon'])
-
            Year      Taxon     Abundance
         0  1999     Agarum         1.0
         1  1999     Saccharina     4.0
@@ -5038,12 +5021,9 @@ def complete(
         3  2000     Saccharina     5.0
         4  2004     Agarum         8.0
         5  2004     Saccharina     2.0
-
     The null value can be replaced with the fill_value argument::
-
         df.complete(columns = ['Year', 'Taxon'],
                     fill_value = {"Abundance" : 0})
-
            Year      Taxon     Abundance
         0  1999     Agarum         1.0
         1  1999     Saccharina     4.0
@@ -5051,16 +5031,13 @@ def complete(
         3  2000     Saccharina     5.0
         4  2004     Agarum         8.0
         5  2004     Saccharina     2.0
-
     What if we wanted the explicit missing values for all the years from
     1999 to 2004? Easy - simply pass a dictionary pairing the column name
     with the new values::
-
         df.complete(columns = [{"Year": lambda x : range(x.Year.min(),
                                                          x.Year.max() + 1)},
                                 "Taxon"],
                     fill_value={"Abundance" : 0})
-
             Year      Taxon     Abundance
         0   1999     Agarum         1.0
         1   1999    Saccharina      4.0
@@ -5074,16 +5051,11 @@ def complete(
         9   2003     Saccharina     0.0
         10  2004     Agarum         8.0
         11  2004    Saccharina      2.0
-
     .. note:: MultiIndex columns are not supported.
-
     Functional usage syntax:
-
     .. code-block:: python
-
         import pandas as pd
         import janitor as jn
-
         df = pd.DataFrame(...)
         df = jn.complete(
             df = df,
@@ -5094,11 +5066,8 @@ def complete(
             ],
             fill_value = None
         )
-
     Method chaining syntax:
-
     .. code-block:: python
-
         df = (
             pd.DataFrame(...)
             .complete(columns=[
@@ -5108,8 +5077,6 @@ def complete(
             ],
             fill_value=None,
         )
-
-
     :param df: A pandas dataframe.
     :param columns: This is a list containing the columns to be
         completed. It could be column labels (string type),
@@ -5124,7 +5091,6 @@ def complete(
         str/dict/list/tuple.
     :raises ValueError: if entry in `columns` is a dict/list/tuple
         and is empty.
-
     .. # noqa: DAR402
     """
     df = df.copy()

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -4366,7 +4366,8 @@ def sort_naturally(
 def expand_grid(
     df: Optional[pd.DataFrame] = None,
     df_key: Optional[str] = None,
-    others: Dict = None,
+    others: Dict = {},
+    **kwargs,
 ) -> pd.DataFrame:
     """
     Creates a dataframe from a combination of all inputs.
@@ -4450,12 +4451,19 @@ def expand_grid(
         to be combined with the dataframe.
         If no dataframe exists, all inputs
         in others will be combined to create a dataframe.
+    :param kwargs: Keyword arguments are accepted.
     :returns: A pandas dataframe of all combinations of name value pairs.
-    :raises TypeError: if others is not a dictionary
+    :raises TypeError: if `others` is not a dictionary
     :raises KeyError: if there is a dataframe and no key is provided.
+    :raises ValueError: if `others` is empty.
+
+    .. # noqa: DAR402
+
     """
 
     check("others", others, [dict])
+
+    others = {**others, **kwargs}
 
     # if there is a dataframe, for the method chaining,
     # it must have a key, to create a name value pair

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -4375,8 +4375,9 @@ def expand_grid(
     It creates a cartesian product of all the inputs.
 
     This works with a dictionary of name value pairs,
-    or keyword arguments (`kwargs`); it is also not restricted
-    to dataframes; it can work with any list-like structure
+    or keyword arguments (`kwargs`); 
+    it is also not restricted to dataframes; 
+    it can work with any list-like structure
     that is 1 or 2 dimensional.
     MultiIndex objects are not supported though.
 

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -4398,8 +4398,8 @@ def expand_grid(
     It creates a cartesian product of all the inputs.
 
     This works with a dictionary of name value pairs,
-    or keyword arguments (`kwargs`); 
-    it is also not restricted to dataframes; 
+    or keyword arguments (`kwargs`);
+    it is also not restricted to dataframes;
     it can work with any list-like structure
     that is 1 or 2 dimensional.
     MultiIndex objects are not supported though.
@@ -4410,7 +4410,7 @@ def expand_grid(
     Note that if a MultiIndex dataframe or series is passed, the index/columns
     will be discarded, and a single indexed dataframe will be returned.
 
-    Existing data types are preserved in this function. 
+    Existing data types are preserved in this function.
     This includes Pandas' extension array dtypes.
 
     The output will always be a dataframe.

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -4393,9 +4393,7 @@ def expand_grid(
     **kwargs,
 ) -> pd.DataFrame:
     """
-    Creates a dataframe from a combination of all inputs.
-
-    It creates a cartesian product of all the inputs.
+    Creates a dataframe from a cartesian combination of all inputs.
 
     This works with a dictionary of name value pairs,
     or keyword arguments (`kwargs`);
@@ -4435,7 +4433,7 @@ def expand_grid(
         #    2 |      1 |   2
         #    2 |      1 |   3
 
-        #create a dataframe from all combinations in a dictionary
+        # create a dataframe from all combinations in a dictionary
         data = {"x":range(1,4), "y":[1,2]}
 
         jn.expand_grid(others=data)

--- a/janitor/utils.py
+++ b/janitor/utils.py
@@ -468,15 +468,15 @@ def _computations_expand_grid(others: dict) -> pd.DataFrame:
     """
     Creates a cartesian product of all the inputs in `others`.
     Numpy's `mgrid`, combined with the `take` method in numpy/Pandas,
-    to expand each input to the length of the cumulative product of 
+    to expand each input to the length of the cumulative product of
     all inputs in `others`.
 
     There is a performance penalty for small entries (length less than 10)
-    in using this method, instead of `itertools.product`; however, there is 
+    in using this method, instead of `itertools.product`; however, there is
     significant performance benefits as the size of the data increases.
 
-    Another benefit of this approach, 
-    in addition to the significant performance gains, 
+    Another benefit of this approach,
+    in addition to the significant performance gains,
     is the preservation of data types. This is particularly noticeable for
     Pandas' extension arrays dtypes (categoricals, nullable integers, ...).
 
@@ -522,7 +522,7 @@ def _expand_grid(value, key, mgrid_values, mode="expand_grid"):
 
     `mode` parameter is added, to make the function reusable
     in the `_computations_complete` function.
-    Also, allowing `key` as None enables reuse in the 
+    Also, allowing `key` as None enables reuse in the
     `_computations_complete` function.
     """
 
@@ -543,7 +543,7 @@ def _sub_expand_grid(value, key, mgrid_values):  # noqa: F811
 
     `mode` parameter is added, to make the function reusable
     in the `_computations_complete` function.
-    Also, allowing `key` as None enables reuse in the 
+    Also, allowing `key` as None enables reuse in the
     `_computations_complete` function.
 
     Returns Series with name if 1-Dimensional array
@@ -566,7 +566,7 @@ def _sub_expand_grid(  # noqa: F811
 
     `mode` parameter is added, to make the function reusable
     in the `_computations_complete` function.
-    Also, allowing `key` as None enables reuse in the 
+    Also, allowing `key` as None enables reuse in the
     `_computations_complete` function.
 
     Returns Series with name if 1-Dimensional array
@@ -605,7 +605,7 @@ def _sub_expand_grid(  # noqa: F811
 
     `mode` parameter is added, to make the function reusable
     in the `_computations_complete` function.
-    Also, allowing `key` as None enables reuse in the 
+    Also, allowing `key` as None enables reuse in the
     `_computations_complete` function.
 
     Checks for empty Series and returns modified keys.
@@ -639,11 +639,11 @@ def _sub_expand_grid(  # noqa: F811
 
     `mode` parameter is added, to make the function reusable
     in the `_computations_complete` function.
-    Also, allowing `key` as None enables reuse in the 
+    Also, allowing `key` as None enables reuse in the
     `_computations_complete` function.
 
     Checks for empty dataframe and returns modified keys.
-    
+
     Returns a DataFrame with new column names.
     """
     if key is not None:

--- a/janitor/utils.py
+++ b/janitor/utils.py
@@ -467,7 +467,7 @@ def check_expand_grid_list(value):
 def _computations_expand_grid(others: dict) -> pd.DataFrame:
     """
     Creates a cartesian product of all the inputs in `others`.
-    Numpy's `mgrid`, combined with the `take` method in numpy/Pandas,
+    Combines Numpy's `mgrid`, with the `take` method in numpy/Pandas,
     to expand each input to the length of the cumulative product of
     all inputs in `others`.
 
@@ -501,6 +501,11 @@ def _computations_expand_grid(others: dict) -> pd.DataFrame:
 
     others = list(others)
 
+    # this section gets the length of each data in others,
+    # creates a mesh, essentially a catersian product of indices
+    # for each data in `others`.
+    # the rest of the code then expands/explodes the data,
+    # based on its type, before concatenating into a dataframe.
     mgrid_values = [slice(len(value)) for value, _ in others]
     mgrid_values = np.mgrid[mgrid_values]
     mgrid_values = map(np.ravel, mgrid_values)

--- a/tests/functions/test_complete.py
+++ b/tests/functions/test_complete.py
@@ -407,4 +407,3 @@ def test_complete_multiple_groupings():
     ).sort_values("project_id", ignore_index=True)
 
     assert_frame_equal(result, output3)
-

--- a/tests/functions/test_complete.py
+++ b/tests/functions/test_complete.py
@@ -407,3 +407,4 @@ def test_complete_multiple_groupings():
     ).sort_values("project_id", ignore_index=True)
 
     assert_frame_equal(result, output3)
+

--- a/tests/functions/test_expand_grid.py
+++ b/tests/functions/test_expand_grid.py
@@ -6,7 +6,6 @@ import pytest
 from pandas.testing import assert_frame_equal
 
 from janitor.functions import expand_grid
-from janitor.utils import _check_instance
 
 
 def test_not_a_dict():
@@ -254,3 +253,16 @@ def test_expand_grid_others_only(grid_input, grid_output):
     is supplied.
     """
     assert_frame_equal(expand_grid(others=grid_input), grid_output)
+
+
+import janitor
+
+df1 = pd.DataFrame({"x":range(1,3), "y":[2,1]})
+df2 = pd.DataFrame({"x":[1,2,3],"y":[3,2,1]})
+df3 = pd.DataFrame({"x":[2,3],"y":["a","b"]})
+
+data = {"df1":df1, "df2":df2, "df3":df3}
+
+result = expand_grid(others=data)
+
+print(result)

--- a/tests/functions/test_expand_grid.py
+++ b/tests/functions/test_expand_grid.py
@@ -262,4 +262,3 @@ def test_not_accepted_type():
 
     with pytest.raises(TypeError):
         expand_grid(others=others)
-

--- a/tests/functions/test_expand_grid.py
+++ b/tests/functions/test_expand_grid.py
@@ -107,6 +107,7 @@ def test_frames_series_multi_iIdex(multiIndex_data, multiIndex_outputs):
     """
     assert_frame_equal(expand_grid(others=multiIndex_data), multiIndex_outputs)
 
+
 @pytest.mark.xfail(reason="""Tests not required for this""")
 def test_scalar_to_list():
     """Test that scalars are converted to lists."""
@@ -133,7 +134,7 @@ def test_scalar_to_list():
         "f": range(2, 12),
     }
 
-    assert expand_grid(others = data) == expected
+    assert expand_grid(others=data) == expected
 
 
 def test_computation_output():
@@ -191,7 +192,7 @@ input_others = [
         "y": np.reshape(np.arange(5, 9), (2, -1), order="F"),
     },
     {"V1": (5, np.nan, 1), "V2": (1, 3, 2)},
-     {"V1": (5, np.nan, 1), "V2": pd.Index([1, 3, 2])}
+    {"V1": (5, np.nan, 1), "V2": pd.Index([1, 3, 2])},
 ]
 
 output_others = [
@@ -216,7 +217,7 @@ output_others = [
             "l2": ["A", "B", "C", "A", "B", "C", "A", "B", "C"],
         }
     ),
-    pd.DataFrame({'x_0': [2, 4], 'x_1': [3, 3]}),
+    pd.DataFrame({"x_0": [2, 4], "x_1": [3, 3]}),
     pd.DataFrame(np.array([2, 3]), columns=["x"]),
     pd.DataFrame(np.array([[2, 3]]), columns=["x_0", "x_1"]),
     pd.DataFrame(
@@ -238,7 +239,7 @@ output_others = [
             "V1": [5.0, 5.0, 5.0, np.nan, np.nan, np.nan, 1.0, 1.0, 1.0],
             "V2": [1, 3, 2, 1, 3, 2, 1, 3, 2],
         }
-    )
+    ),
 ]
 
 zip_others_only = zip(input_others, output_others)
@@ -252,23 +253,13 @@ def test_expand_grid_others_only(grid_input, grid_output):
     """
     assert_frame_equal(expand_grid(others=grid_input), grid_output)
 
+
 def test_not_accepted_type():
     """Raise TypeError if wrong data type is used in `others`."""
-    others = {"rar" : pd.MultiIndex.from_tuples([('A','B','C'), ('D','E','F')])}
+    others = {
+        "rar": pd.MultiIndex.from_tuples([("A", "B", "C"), ("D", "E", "F")])
+    }
 
     with pytest.raises(TypeError):
-        expand_grid(others = others)
+        expand_grid(others=others)
 
-# import janitor
-
-# df1 = pd.DataFrame({"x": range(1, 3), "y": [2, 1]})
-# df2 = pd.DataFrame({"x": [1, 2, 3], "y": [3, 2, 1]})
-# df3 = pd.DataFrame({"x": [2, 3], "y": ["a", "b"]})
-
-# data = {"df1": df1, "df2": df2, "df3": df3}
-# data = {"x": [[2, 3], [4, 3]]}
-
-# others = {"rar" : pd.MultiIndex.from_tuples([('A','B','C'), ('D','E','F')])}
-# result = expand_grid(others=others)
-
-# print(result)


### PR DESCRIPTION
# PR Description

Please describe the changes proposed in the pull request:

- Use numpy's mgrid to create cartesian product
- Dtypes preserved - This includes pandas extension type arrays (categoricals, nullable integers, ...)
- Dispatch method employed for different instances.
- Much faster output for expand_grid. Performance penalty for small datasets (less than 10 rows). 
- SIgnificant performance gains as the dataset grows.


**Speed Tests Comparison**:

Dev :
```python

In [1]: import pandas as pd; import numpy as np; import janitor

In [2]: %timeit janitor.expand_grid(others = {"x":np.arange(4), "y": np.arange(3)})
418 µs ± 5.95 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [3]: %timeit janitor.expand_grid(others = {"x":np.arange(10), "y": np.arange(20)})
802 µs ± 15.6 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [4]: %timeit janitor.expand_grid(others = {"x":np.arange(100), "y": np.arange(200)})
43.4 ms ± 902 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

```

PR:
```python
In [1]: import pandas as pd; import numpy as np; import janitor

In [2]: %timeit janitor.expand_grid(others = {"x":np.arange(4), "y": np.arange(3)})
794 µs ± 39.9 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [3]: %timeit janitor.expand_grid(others = {"x":np.arange(10), "y": np.arange(20)})
798 µs ± 34.9 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [4]: %timeit janitor.expand_grid(others = {"x":np.arange(100), "y": np.arange(200)})
940 µs ± 7.09 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)


```


**This PR improves the `expand_grid` function.**


Please ensure that you have done the following:

1. [x] PR in from a fork off your branch. Do not PR from `<your_username>`:`dev`, but rather from `<your_username>`:`<feature-branch_name>`.
<!-- Doing this helps us keep the commit history much cleaner than it would otherwise be. -->
2. [x] If you're not on the contributors list, add yourself to `AUTHORS.rst`.
<!-- We'd like to acknowledge your contributions! -->
3. [x] Add a line to `CHANGELOG.md` under the latest version header (i.e. the one that is "on deck") describing the contribution.
    - Do use some discretion here; if there are multiple PRs that are related, keep them in a single line.

## Quick Check

To do a very quick check that everything is correct, follow these steps below:

- [x] Run the command `make check` from pyjanitor's top-level directory. This will automatically run:
    - black formatting
    - flake8 checking
    - running the test suite
    - docs build

Once done, please check off the check-box above.

If `make check` does not work for you, you can execute the commands listed in the Makefile individually.

## Code Changes

<!-- If you have not made code changes, please feel free to delete this section. -->

If you are adding code changes, please ensure the following:

- [x] Ensure that you have added tests.
- [x] Run all tests (`$ pytest .`) locally on your machine.
    - [ ] Check to ensure that test coverage covers the lines of code that you have added.
    - [ ] Ensure that all tests pass.

## Documentation Changes

<!-- If you have not made documentation changes, please feel free to delete this section. -->

If you are adding documentation changes, please ensure the following:

- [x] Build the docs locally.
- [x] View the docs to check that it renders correctly.

# Relevant Reviewers

<!-- Finally, please tag relevant maintainers to review. -->

Please tag maintainers to review.

- @ericmjl
