### PR TITLE
[ENH] dropna parameter for `pivot_longer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 -   [ENH] Added support for extension arrays in `expand_grid`. Issue #1121 @samukweku
 -   [ENH] Add `names_expand` and `index_expand` parameters to `pivot_wider` for exposing missing categoricals. Issue #1108 @samukweku
 -   [ENH] Add fix  for slicing error when selecting columns in `pivot_wider`. Issue #1134 @samukweku
+-   [ENH] `dropna` parameter added to `pivot_longer`. Issue #1132 @samukweku
 
 ## [v0.23.1] - 2022-05-03
 

--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -970,7 +970,7 @@ def _pivot_longer_dot_value(
         # and in the same order
         # reindex ensures that, after getting a MultiIndex.from_product
         other = [entry for entry in names_to if entry != ".value"]
-        columns = [*mapping.columns]
+        columns = mapping.columns.tolist()
         others = mapping.loc[:, other].drop_duplicates()
         outcome = mapping.loc[:, ".value"].unique()
         if not mapping.duplicated().any(axis=None):
@@ -979,7 +979,7 @@ def _pivot_longer_dot_value(
         else:
             columns.append("".join(columns))
             cumcount = mapping.groupby(
-                [*mapping.columns], sort=False, observed=True
+                mapping.columns.tolist(), sort=False, observed=True
             ).cumcount()
             df.columns = [arr for _, arr in mapping.items()] + [cumcount]
             indexer = {
@@ -988,6 +988,7 @@ def _pivot_longer_dot_value(
                 "cumcount": cumcount.unique(),
             }
         indexer = _computations_expand_grid(indexer)
+
         indexer.columns = columns
         df = df.reindex(columns=indexer)
         df.columns = df.columns.get_level_values(".value")

--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -746,7 +746,9 @@ def _pivot_longer_names_pattern_sequence(
     )
 
     if values_to_is_a_sequence:
-        df = df.loc[:, names_to]
+        # dump down for speed improvement
+        df = {name: df[name]._values for name in names_to}
+        return pd.DataFrame(df, copy=False)
 
     return df
 

--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -1008,7 +1008,6 @@ def _pivot_longer_dot_value(
         others = mapping.loc[:, other].drop_duplicates()
         outcome = mapping.loc[:, ".value"].unique()
         if not mapping.duplicated().any(axis=None):
-            print(mapping.duplicated())
             df.columns = pd.MultiIndex.from_frame(mapping)
             indexer = {".value": outcome, "other": others}
         else:

--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -32,7 +32,7 @@ def pivot_longer(
     names_sep: Optional[Union[str, Pattern]] = None,
     names_pattern: Optional[Union[list, tuple, str, Pattern]] = None,
     names_transform: Optional[Union[str, Callable, dict]] = None,
-    values_dropna: bool = False,
+    dropna: bool = False,
     sort_by_appearance: Optional[bool] = False,
     ignore_index: Optional[bool] = True,
 ) -> pd.DataFrame:
@@ -261,7 +261,7 @@ def pivot_longer(
     :param names_transform: Use this option to change the types of columns that
         have been transformed to rows. This does not applies to the values' columns.
         Accepts any argument that is acceptable by `pd.astype`.
-    :param values_dropna: Determines whether or not to drop nulls
+    :param dropna: Determines whether or not to drop nulls
         from the values columns. Default is `False`.
     :param sort_by_appearance: Default `False`. Boolean value that determines
         the final look of the DataFrame. If `True`, the unpivoted DataFrame
@@ -287,7 +287,7 @@ def pivot_longer(
         names_sep,
         names_pattern,
         names_transform,
-        values_dropna,
+        dropna,
         sort_by_appearance,
         ignore_index,
     ) = _data_checks_pivot_longer(
@@ -300,7 +300,7 @@ def pivot_longer(
         names_sep,
         names_pattern,
         names_transform,
-        values_dropna,
+        dropna,
         sort_by_appearance,
         ignore_index,
     )
@@ -314,7 +314,7 @@ def pivot_longer(
         names_sep,
         names_pattern,
         names_transform,
-        values_dropna,
+        dropna,
         sort_by_appearance,
         ignore_index,
     )
@@ -330,7 +330,7 @@ def _data_checks_pivot_longer(
     names_sep,
     names_pattern,
     names_transform,
-    values_dropna,
+    dropna,
     sort_by_appearance,
     ignore_index,
 ) -> tuple:
@@ -533,7 +533,7 @@ def _data_checks_pivot_longer(
                     "index parameter. Kindly provide unique label(s)."
                 )
 
-    check("values_dropna", values_dropna, [bool])
+    check("dropna", dropna, [bool])
 
     check("sort_by_appearance", sort_by_appearance, [bool])
 
@@ -576,7 +576,7 @@ def _data_checks_pivot_longer(
         names_sep,
         names_pattern,
         names_transform,
-        values_dropna,
+        dropna,
         sort_by_appearance,
         ignore_index,
     )
@@ -591,7 +591,7 @@ def _computations_pivot_longer(
     names_sep: Union[str, Pattern],
     names_pattern: Union[list, tuple, str, Pattern],
     names_transform: Union[str, Callable, dict],
-    values_dropna: bool,
+    dropna: bool,
     sort_by_appearance: bool,
     ignore_index: bool,
 ) -> pd.DataFrame:
@@ -625,7 +625,7 @@ def _computations_pivot_longer(
             len_index=len_index,
             values_to=values_to,
             names_transform=names_transform,
-            values_dropna=values_dropna,
+            dropna=dropna,
             sort_by_appearance=sort_by_appearance,
             ignore_index=ignore_index,
         )
@@ -639,7 +639,7 @@ def _computations_pivot_longer(
             names_sep=names_sep,
             names_transform=names_transform,
             values_to=values_to,
-            values_dropna=values_dropna,
+            dropna=dropna,
             sort_by_appearance=sort_by_appearance,
             ignore_index=ignore_index,
         )
@@ -653,7 +653,7 @@ def _computations_pivot_longer(
             names_pattern=names_pattern,
             names_transform=names_transform,
             values_to=values_to,
-            values_dropna=values_dropna,
+            dropna=dropna,
             sort_by_appearance=sort_by_appearance,
             ignore_index=ignore_index,
         )
@@ -665,7 +665,7 @@ def _computations_pivot_longer(
         names_to=names_to,
         names_pattern=names_pattern,
         names_transform=names_transform,
-        values_dropna=values_dropna,
+        dropna=dropna,
         sort_by_appearance=sort_by_appearance,
         values_to=values_to,
         ignore_index=ignore_index,
@@ -679,7 +679,7 @@ def _pivot_longer_names_pattern_sequence(
     names_to: list,
     names_pattern: Union[list, tuple],
     names_transform: Union[str, Callable, dict],
-    values_dropna: bool,
+    dropna: bool,
     sort_by_appearance: bool,
     values_to: Union[str, list, tuple],
     ignore_index: bool,
@@ -760,7 +760,7 @@ def _pivot_longer_names_pattern_sequence(
         outcome=values,
         values=outcome,
         names_to=names_to,
-        values_dropna=values_dropna,
+        dropna=dropna,
         sort_by_appearance=sort_by_appearance,
         ignore_index=ignore_index,
     )
@@ -776,7 +776,7 @@ def _pivot_longer_names_pattern_str(
     names_pattern: Union[str, Pattern],
     names_transform: bool,
     values_to: str,
-    values_dropna: bool,
+    dropna: bool,
     sort_by_appearance: bool,
     ignore_index: bool,
 ) -> pd.DataFrame:
@@ -810,7 +810,7 @@ def _pivot_longer_names_pattern_str(
             len_index=len_index,
             values_to=values_to,
             names_transform=names_transform,
-            values_dropna=values_dropna,
+            dropna=dropna,
             sort_by_appearance=sort_by_appearance,
             ignore_index=ignore_index,
         )
@@ -822,7 +822,7 @@ def _pivot_longer_names_pattern_str(
         sort_by_appearance=sort_by_appearance,
         ignore_index=ignore_index,
         names_to=names_to,
-        values_dropna=values_dropna,
+        dropna=dropna,
         names_transform=names_transform,
         mapping=mapping,
     )
@@ -836,7 +836,7 @@ def _pivot_longer_names_sep(
     names_sep: Union[str, Pattern],
     values_to: str,
     names_transform: bool,
-    values_dropna: bool,
+    dropna: bool,
     sort_by_appearance: bool,
     ignore_index: bool,
 ) -> pd.DataFrame:
@@ -871,7 +871,7 @@ def _pivot_longer_names_sep(
             len_index=len_index,
             values_to=values_to,
             names_transform=names_transform,
-            values_dropna=values_dropna,
+            dropna=dropna,
             sort_by_appearance=sort_by_appearance,
             ignore_index=ignore_index,
         )
@@ -883,7 +883,7 @@ def _pivot_longer_names_sep(
         sort_by_appearance=sort_by_appearance,
         ignore_index=ignore_index,
         names_to=names_to,
-        values_dropna=values_dropna,
+        dropna=dropna,
         names_transform=names_transform,
         mapping=mapping,
     )
@@ -895,7 +895,7 @@ def _base_melt(
     len_index: int,
     values_to: str,
     names_transform: Union[str, Callable, dict, None],
-    values_dropna: bool,
+    dropna: bool,
     sort_by_appearance: bool,
     ignore_index: bool,
 ) -> pd.DataFrame:
@@ -925,7 +925,7 @@ def _base_melt(
         outcome=outcome,
         values=values,
         names_to=None,
-        values_dropna=values_dropna,
+        dropna=dropna,
         sort_by_appearance=sort_by_appearance,
         ignore_index=ignore_index,
     )
@@ -938,7 +938,7 @@ def _pivot_longer_dot_value(
     sort_by_appearance: bool,
     ignore_index: bool,
     names_to: list,
-    values_dropna: bool,
+    dropna: bool,
     names_transform: Union[str, Callable, dict, None],
     mapping: pd.DataFrame,
 ) -> pd.DataFrame:
@@ -1000,6 +1000,7 @@ def _pivot_longer_dot_value(
         others = mapping.loc[:, other].drop_duplicates()
         outcome = mapping.loc[:, ".value"].unique()
         if not mapping.duplicated().any(axis=None):
+            print(mapping.duplicated())
             df.columns = pd.MultiIndex.from_frame(mapping)
             indexer = {".value": outcome, "other": others}
         else:
@@ -1039,7 +1040,7 @@ def _pivot_longer_dot_value(
         outcome=outcome,
         values=values,
         names_to=None,
-        values_dropna=values_dropna,
+        dropna=dropna,
         sort_by_appearance=sort_by_appearance,
         ignore_index=ignore_index,
     )
@@ -1196,7 +1197,7 @@ def _final_frame_longer(
     outcome: dict,
     values: dict,
     names_to: Union[list, None],
-    values_dropna: bool,
+    dropna: bool,
     sort_by_appearance: bool,
     ignore_index: bool,
 ) -> pd.DataFrame:
@@ -1210,12 +1211,11 @@ def _final_frame_longer(
     else:
         index = {}
 
-    if values_dropna and not names_to:
+    if dropna and not names_to:
         if len(values) == 1:
             key = next(iter(values))
             any_nulls = pd.isna(values[key])
         else:
-            _, any_nulls = zip(*values.items())
             any_nulls = [pd.isna(arr) for _, arr in values.items()]
             bools = np.equal.reduce(any_nulls)
             any_nulls = np.where(bools, any_nulls[0], False)
@@ -1230,6 +1230,7 @@ def _final_frame_longer(
                 }
 
     any_nulls = None
+    bools = None
 
     df = {**index, **outcome, **values}
 

--- a/tests/functions/test_pivot_longer.py
+++ b/tests/functions/test_pivot_longer.py
@@ -1268,3 +1268,26 @@ def test_dot_value_duplicated_sub_columns():
     )
 
     assert_frame_equal(actual, expected)
+
+
+def test_preserve_extension_types():
+    """Preserve extension types where possible."""
+    cats = pd.DataFrame(
+        [
+            {"Cat": "A", "L_1": 1, "L_2": 2, "L_3": 3},
+            {"Cat": "B", "L_1": 4, "L_2": 5, "L_3": 6},
+            {"Cat": "C", "L_1": 7, "L_2": 8, "L_3": 9},
+        ]
+    )
+    cats = cats.astype("category")
+
+    actual = cats.pivot_longer("Cat", sort_by_appearance=True)
+    expected = (
+        cats.set_index("Cat")
+        .rename_axis(columns="variable")
+        .stack()
+        .rename("value")
+        .reset_index()
+    )
+
+    assert_frame_equal(expected, actual)

--- a/tests/functions/test_pivot_longer.py
+++ b/tests/functions/test_pivot_longer.py
@@ -1002,18 +1002,14 @@ def test_names_pattern_nulls_in_data():
     result = df.pivot_longer(
         "family",
         names_to=[".value", "child"],
-        names_pattern=r"(.+)_(.+)\d",
+        names_pattern=r"(.+)_(.+)",
         ignore_index=False,
     )
     result.index = range(len(result))
 
-    actual = (
-        pd.wide_to_long(
-            df, ["dob", "gender"], i="family", j="child", sep="_", suffix=".+"
-        )
-        .reset_index()
-        .assign(child=lambda df: df.child.str[:-1])
-    )
+    actual = pd.wide_to_long(
+        df, ["dob", "gender"], i="family", j="child", sep="_", suffix=".+"
+    ).reset_index()
 
     assert_frame_equal(result, actual)
 

--- a/tests/functions/test_pivot_longer.py
+++ b/tests/functions/test_pivot_longer.py
@@ -56,6 +56,12 @@ def test_type_names_to(df_checks):
         df_checks.pivot_longer(names_to={2007})
 
 
+def test_type_dropna(df_checks):
+    """Raise TypeError if wrong type is provided for dropna."""
+    with pytest.raises(TypeError):
+        df_checks.pivot_longer(dropna="True")
+
+
 def test_subtype_names_to(df_checks):
     """
     Raise TypeError if names_to is a sequence
@@ -975,9 +981,10 @@ def test_names_pattern_seq_single_column(single_val):
     assert_frame_equal(result, df.rename(columns={"x1": "yA"}))
 
 
-def test_names_pattern_nulls_in_data():
-    """Test output if nulls are present in data."""
-    df = pd.DataFrame(
+@pytest.fixture
+def df_null():
+    "Dataframe with nulls."
+    return pd.DataFrame(
         {
             "family": [1, 2, 3, 4, 5],
             "dob_child1": [
@@ -999,19 +1006,66 @@ def test_names_pattern_nulls_in_data():
         }
     )
 
-    result = df.pivot_longer(
+
+def test_names_pattern_nulls_in_data(df_null):
+    """Test output if nulls are present in data."""
+    result = df_null.pivot_longer(
         "family",
         names_to=[".value", "child"],
         names_pattern=r"(.+)_(.+)",
-        ignore_index=False,
+        ignore_index=True,
     )
-    result.index = range(len(result))
 
     actual = pd.wide_to_long(
-        df, ["dob", "gender"], i="family", j="child", sep="_", suffix=".+"
+        df_null, ["dob", "gender"], i="family", j="child", sep="_", suffix=".+"
     ).reset_index()
 
     assert_frame_equal(result, actual)
+
+
+def test_dropna_multiple_columns(df_null):
+    """Test output if dropna = True."""
+    result = df_null.pivot_longer(
+        "family",
+        names_to=[".value", "child"],
+        names_pattern=r"(.+)_(.+)",
+        ignore_index=True,
+        dropna=True,
+    )
+
+    actual = (
+        pd.wide_to_long(
+            df_null,
+            ["dob", "gender"],
+            i="family",
+            j="child",
+            sep="_",
+            suffix=".+",
+        )
+        .dropna()
+        .reset_index()
+    )
+
+    assert_frame_equal(result, actual)
+
+
+def test_dropna_single_column():
+    """
+    Test output if dropna = True,
+    and a single value column is returned.
+    """
+    df = pd.DataFrame(
+        [
+            {"a": 1.0, "b": np.nan, "c": np.nan, "d": np.nan},
+            {"a": np.nan, "b": 2.0, "c": np.nan, "d": np.nan},
+            {"a": np.nan, "b": np.nan, "c": 3.0, "d": 2.0},
+            {"a": np.nan, "b": np.nan, "c": 1.0, "d": np.nan},
+        ]
+    )
+
+    expected = df.pivot_longer(dropna=True)
+    actual = df.melt().dropna().reset_index(drop=True)
+    assert_frame_equal(expected, actual)
 
 
 @pytest.fixture
@@ -1173,6 +1227,44 @@ def test_duplicated_columns():
     )
     expected = df.pivot_longer(
         names_to=".value", names_pattern="(.+)", ignore_index=False
+    )
+
+    assert_frame_equal(actual, expected)
+
+
+def test_dot_value_duplicated_sub_columns():
+    """Test output when the column extracts are not unique."""
+    # https://stackoverflow.com/q/64061588/7175713
+    df = pd.DataFrame(
+        {
+            "id": [1, 2, 3],
+            "M_start_date_1": [201709, 201709, 201709],
+            "M_end_date_1": [201905, 201905, 201905],
+            "M_start_date_2": [202004, 202004, 202004],
+            "M_end_date_2": [202005, 202005, 202005],
+            "F_start_date_1": [201803, 201803, 201803],
+            "F_end_date_1": [201904, 201904, 201904],
+            "F_start_date_2": [201912, 201912, 201912],
+            "F_end_date_2": [202007, 202007, 202007],
+        }
+    )
+
+    expected = df.set_index("id")
+    expected.columns = expected.columns.str.split("_", expand=True)
+    expected = (
+        expected.stack(level=[0, 2, 3])
+        .sort_index(level=[0, 1], ascending=[True, False])
+        .reset_index(level=[2, 3], drop=True)
+        .sort_index(axis=1, ascending=False)
+        .rename_axis(["id", "cod"])
+        .reset_index()
+    )
+
+    actual = df.pivot_longer(
+        "id",
+        names_to=("cod", ".value"),
+        names_pattern="(.)_(start|end).+",
+        sort_by_appearance=True,
     )
 
     assert_frame_equal(actual, expected)


### PR DESCRIPTION
# PR Description

Please describe the changes proposed in the pull request:

- add `dropna` parameter to drop nulls , similar to stack
- improve speed for scenarios where dot value is not involved - close to melt speed
- improve speed in some cases for multiple values_to

<!-- Doing so provides maintainers with context on what the PR is, and can help us more effectively review your PR. -->

<!-- Please also identify below which issue that has been raised that you are going to close. -->

**This PR resolves #1132.**

Tests ... pinch of salt

```py
url = 'https://raw.githubusercontent.com/tidyverse/tidyr/main/data-raw/billboard.csv'
df = pd.read_csv(url)
df = pd.concat([df]*100, ignore_index = True)
df.shape
(31700, 81)

 %timeit df.melt(['year', 'artist', 'track', 'time', 'date.entered'], ignore_index = False).dropna(subset=['value'])
