### PR TITLE
[INF] Update vscode devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,6 +20,9 @@
 			"--config pyproject.toml",
 		],
 		"editor.formatOnSave": true,
+		"files.insertFinalNewline": true,
+		"files.trimFinalNewlines": true,
+		"files.trimTrailingWhitespace": true,
 		"[python]": {
 			"editor.formatOnSaveMode": "file",
 		},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,6 +19,7 @@
 		"python.formatting.blackArgs": [
 			"-l 79",
 		],
+		"editor.formatOnSave": true,
 		"[python]": {
 			"editor.formatOnSaveMode": "file",
 		},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
 		"python.linting.pylintPath": "/opt/conda/bin/pylint",
 		"python.formatting.provider": "black",
 		"python.formatting.blackArgs": [
-			"-l 79",
+			"--config pyproject.toml",
 		],
 		"editor.formatOnSave": true,
 		"[python]": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,11 +10,18 @@
 	},
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
-		"terminal.integrated.shell.linux": "/bin/bash",
+		"terminal.integrated.defaultProfile.linux": "bash",
 		"python.pythonPath": "/opt/conda/bin/python",
 		"python.linting.enabled": true,
 		"python.linting.pylintEnabled": true,
-		"python.linting.pylintPath": "/opt/conda/bin/pylint"
+		"python.linting.pylintPath": "/opt/conda/bin/pylint",
+		"python.formatting.provider": "black",
+		"python.formatting.blackArgs": [
+			"-l 79",
+		],
+		"[python]": {
+			"editor.formatOnSaveMode": "file",
+		},
 	},
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [


### PR DESCRIPTION
# PR Description

Some small changes/improvements to `devcontainer.json` that I would like to propose. 

1. Use of `terminal.integrated.shell.linux` is deprecated, now the best practice is to use integratedProfiles and designate one of them as the defaultProfile. (https://code.visualstudio.com/docs/editor/integrated-terminal#_terminal-profiles)
2. Since `black` is already running in the precommit, I suggest to also set up the development container to run black on save? (Some people might not like this behaviour -- if they don't, I suppose they can always set up user settings to override -- but I think having `black` run automatically on save is a nice default to have.) It's just an additional layer to ensure code quality when contributors push changes up.
3. Similarly for trimming new lines and whitespaces;

Thoughts/Opinions?

# Relevant Reviewers

<!-- Finally, please tag relevant maintainers to review. -->

Please tag maintainers to review.

- @ericmjl
- @samukweku 
