### PR TITLE
[WIP] Numba support for single join

### DIFF
--- a/janitor/functions/conditional_join.py
+++ b/janitor/functions/conditional_join.py
@@ -608,9 +608,10 @@ def _less_than_indices(
         if any_nulls:
             return left_index, right_index[search_indices]
         return left_index, search_indices
-    if use_numba & (keep != _KeepTypes.ALL.value):
-        right_c = _numba_utils(search_indices, right_index, len_right, keep)
-        return left_index, right_c
+    if use_numba:
+        return _numba_utils(
+            search_indices, right_index, left_index, len_right, keep
+        )
     right_c = [right_index[ind:len_right] for ind in search_indices]
     if keep == _KeepTypes.FIRST.value:
         right_c = [arr.min() for arr in right_c]
@@ -719,9 +720,8 @@ def _greater_than_indices(
         if any_nulls:
             return left_index, right_index[search_indices - 1]
         return left_index, search_indices - 1
-    if use_numba & (keep != _KeepTypes.ALL.value):
-        right_c = _numba_utils(search_indices, right_index, 0, keep)
-        return left_index, right_c
+    if use_numba:
+        return _numba_utils(search_indices, right_index, left_index, 0, keep)
     right_c = [right_index[:ind] for ind in search_indices]
     if keep == _KeepTypes.FIRST.value:
         right_c = [arr.min() for arr in right_c]

--- a/tests/functions/test_conditional_join.py
+++ b/tests/functions/test_conditional_join.py
@@ -358,6 +358,33 @@ def test_single_condition_less_than_floats(df, right):
     assert_frame_equal(expected, actual)
 
 
+@pytest.mark.turtle
+@settings(deadline=None)
+@given(df=conditional_df(), right=conditional_right())
+def test_single_condition_less_than_floats_numba(df, right):
+    """Test output for a single condition. "<"."""
+
+    expected = (
+        df[["B"]]
+        .merge(right[["Numeric"]], how="cross")
+        .loc[lambda df: df.B.lt(df.Numeric)]
+        .sort_values(["B", "Numeric"], ignore_index=True)
+    )
+    actual = (
+        df[["B"]]
+        .conditional_join(
+            right[["Numeric"]],
+            ("B", "Numeric", "<"),
+            how="inner",
+            sort_by_appearance=False,
+            use_numba=True,
+        )
+        .sort_values(["B", "Numeric"], ignore_index=True)
+    )
+
+    assert_frame_equal(expected, actual)
+
+
 @settings(deadline=None)
 @pytest.mark.turtle
 @given(df=conditional_df(), right=conditional_right())
@@ -609,6 +636,38 @@ def test_single_condition_less_than_ints_extension_array(df, right):
 
 
 @pytest.mark.turtle
+@settings(deadline=None)
+@given(df=conditional_df(), right=conditional_right())
+def test_single_condition_less_than_ints_extension_array_numba(df, right):
+    """Test output for a single condition. "<"."""
+
+    df = df.assign(A=df["A"].astype("Int64"))
+    right = right.assign(Integers=right["Integers"].astype(pd.Int64Dtype()))
+
+    expected = (
+        df[["A"]]
+        .assign(index=df.index)
+        .merge(right[["Integers"]], how="cross")
+        .loc[lambda df: df.A < df.Integers]
+        .groupby("index")
+        .head(1)
+        .drop(columns="index")
+        .reset_index(drop=True)
+    )
+
+    actual = df[["A"]].conditional_join(
+        right[["Integers"]],
+        ("A", "Integers", "<"),
+        how="inner",
+        keep="first",
+        sort_by_appearance=False,
+        use_numba=True,
+    )
+
+    assert_frame_equal(expected, actual)
+
+
+@pytest.mark.turtle
 @given(df=conditional_df(), right=conditional_right())
 def test_single_condition_less_than_equal(df, right):
     """Test output for a single condition. "<=". DateTimes"""
@@ -678,6 +737,33 @@ def test_single_condition_greater_than_datetime(df, right):
             ("E", "Dates", ">"),
             how="inner",
             sort_by_appearance=False,
+        )
+        .sort_values(["E", "Dates"], ignore_index=True)
+    )
+
+    assert_frame_equal(expected, actual)
+
+
+@pytest.mark.turtle
+@settings(deadline=None)
+@given(df=conditional_df(), right=conditional_right())
+def test_single_condition_greater_than_datetime_numba(df, right):
+    """Test output for a single condition. ">". Datetimes"""
+
+    expected = (
+        df[["E"]]
+        .merge(right[["Dates"]], how="cross")
+        .loc[lambda df: df.E.gt(df.Dates)]
+        .sort_values(["E", "Dates"], ignore_index=True)
+    )
+    actual = (
+        df[["E"]]
+        .conditional_join(
+            right[["Dates"]],
+            ("E", "Dates", ">"),
+            how="inner",
+            sort_by_appearance=False,
+            use_numba=True,
         )
         .sort_values(["E", "Dates"], ignore_index=True)
     )


