### PR TITLE
[TST] Fix clean names tests

### DIFF
--- a/tests/functions/test_clean_names.py
+++ b/tests/functions/test_clean_names.py
@@ -1,15 +1,13 @@
 import pandas as pd
 import pytest
-from hypothesis import given
 
 from janitor.errors import JanitorError
-from janitor.testing_utils.strategies import df_strategy
 
 
 @pytest.mark.functions
-@given(df=df_strategy())
-def test_clean_names_method_chain(df):
-    df = df.clean_names()
+def test_clean_names_method_chain(dataframe):
+    """Tests clean_names default args in a method chain."""
+    df = dataframe.clean_names()
     expected_columns = [
         "a",
         "bell_chart",
@@ -21,9 +19,9 @@ def test_clean_names_method_chain(df):
 
 
 @pytest.mark.functions
-@given(df=df_strategy())
-def test_clean_names_special_characters(df):
-    df = df.clean_names(remove_special=True)
+def test_clean_names_special_characters(dataframe):
+    """Tests clean_names `remove_special` parameter."""
+    df = dataframe.clean_names(remove_special=True)
     expected_columns = [
         "a",
         "bell_chart",
@@ -35,9 +33,9 @@ def test_clean_names_special_characters(df):
 
 
 @pytest.mark.functions
-@given(df=df_strategy())
-def test_clean_names_uppercase(df):
-    df = df.clean_names(case_type="upper", remove_special=True)
+def test_clean_names_uppercase(dataframe):
+    """Tests clean_names `case_type` parameter = upper."""
+    df = dataframe.clean_names(case_type="upper", remove_special=True)
     expected_columns = [
         "A",
         "BELL_CHART",
@@ -49,9 +47,9 @@ def test_clean_names_uppercase(df):
 
 
 @pytest.mark.functions
-@given(df=df_strategy())
-def test_clean_names_original_columns(df):
-    df = df.clean_names(preserve_original_columns=True)
+def test_clean_names_original_columns(dataframe):
+    """Tests clean_names `preserve_original_columns` parameter."""
+    df = dataframe.clean_names(preserve_original_columns=True)
     expected_columns = [
         "a",
         "Bell__Chart",
@@ -64,6 +62,7 @@ def test_clean_names_original_columns(df):
 
 @pytest.mark.functions
 def test_multiindex_clean_names(multiindex_dataframe):
+    """Tests clean_names default args on a multi-index dataframe."""
     df = multiindex_dataframe.clean_names()
 
     levels = [
@@ -82,8 +81,12 @@ def test_multiindex_clean_names(multiindex_dataframe):
     "strip_underscores", ["both", True, "right", "r", "left", "l"]
 )
 def test_clean_names_strip_underscores(
-    multiindex_dataframe, strip_underscores
+    multiindex_dataframe,
+    strip_underscores,
 ):
+    """Tests clean_names `strip_underscores` param on a multi-index
+    dataframe.
+    """
     if strip_underscores in ["right", "r"]:
         df = multiindex_dataframe.rename(columns=lambda x: x + "_")
     elif strip_underscores in ["left", "l"]:
@@ -107,6 +110,7 @@ def test_clean_names_strip_underscores(
 
 @pytest.mark.functions
 def test_clean_names_strip_accents():
+    """Tests clean_names `strip_accents` parameter."""
     df = pd.DataFrame({"João": [1, 2], "Лука́ся": [1, 2], "Käfer": [1, 2]})
     df = df.clean_names(strip_accents=True)
     expected_columns = ["joao", "лукася", "kafer"]
@@ -115,12 +119,16 @@ def test_clean_names_strip_accents():
 
 @pytest.mark.functions
 def test_incorrect_strip_underscores(multiindex_dataframe):
+    """Checks error is thrown when `strip_underscores` is given an
+    invalid argument.
+    """
     with pytest.raises(JanitorError):
         multiindex_dataframe.clean_names(strip_underscores="hello")
 
 
 @pytest.mark.functions
 def test_clean_names_preserve_case_true(multiindex_dataframe):
+    """Tests clean_names `case_type` parameter = preserve."""
     df = multiindex_dataframe.clean_names(case_type="preserve")
 
     levels = [
@@ -135,10 +143,10 @@ def test_clean_names_preserve_case_true(multiindex_dataframe):
 
 
 @pytest.mark.functions
-@given(df=df_strategy())
-def test_clean_names_camelcase_to_snake(df):
+def test_clean_names_camelcase_to_snake(dataframe):
+    """Tests clean_names `case_type` parameter = snake."""
     df = (
-        df.select_columns(["a"])
+        dataframe.select_columns(["a"])
         .rename_column("a", "AColumnName")
         .clean_names(case_type="snake")
     )
@@ -147,6 +155,9 @@ def test_clean_names_camelcase_to_snake(df):
 
 @pytest.mark.functions
 def test_clean_names_camelcase_to_snake_multi(dataframe):
+    """Tests clean_names `case_type` parameter = snake on a multi-index
+    dataframe.
+    """
     df = (
         dataframe.select_columns(["a", "Bell__Chart", "decorated-elephant"])
         .rename_column("a", "snakesOnAPlane")
@@ -165,6 +176,7 @@ def test_clean_names_camelcase_to_snake_multi(dataframe):
 
 @pytest.mark.functions
 def test_clean_names_enforce_string(dataframe):
+    """Tests clean_names `enforce_string` parameter."""
     df = dataframe.rename(columns={"a": 1}).clean_names(enforce_string=True)
     for c in df.columns:
         assert isinstance(c, str)
@@ -172,6 +184,7 @@ def test_clean_names_enforce_string(dataframe):
 
 @pytest.mark.functions
 def test_clean_names_truncate_limit(dataframe):
+    """Tests clean_names `truncate_limit` parameter."""
     df = dataframe.clean_names(truncate_limit=7)
     expected_columns = ["a", "bell_ch", "decorat", "animals", "cities"]
     assert set(df.columns) == set(expected_columns)

--- a/tests/functions/test_clean_names.py
+++ b/tests/functions/test_clean_names.py
@@ -190,32 +190,15 @@ def test_clean_names_truncate_limit(dataframe):
     assert set(df.columns) == set(expected_columns)
 
 
-"""
-The following tests ensure nonstandard characters
-and spaces have been cleaned up.
-"""
-
-
 @pytest.mark.functions
 def test_charac():
-    table_GDP = pd.read_html(
-        "https://en.wikipedia.org/wiki/Economy_of_the_United_States",
-        match="Nominal GDP",
-    )
-    df = table_GDP[0]
+    """Ensure non standard characters and spaces have been cleaned up."""
 
+    df = pd.DataFrame(
+        {
+            r"Current accountbalance(in % of GDP)": range(5),
+        }
+    )
     df = df.clean_names(strip_underscores=True, case_type="lower")
 
     assert "current_accountbalance_in_%_of_gdp" in df.columns
-
-
-@pytest.mark.functions
-def test_space():
-    table_GDP = pd.read_html(
-        "https://en.wikipedia.org/wiki/Economy_of_Russia", match="Year"
-    )
-    df = table_GDP[0]
-
-    df = df.clean_names(strip_underscores=True, case_type="lower")
-
-    assert ("in %" in df.columns) is False


### PR DESCRIPTION
Tests are failing for `clean_names` on the latest commit due to the Data on wikipedia being modified. (someone removed the "Current account balance (in % of GDP)" column from the wiki table).

## Changes
- Use a fixed dataframe for the `test_char` test instead of relying on the live table from wikipedia (for stability of our tests).
- Removed the `test_space` test (which also relied on the Russia GDP wikipedia page); this test can already be covered by the `test_char` test function.
- Removed the use of `hypothesis` in the `test_clean_names` test suite; It is redundant since we only care about the column names, not the df data.