### PR TITLE
[ENH] Add io module to top-level import

### DIFF
--- a/janitor/__init__.py
+++ b/janitor/__init__.py
@@ -5,6 +5,7 @@ except ImportError:
     pass
 
 from .functions import *  # noqa: F403, F401
+from .io import *  # noqa: F403, F401
 from .math import *  # noqa: F403, F401
 from .ml import get_features_targets as _get_features_targets
 from .utils import refactored_function

--- a/janitor/io.py
+++ b/janitor/io.py
@@ -88,7 +88,7 @@ def read_commandline(cmd: str, **kwargs) -> pd.DataFrame:
 
     ```python
     import janitor as jn
-    df = jn.io.read_commandline("cat data.csv | grep .SEA1AA")
+    df = jn.read_commandline("cat data.csv | grep .SEA1AA")
 
     This function assumes that your command line command will return
     an output that is parsable using pandas.read_csv and StringIO.


### PR DESCRIPTION
# PR Description

Please describe the changes proposed in the pull request:

- Minor update to include `io` in top-level import. Now the following is possible:
  ```python
  In [1]: import janitor as jn
  In [2]: jn.read_commandline("echo 'a,b\n1,2'")
  Out[2]: 
     a  b
  0  1  2
  ```

`read_commandline` is a function from the `janitor.io` module.

**This PR resolves #984.**

# Relevant Reviewers

<!-- Finally, please tag relevant maintainers to review. -->

Please tag maintainers to review.

- @ericmjl
