### PR TITLE
[INF] pythonPath is deprecated

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
 		"terminal.integrated.defaultProfile.linux": "bash",
-		"python.pythonPath": "/opt/conda/bin/python",
+		"python.defaultInterpreterPath": "/opt/conda/bin/python",
 		"python.linting.enabled": true,
 		"python.linting.pylintEnabled": true,
 		"python.linting.pylintPath": "/opt/conda/bin/pylint",


### PR DESCRIPTION
See https://github.com/microsoft/vscode-python/issues/12313#issuecomment-867932929.

The relevant setting used by the vscode-python extension is now `python.defaultInterpreterPath`.