### PR TITLE
[INF] Add docs build GitHub action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - dev
+      - ghactions-docs
 
 jobs:
   build-environment:
@@ -74,6 +75,7 @@ jobs:
         run: |
           source /tmp/pyjanitor-dev_env/bin/activate
           python -m ipykernel install --user --name pyjanitor-dev
+          pip install -e .
           make docs
 
       - name: Deploy website

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - dev
-      - ghactions-docs # TODO: delete this if we are sure it works on the PR.
 
 jobs:
   build-environment:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,91 @@
+name: Build documentation
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  build-environment:
+    runs-on: ubuntu-18.04
+    name: Build environment
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # See: https://github.com/marketplace/actions/setup-conda
+      - name: Setup anaconda
+        uses: s-weigand/setup-conda@v1
+        with:
+          conda-channels: "conda-forge"
+
+      - name: Cache conda environment
+        id: cache-environment
+        uses: actions/cache@v2
+        # Conda environment build step depends on two files,
+        # so we ensure that the hash key contains both their hashes.
+        with:
+          path: |
+            pyjanitor-dev.tar.gz
+          key: ${{ runner.os }}-env.${{ hashFiles('environment-dev.yml') }}
+
+      - name: Build environment
+        if: steps.cache-environment.outputs.cache-hit != 'true'
+        run: |
+          conda env create -f environment-dev.yml
+          python -m pip install .
+
+      - name: Install conda-pack
+        if: steps.cache-environment.outputs.cache-hit != 'true'
+        run: conda install -c conda-forge conda-pack
+
+      - name: Run conda-pack
+        if: steps.cache-environment.outputs.cache-hit != 'true'
+        run: conda pack -n pyjanitor-dev -o pyjanitor-dev.tar.gz
+
+      # See: https://github.com/actions/upload-artifact
+      - name: Upload environment
+        uses: actions/upload-artifact@v2
+        with:
+          name: pyjanitor-dev-tarball
+          path: pyjanitor-dev.tar.gz
+
+  docs:
+    name: Build static site docs
+    runs-on: ubuntu-latest
+    needs: build-environment
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # https://github.com/actions/download-artifact
+      - name: Download environment tarball
+        uses: actions/download-artifact@v2
+        with:
+          name: pyjanitor-dev-tarball
+
+      - name: Unpack environment and activate it
+        run: |
+          bash scripts/ci/unpack_environment.sh
+
+      - name: Build docs
+        run: |
+          source /tmp/pyjanitor-dev_env/bin/activate
+          python -m ipykernel install --user --name pyjanitor-dev
+          make docs
+
+      - name: Deploy website
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          # https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-set-personal-access-token-personal_token
+          personal_token: ${{ secrets.GHPAGES_TOKEN }}
+          publish_dir: ./docs/_build/html
+          publish_branch: gh-pages
+          # destination_dir: manuscript
+          allow_empty_commit: false
+          keep_files: false
+          force_orphan: true
+          enable_jekyll: false
+          disable_nojekyll: false

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - dev
+      - ghactions-docs # TODO: delete this if we are sure it works on the PR.
 
 jobs:
   build-environment:


### PR DESCRIPTION
This allows us to build docs on `dev` branch automatically on every push to `dev`. 

Enabling this PR should also nudge us to do more frequent releases especially when we have an API change.

 Tagging @loganthomas, it should save us the need to do what you did in #867.

Resolves #868.