### PR TITLE
[INF] GitHub Auto-Release Pointer

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -97,5 +97,14 @@ jobs:
       - name: Push changes with tags
         run: git push && git push --tags
 
+      # This will create an actual pointer in the "Release" section of the GitHub repo
+      # The intent is to always have "latest" point to <this> release
+      - name: Create release in GitHub repo
+        uses: ncipollo/release-action@v1
+        with:
+            body: "Contribution details can be found in CHANGELOG.rst"
+            token: ${{ secrets.GITHUB_TOKEN }}
+            tag: v${{ env.version_number}}
+
       - name: Ensure complete
         run: echo "Auto-release complete!"

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Create release in GitHub repo
         uses: ncipollo/release-action@v1
         with:
-            body: "Contribution details can be found in CHANGELOG.rst"
+            body: "Contribution details can be found in CHANGELOG.md"
             token: ${{ secrets.GITHUB_TOKEN }}
             tag: v${{ env.version_number}}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+-   [INF] Add GitHub Release pointer to auto-release script. Issue #818. @loganthomas
 
 ## [v0.21.0] - 2021-07-16
 


### PR DESCRIPTION
# PR Description
- With a few simple lines added to `.github/workflows/auto-release.yml`, we can correctly reference (i.e. "point") to the latest release in the landing page of the GitHub repo. In addition, this will include a "prettier" interface when navigating the releases.
- This has been tested on `solid-octo-guac` (thanks @ericmjl for keeping this up 😅 ) [here](https://github.com/ericmjl/solid-octo-guac)
- See [https://github.com/ncipollo/release-action](https://github.com/ncipollo/release-action)

**This PR resolves #818**

# PR Checklist

Please ensure that you have done the following:

1. [X] PR in from a fork off your branch. Do not PR from `<your_username>`:`dev`, but rather from `<your_username>`:`<feature-branch_name>`.
2. [X] If you're not on the contributors list, add yourself to `AUTHORS.rst`.
3. [X] Add a line to `CHANGELOG.md` under the latest version header (i.e. the one that is "on deck") describing the contribution.
    - Do use some discretion here; if there are multiple PRs that are related, keep them in a single line.

# Automatic checks

There will be automatic checks run on the PR. These include:

- Building a preview of the docs on Netlify
- Automatically linting the code
- Making sure the code is documented
- Making sure that all tests are passed
- Making sure that code coverage doesn't go down.

# Relevant Reviewers

@samukweku and @jk3587 this will add a single step to the auto-release script.

Please tag maintainers to review.

- @ericmjl
