### PR TITLE
[DOC] Convert docstring example to doctest for expand_column()

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -103,3 +103,4 @@ Contributors
 - [@Zeroto521](https://github.com/Zeroto521) | [contributions](https://github.com/pyjanitor-devs/pyjanitor/pulls?utf8=%E2%9C%93&q=is%3Aclosed+mentions%3Zeroto521)
 - [@thatlittleboy](https://github.com/thatlittleboy) | [contributions](https://github.com/pyjanitor-devs/pyjanitor/issues?q=is%3Aclosed+mentions%3Athatlittleboy)
 - [@robertmitchellv](https://github.com/robertmitchellv) | [contributions](https://github.com/pyjanitor-devs/pyjanitor/issues?q=is%3Aclosed+mentions%3Arobertmitchellv)
+- [@gahjelle](https://github.com/gahjelle) | [contributions](https://github.com/pyjanitor-devs/pyjanitor/issues?q=is%3Aclosed+mentions%3Agahjelle)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 -   [ENH] `names_glue` in `pivot_wider` now takes a string form, using str.format_map under the hood. `levels_order` is also deprecated. @samukweku
 -   [BUG] Fixed bug in `transform_columns` which ignored the `column_names` specification when `new_column_names` dictionary was provided as an argument, issue #1063. @thatlittleboy
 -   [BUG] `count_cumulative_unique` no longer modifies the column being counted in the output when `case_sensitive` argument is set to False, issue #1065. @thatlittleboy
+-   [DOC] Convert `expand_column` code examples to doctests, issue #972. @gahjelle
 
 ## [v0.22.0] - 2021-11-21
 

--- a/janitor/functions/expand_column.py
+++ b/janitor/functions/expand_column.py
@@ -1,6 +1,8 @@
+"""Implementation for expand_column."""
 from typing import Hashable
-import pandas_flavor as pf
+
 import pandas as pd
+import pandas_flavor as pf
 
 from janitor.utils import deprecated_alias
 
@@ -21,23 +23,47 @@ def expand_column(
 
     Functional usage syntax:
 
-        df = expand_column(
-            df,
-            column_name='col_name',
-            sep=', '  # note space in sep
-        )
+        >>> import pandas as pd
+        >>> df = pd.DataFrame(
+        ...     {
+        ...         "col1": ["A, B", "B, C, D", "E, F", "A, E, F"],
+        ...         "col2": [1, 2, 3, 4],
+        ...     }
+        ... )
+        >>> df = expand_column(
+        ...     df,
+        ...     column_name="col1",
+        ...     sep=", "  # note space in sep
+        ... )
+        >>> df
+              col1  col2  A  B  C  D  E  F
+        0     A, B     1  1  1  0  0  0  0
+        1  B, C, D     2  0  1  1  1  0  0
+        2     E, F     3  0  0  0  0  1  1
+        3  A, E, F     4  1  0  0  0  1  1
 
     Method chaining syntax:
 
-        import pandas as pd
-        import janitor
-        df = (
-            pd.DataFrame(...)
-            .expand_column(
-                column_name='col_name',
-                sep=', '
-            )
-        )
+        >>> import pandas as pd
+        >>> import janitor
+        >>> df = (
+        ...     pd.DataFrame(
+        ...         {
+        ...             "col1": ["A, B", "B, C, D", "E, F", "A, E, F"],
+        ...             "col2": [1, 2, 3, 4],
+        ...         }
+        ...     )
+        ...     .expand_column(
+        ...         column_name='col1',
+        ...         sep=', '
+        ...     )
+        ... )
+        >>> df
+              col1  col2  A  B  C  D  E  F
+        0     A, B     1  1  1  0  0  0  0
+        1  B, C, D     2  0  1  1  1  0  0
+        2     E, F     3  0  0  0  0  1  1
+        3  A, E, F     4  1  0  0  0  1  1
 
     :param df: A pandas DataFrame.
     :param column_name: Which column to expand.


### PR DESCRIPTION
- Adds doctest examples for `.expand_column()`

**Related to #972.**

<!-- As you go down the PR template, please feel free to delete sections that are irrelevant. -->

Please ensure that you have done the following:

1. [x] PR in from a fork off your branch. Do not PR from `<your_username>`:`dev`, but rather from `<your_username>`:`<feature-branch_name>`.
<!-- Doing this helps us keep the commit history much cleaner than it would otherwise be. -->
2. [x] If you're not on the contributors list, add yourself to `AUTHORS.rst`.
<!-- We'd like to acknowledge your contributions! -->
3. [x] Add a line to `CHANGELOG.md` under the latest version header (i.e. the one that is "on deck") describing the contribution.
    - Do use some discretion here; if there are multiple PRs that are related, keep them in a single line.

# Automatic checks

There will be automatic checks run on the PR. These include:

- Building a preview of the docs on Netlify
- Automatically linting the code
- Making sure the code is documented
- Making sure that all tests are passed
- Making sure that code coverage doesn't go down.

# Relevant Reviewers

Please tag maintainers to review.

- @ericmjl
