### PR TITLE
[ENH] Pivot_wider column selection fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 -   [INF] Require pyspark minimal version is v3.2.0 to cut duplicates codes. Issue #1110 @Zeroto521
 -   [ENH] Added support for extension arrays in `expand_grid`. Issue #1121 @samukweku
 -   [ENH] Add `names_expand` and `index_expand` parameters to `pivot_wider` for exposing missing categoricals. Issue #1108 @samukweku
+-   [ENH] Add fix  for slicing error when selecting columns in `pivot_wider`. Issue #1134 @samukweku
 
 ## [v0.23.1] - 2022-05-03
 

--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -1492,8 +1492,9 @@ def _data_checks_pivot_wider(
 
     if index is not None:
         if is_list_like(index):
-            index = [*index]
+            index = list(index)
         index = _select_column_names(index, df)
+        index = list(index)
 
     if names_from is None:
         raise ValueError(
@@ -1501,13 +1502,15 @@ def _data_checks_pivot_wider(
         )
 
     if is_list_like(names_from):
-        names_from = [*names_from]
+        names_from = list(names_from)
     names_from = _select_column_names(names_from, df)
+    names_from = list(names_from)
 
     if values_from is not None:
         if is_list_like(values_from):
-            values_from = [*values_from]
+            values_from = list(values_from)
         out = _select_column_names(values_from, df)
+        out = list(out)
         # hack to align with pd.pivot
         if values_from == out[0]:
             values_from = out[0]

--- a/tests/functions/test_pivot_wider.py
+++ b/tests/functions/test_pivot_wider.py
@@ -433,7 +433,7 @@ def test_names_glue_single_column(df_checks_output):
     )
 
     result = df_checks_output.pivot_wider(
-        ["geoid", "name"],
+        slice("geoid", "name"),
         "variable",
         "estimate",
         names_glue="{variable}_estimate",


### PR DESCRIPTION
# PR Description

Please describe the changes proposed in the pull request:

- Column selection works for all forms, including slicing
- 
```py

df

   Author  Article  Year  First  Second
0       1       11  2017      1       0
1       1       11  2018      0       1
2       2       22  2017      0       1
3       2       22  2018      0       1


df.pivot_wider(index = slice('Author','Article'), 
               names_from = 'Year', 
               flatten_levels = False)

               First      Second     
Year            2017 2018   2017 2018
Author Article                       
1      11          1    0      0    1
2      22          0    0      1    1


df.pivot_wider(index = 'A*', 
               names_from = 'Year', 
               flatten_levels = False)

               First      Second     
Year            2017 2018   2017 2018
Author Article                       
1      11          1    0      0    1
2      22          0    0      1    1

```


<!-- Doing so provides maintainers with context on what the PR is, and can help us more effectively review your PR. -->

<!-- Please also identify below which issue that has been raised that you are going to close. -->

**This PR resolves #1134.**

<!-- As you go down the PR template, please feel free to delete sections that are irrelevant. -->

# PR Checklist

<!-- This checklist exists for newcomers who are not yet familiar with our requirements. If you are experienced with
the project, please feel free to delete this section. -->

Please ensure that you have done the following:

1. [ ] PR in from a fork off your branch. Do not PR from `<your_username>`:`dev`, but rather from `<your_username>`:`<feature-branch_name>`.
<!-- Doing this helps us keep the commit history much cleaner than it would otherwise be. -->
2. [x] If you're not on the contributors list, add yourself to `AUTHORS.md`.
<!-- We'd like to acknowledge your contributions! -->
3. [x] Add a line to `CHANGELOG.md` under the latest version header (i.e. the one that is "on deck") describing the contribution.
    - Do use some discretion here; if there are multiple PRs that are related, keep them in a single line.

# Automatic checks

There will be automatic checks run on the PR. These include:

- Building a preview of the docs on Netlify
- Automatically linting the code
- Making sure the code is documented
- Making sure that all tests are passed
- Making sure that code coverage doesn't go down.

# Relevant Reviewers

<!-- Finally, please tag relevant maintainers to review. -->

Please tag maintainers to review.

- @ericmjl
