### PR TITLE
 [DOC] Add a link to the documentation, update deprecated links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,8 @@ pyjanitor
 ``pyjanitor`` is a Python implementation of the R package `janitor`_, and
 provides a clean API for cleaning data.
 
+The official is hosted on: https://pyjanitor-devs.github.io/pyjanitor/
+
 .. _janitor: https://github.com/sfirke/janitor
 
 Why janitor?
@@ -277,7 +279,7 @@ Contributing
 ------------
 
 Follow `contribution docs
-<https://pyjanitor.readthedocs.io/contributing.html>`_ for a full description of the process of contributing to ``pyjanitor``.
+<https://pyjanitor-devs.github.io/pyjanitor/contributing.html>`_ for a full description of the process of contributing to ``pyjanitor``.
 
 Adding new functionality
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -314,7 +316,7 @@ Secondly, we ask that you contribute a test case,
 to ensure that it works as intended.
 Follow the `contribution`_ docs for further details.
 
-.. _contribution: https://pyjanitor.readthedocs.io/CONTRIBUTION_TYPES.html#unit-test-guidelines
+.. _contribution: https://pyjanitor-devs.github.io/pyjanitor/CONTRIBUTION_TYPES.html#unit-test-guidelines
 
 Feature requests
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Pyjanitor has moved from readthedocs to Github pages. 
This commit:
- Updates deprecated links
- Add a link to the official documentation 

I added a link to the official documentation, because it is currently hard to find the doc (referencing is bad on google, and there is no links in the project description in the README.md (I had to look for https://github.com/pyjanitor-devs/pyjanitor/issues/863 and this probably solve  issue https://github.com/pyjanitor-devs/pyjanitor/issues/869 )



- @ericmjl @loganthomas
