### PR TITLE
[DOC] Fixing groupby_topk.py doctest whitespace normalization.

### DIFF
--- a/janitor/functions/groupby_topk.py
+++ b/janitor/functions/groupby_topk.py
@@ -42,6 +42,7 @@ def groupby_topk(
         3   43   2   pass
         4   21   5   fail
         >>> df.groupby_topk('result', 'age', 3) # Ascending top 3
+        ... # doctest: +NORMALIZE_WHITESPACE
                   age  id result
         result
         fail   4   21   5   fail
@@ -50,6 +51,7 @@ def groupby_topk(
                1   23   4   pass
                3   43   2   pass
         >>> df.groupby_topk('result', 'age', 2, {'ascending':False}) # Descending top 2
+        ... # doctest: +NORMALIZE_WHITESPACE
                   age  id result
         result
         fail   2   22   6   fail


### PR DESCRIPTION
Fixes stuff leftover from #1077.