232 ms ± 3.37 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

%timeit df.pivot_longer(column_names = 'wk*', dropna = True, ignore_index = True)
196 ms ± 2.56 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

A = df.melt(['year', 'artist', 'track', 'time', 'date.entered'], ignore_index = False).dropna(subset=['value'])
B = df.pivot_longer(column_names = 'wk*', dropna = True, ignore_index = True)

A.reset_index(drop=True).equals(B)
True

%timeit df.pivot_longer(column_names = 'wk*', dropna = False)
146 ms ± 2.62 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

%timeit df.melt(['year', 'artist', 'track', 'time', 'date.entered'])
154 ms ± 1.06 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```



# PR Checklist

<!-- This checklist exists for newcomers who are not yet familiar with our requirements. If you are experienced with
the project, please feel free to delete this section. -->

Please ensure that you have done the following:

1. [x] PR in from a fork off your branch. Do not PR from `<your_username>`:`dev`, but rather from `<your_username>`:`<feature-branch_name>`.
<!-- Doing this helps us keep the commit history much cleaner than it would otherwise be. -->
2. [x] If you're not on the contributors list, add yourself to `AUTHORS.md`.
<!-- We'd like to acknowledge your contributions! -->
3. [x] Add a line to `CHANGELOG.md` under the latest version header (i.e. the one that is "on deck") describing the contribution.
    - Do use some discretion here; if there are multiple PRs that are related, keep them in a single line.

# Automatic checks

There will be automatic checks run on the PR. These include:

- Building a preview of the docs on Netlify
- Automatically linting the code
- Making sure the code is documented
- Making sure that all tests are passed
- Making sure that code coverage doesn't go down.

# Relevant Reviewers

<!-- Finally, please tag relevant maintainers to review. -->

Please tag maintainers to review.

- @ericmjl
