### PR TITLE
[DOC] Added author name back

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -102,3 +102,4 @@ Contributors
 - [@fireddd](https://github.com/fireddd) |  [contributions](https://github.com/pyjanitor-devs/pyjanitor/issues?q=is%3Aclosed+mentions%3Afireddd)
 - [@Zeroto521](https://github.com/Zeroto521) | [contributions](https://github.com/pyjanitor-devs/pyjanitor/pulls?utf8=%E2%9C%93&q=is%3Aclosed+mentions%3Zeroto521)
 - [@thatlittleboy](https://github.com/thatlittleboy) | [contributions](https://github.com/pyjanitor-devs/pyjanitor/issues?q=is%3Aclosed+mentions%3Athatlittleboy)
+- [@robertmitchellv](https://github.com/robertmitchellv) | [contributions](https://github.com/pyjanitor-devs/pyjanitor/issues?q=is%3Aclosed+mentions%3Arobertmitchellv)


### PR DESCRIPTION
Author name fell off of docs during the move from readthedocs to sphinx

# PR Description

It looks like my name fell off of the old `AUTHORS.rst` file during the transition from ReadTheDocs to Sphinx (just based on the commit I identified where it came off).

- Added myself to the bottom of `AUTHORS.md`

**This PR resolves #1054.**

# PR Checklist

Please ensure that you have done the following:

1. [x] PR in from a fork off your branch. Do not PR from `<your_username>`:`dev`, but rather from `<your_username>`:`<feature-branch_name>`.
2. [x] If you're not on the contributors list, add yourself to `AUTHORS.rst`.

Looking at the docs I noticed that adding to `pyjanitor/AUTHORS.md` was the place where I needed to add the missing line since the `pyjanitor/mkdocs/AUTHORS.md` appears to be a symlink. After running `make docs` it looks like everything updated correctly in `pyjanitor/site/AUTHORS/index.html`

# Automatic checks

There will be automatic checks run on the PR. These include:

- Building a preview of the docs on Netlify
- Automatically linting the code
- Making sure the code is documented
- Making sure that all tests are passed
- Making sure that code coverage doesn't go down.

# Relevant Reviewers

- @samukweku 
