### PR TITLE
[INF] Update environment-dev.yml

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python=3.9
   - biopython
-  - black=21.7b0
+  - black=22.1.0
   - bump2version=1.0.1
   - cairo
   - conda

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -26,7 +26,6 @@ dependencies:
   - multipledispatch
   - mypy
   - natsort
-  - nbsphinx
   - nox
   - numpy
   - openpyxl
@@ -46,8 +45,6 @@ dependencies:
   - rdkit=2021.09.3
   - recommonmark
   - seaborn
-  - sphinx
-  - sphinxcontrib-fulltoc
   - twine
   - unyt
   - xarray


### PR DESCRIPTION
`black` is no longer under beta, and our precommit is running v22.1.0 black as well.

This PR is just a small update to the container `environment-dev.yml` to reflect this change.

**Question:**
Can @ericmjl  or anyone else comment on whether we can remove the sphinx dependencies in `environment-dev.yml` as well? Specifically, `sphinx`, `nbsphinx` and `sphinxcontrib-fulltoc`.
I wasn't around when the migration from Sphinx to mkdocs happened last year, but as far as I can tell, we're no longer using Sphinx for docs generation anywhere, right?

If so, then I suggest we remove those dependencies in this PR as well. Clean up the code base a little. 😄 

ps. I tried removing the sphinx dependencies locally, rebuilt the container and everything seems to work fine.