### PR DESCRIPTION
# PR Description

Please describe the changes proposed in the pull request:

- Numba support extend to all matches; previous PR #1131 was just for first and last match (unsorted data)
- `_numba_utils.py` cleaned up some more
- Tests added

Speed tests - usual disclaimer: Pinch of salt

```py
import pandas as pd
import numpy as np
import janitor
np.random.seed(3)
df = pd.DataFrame({'start':np.random.randint(100_000, size=1_000), 
                   'end':np.random.randint(100_000, size=1_000)})
dd = pd.DataFrame({'ID':np.random.randint(100_000, size=50_000)})

In [23]: %timeit df.conditional_join(dd, ('start', 'ID', '<'), use_numba = True)
472 ms ± 5.65 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [24]: %timeit df.conditional_join(dd, ('start', 'ID', '<'), use_numba = False)
615 ms ± 17 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [25]: %timeit df.merge(dd, how = 'cross').loc[lambda df: df.start < df.ID]
5.71 s ± 45 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [26]: %timeit df.conditional_join(dd, ('end', 'ID', '>'), use_numba = True)
432 ms ± 7.93 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [27]: %timeit df.conditional_join(dd, ('end', 'ID', '>'), use_numba = False)
558 ms ± 14.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [28]: %timeit df.merge(dd, how = 'cross').loc[lambda df: df.end > df.ID]
5.65 s ± 39.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [29]: A = df.conditional_join(dd, ('start', 'ID', '<'), use_numba = True)

In [30]: B = df.conditional_join(dd, ('start', 'ID', '<'), use_numba = False)

In [32]: C = df.merge(dd, how = 'cross').loc[lambda df: df.start < df.ID]

In [42]: A = A.sort_values(A.columns.tolist(), ignore_index = True)

In [43]: C = C.sort_values(C.columns.tolist(), ignore_index=True)

In [45]: B = B.sort_values(B.columns.tolist(), ignore_index = True)

In [46]: B.equals(C)
Out[46]: True

In [47]: A.equals(C)
Out[47]: True

In [48]: A.equals(B)
Out[48]: True
```

**This PR is related to #1102 .**



# PR Checklist

<!-- This checklist exists for newcomers who are not yet familiar with our requirements. If you are experienced with
the project, please feel free to delete this section. -->

Please ensure that you have done the following:

1. [ ] PR in from a fork off your branch. Do not PR from `<your_username>`:`dev`, but rather from `<your_username>`:`<feature-branch_name>`.
<!-- Doing this helps us keep the commit history much cleaner than it would otherwise be. -->
2. [ ] If you're not on the contributors list, add yourself to `AUTHORS.md`.
<!-- We'd like to acknowledge your contributions! -->
3. [ ] Add a line to `CHANGELOG.md` under the latest version header (i.e. the one that is "on deck") describing the contribution.
    - Do use some discretion here; if there are multiple PRs that are related, keep them in a single line.

# Automatic checks

There will be automatic checks run on the PR. These include:

- Building a preview of the docs on Netlify
- Automatically linting the code
- Making sure the code is documented
- Making sure that all tests are passed
- Making sure that code coverage doesn't go down.

# Relevant Reviewers

<!-- Finally, please tag relevant maintainers to review. -->

Please tag maintainers to review.

- @ericmjl
