### PR TITLE
[ENH] Handle null values in concatenate_columns function

### DIFF
--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -1373,6 +1373,7 @@ def concatenate_columns(
     column_names: List[Hashable],
     new_column_name,
     sep: str = "-",
+    ignore_empty: bool = True
 ) -> pd.DataFrame:
     """Concatenates the set of columns into a single column.
 
@@ -1408,14 +1409,10 @@ def concatenate_columns(
     """
     if len(column_names) < 2:
         raise JanitorError("At least two columns must be specified")
-    for i, col in enumerate(column_names):
-        if i == 0:
-            df[new_column_name] = df[col].astype(str)
-        else:
-            df[new_column_name] = (
-                df[new_column_name] + sep + df[col].astype(str)
-            )
 
+    if ignore_empty:
+        df[column_names] = df[column_names].fillna('')
+    df[new_column_name] = df[column_names].astype(str).agg(sep.join, axis=1)
     return df
 
 

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -1403,6 +1403,7 @@ def concatenate_columns(
     :param column_names: A list of columns to concatenate together.
     :param new_column_name: The name of the new column.
     :param sep: The separator between each column's data.
+    :param ignore_empty: .
     :returns: A pandas DataFrame with concatenated columns.
     :raises JanitorError: if at least two columns are not provided
         within ``column_names``.
@@ -1410,9 +1411,13 @@ def concatenate_columns(
     if len(column_names) < 2:
         raise JanitorError("At least two columns must be specified")
 
-    if ignore_empty:
-        df[column_names] = df[column_names].fillna('')
+    df[column_names] = df[column_names].fillna("")
     df[new_column_name] = df[column_names].astype(str).agg(sep.join, axis=1)
+
+    if ignore_empty:
+        remove_empty_string = lambda x: sep.join(x for x in x.split(sep) if x)
+        df[new_column_name] = df[new_column_name].transform(remove_empty_string)
+
     return df
 
 

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -1366,7 +1366,7 @@ def expand_column(
     return expanded_df
 
 
-@pf.register_dataframe_method
+@pf.register_dataframe_methodex
 @deprecated_alias(columns="column_names")
 def concatenate_columns(
     df: pd.DataFrame,
@@ -1403,7 +1403,7 @@ def concatenate_columns(
     :param column_names: A list of columns to concatenate together.
     :param new_column_name: The name of the new column.
     :param sep: The separator between each column's data.
-    :param ignore_empty: .
+    :param ignore_empty: Ignore null values if exists.
     :returns: A pandas DataFrame with concatenated columns.
     :raises JanitorError: if at least two columns are not provided
         within ``column_names``.

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -1373,7 +1373,7 @@ def concatenate_columns(
     column_names: List[Hashable],
     new_column_name,
     sep: str = "-",
-    ignore_empty: bool = True
+    ignore_empty: bool = True,
 ) -> pd.DataFrame:
     """Concatenates the set of columns into a single column.
 
@@ -1411,14 +1411,18 @@ def concatenate_columns(
     if len(column_names) < 2:
         raise JanitorError("At least two columns must be specified")
 
-    df[column_names] = df[column_names].fillna("")
-    df[new_column_name] = df[column_names].astype(str).agg(sep.join, axis=1)
+    df[new_column_name] = (
+        df[column_names].fillna("").astype(str).agg(sep.join, axis=1)
+    )
 
     if ignore_empty:
+
         def remove_empty_string(x):
             return sep.join(x for x in x.split(sep) if x)
 
-        df[new_column_name] = df[new_column_name].transform(remove_empty_string)
+        df[new_column_name] = df[new_column_name].transform(
+            remove_empty_string
+        )
 
     return df
 

--- a/janitor/functions.py
+++ b/janitor/functions.py
@@ -1366,7 +1366,7 @@ def expand_column(
     return expanded_df
 
 
-@pf.register_dataframe_methodex
+@pf.register_dataframe_method
 @deprecated_alias(columns="column_names")
 def concatenate_columns(
     df: pd.DataFrame,
@@ -1415,7 +1415,9 @@ def concatenate_columns(
     df[new_column_name] = df[column_names].astype(str).agg(sep.join, axis=1)
 
     if ignore_empty:
-        remove_empty_string = lambda x: sep.join(x for x in x.split(sep) if x)
+        def remove_empty_string(x):
+            return sep.join(x for x in x.split(sep) if x)
+
         df[new_column_name] = df[new_column_name].transform(remove_empty_string)
 
     return df

--- a/tests/functions/test_concatenate_columns.py
+++ b/tests/functions/test_concatenate_columns.py
@@ -14,6 +14,18 @@ def test_concatenate_columns(dataframe):
 
 
 @pytest.mark.functions
+def test_concatenate_columns_null_values(missingdata_df):
+    df = missingdata_df.concatenate_columns(
+        column_names=["a", "decorated-elephant"],
+        sep="-",
+        new_column_name="index",
+        ignore_empty=True,
+    )
+    expected_values = ["1.0-1", "2.0-2", "3"] * 3
+    assert expected_values == df["index"].tolist()
+
+
+@pytest.mark.functions
 @pytest.mark.parametrize("column_names", [["a"], []])
 def test_concatenate_columns_errors(dataframe, column_names):
     with pytest.raises(


### PR DESCRIPTION
<!-- Thank you for your PR!

BEFORE YOU CONTINUE! Please add the appropriate three-letter abbreviation to your title.

The abbreviations can be:
- [DOC]: Documentation fixes.
- [ENH]: Code contributions and new features.
- [TST]: Test-related contributions.
- [INF]: Infrastructure-related contributions.

Also, do not forget to tag the relevant issue here as well.

Finally, as commits come in, don't forget to regularly rebase!
-->

# PR Description

Please describe the changes proposed in the pull request:

- Add `ignore_empty` parameter to ignore null values during concatenating columns.
- Simplify the current implementation.

**This PR resolves https://github.com/pyjanitor-devs/pyjanitor/issues/756**

# PR Checklist

Please ensure that you have done the following:

1. [x] PR in from a fork off your branch. Do not PR from `<your_username>`:`dev`, but rather from `<your_username>`:`<feature-branch_name>`.
<!-- Doing this helps us keep the commit history much cleaner than it would otherwise be. -->
2. [ ] If you're not on the contributors list, add yourself to `AUTHORS.rst`.
<!-- We'd like to acknowledge your contributions! -->
3. [ ] Add a line to `CHANGELOG.md` under the latest version header (i.e. the one that is "on deck") describing the contribution.
    - Do use some discretion here; if there are multiple PRs that are related, keep them in a single line.

# Automatic checks

There will be automatic checks run on the PR. These include:

- Building a preview of the docs on Netlify
- Automatically linting the code
- Making sure the code is documented
- Making sure that all tests are passed
- Making sure that code coverage doesn't go down.

# Relevant Reviewers

Please tag maintainers to review.

- @ericmjl
