### PR TITLE
[ENH] Numba support for single non-equi joins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 -   [DOC] Updated developer guide docs.
--   [ENH] Allow column selection/renaming within conditional_join. #1102. Also allow first or last match. #1020 @samukweku.
+-   [ENH] Allow column selection/renaming within conditional_join. Issue #1102. Also allow first or last match. Issue #1020 @samukweku.
 -   [ENH] New decorator `deprecated_kwargs` for breaking API. #1103 @Zeroto521
 -   [ENH] Extend select_columns to support non-string columns. Also allow selection on MultiIndex columns via level parameter. #1105 @samukweku
 -   [ENH] Performance improvement for groupby_topk. #1093 @samukweku
@@ -18,7 +18,7 @@
 -   [BUG] Force `math.softmax` returning `Series`. PR #1139 @Zeroto521
 -   [INF] Set independent environment for building documentation. PR #1141 @Zeroto521
 -   [DOC] Add local documentation preview via github action artifact. PR #1149 @Zeroto521
--   [ENH] Faster computation for a single non-equi join, with a numba engine. #1102 @samukweku
+-   [ENH] Faster computation for a single non-equi join, with a numba engine. Issue #1102 @samukweku
 
 ## [v0.23.1] - 2022-05-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 -   [DOC] Updated developer guide docs.
 -   [ENH] Allow column selection/renaming within conditional_join. Issue #1102. Also allow first or last match. Issue #1020 @samukweku.
 -   [ENH] New decorator `deprecated_kwargs` for breaking API. #1103 @Zeroto521
--   [ENH] Extend select_columns to support non-string columns. Also allow selection on MultiIndex columns via level parameter. #1105 @samukweku
--   [ENH] Performance improvement for groupby_topk. #1093 @samukweku
+-   [ENH] Extend select_columns to support non-string columns. Also allow selection on MultiIndex columns via level parameter. Issue #1105 @samukweku
+-   [ENH] Performance improvement for groupby_topk. Issue #1093 @samukweku
 -   [ENH] `min_max_scale` drop `old_min` and `old_max` to fit sklearn's method API. Issue #1068 @Zeroto521
 -   [ENH] Add `jointly` option for `min_max_scale` support to transform each column values or entire values. Default transform each column, similar behavior to `sklearn.preprocessing.MinMaxScaler`. (Issue #1067, PR #1112, PR #1123) @Zeroto521
 -   [INF] Require pyspark minimal version is v3.2.0 to cut duplicates codes. Issue #1110 @Zeroto521

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 -   [BUG] Force `math.softmax` returning `Series`. PR #1139 @Zeroto521
 -   [INF] Set independent environment for building documentation. PR #1141 @Zeroto521
 -   [DOC] Add local documentation preview via github action artifact. PR #1149 @Zeroto521
+-   [ENH] Faster computation for a single non-equi join, with a numba engine. #1102 @samukweku
 
 ## [v0.23.1] - 2022-05-03
 

--- a/janitor/functions/_numba.py
+++ b/janitor/functions/_numba.py
@@ -50,6 +50,10 @@ def _numba_single_join(
             right = np.maximum.reduceat(right[indexer], pos)
         return left, right
 
+    # convert Series to numpy arrays
+    # get the regions for left and right
+    # get the total count of indices
+    # build the final left and right indices
     if op_code == 1:
         result = _numba_less_than_indices(left, right)
     else:
@@ -60,6 +64,7 @@ def _numba_single_join(
     if result is None:
         return None
     left_index, right_index, left_region, right_region = result
+    # numpy version of pandas monotonic increasing
     bools = np.all(right_region[1:] >= right_region[:-1])
     if not bools:
         indexer = np.lexsort((right_index, right_region))
@@ -67,6 +72,7 @@ def _numba_single_join(
         right_index = right_index[indexer]
     positions = right_region.searchsorted(left_region, side="left")
     if keep == "all":
+        # get actual length of left and right indices
         counts = right_region.size - positions
         counts = counts.cumsum()
         return _numba_single_non_equi(
@@ -99,6 +105,7 @@ def _numba_generate_indices_ne(
     if result is None:
         return dummy, dummy
     left_index, right_index, left_region, right_region = result
+    # numpy version of pandas monotonic increasing
     bools = np.all(right_region[1:] >= right_region[:-1])
     if not bools:
         indexer = np.lexsort((right_index, right_region))
@@ -106,6 +113,7 @@ def _numba_generate_indices_ne(
         right_index = right_index[indexer]
     positions = right_region.searchsorted(left_region, side="left")
     if keep == "all":
+        # get actual length of left and right indices
         counts = right_region.size - positions
         counts = counts.cumsum()
         return _numba_single_non_equi(

--- a/janitor/functions/_numba.py
+++ b/janitor/functions/_numba.py
@@ -1,0 +1,388 @@
+"""Various Functions powered by Numba"""
+
+import numpy as np
+import pandas as pd
+from enum import Enum
+from janitor.functions.utils import _convert_to_numpy_array
+from numba import njit, prange as loop_range
+
+
+class _KeepTypes(Enum):
+    """
+    List of keep types for conditional_join.
+    """
+
+    ALL = "all"
+    FIRST = "first"
+    LAST = "last"
+
+
+def _numba_single_join(left_c, right_c, strict, keep, op_code):
+    """Return matching indices for single non-equi join."""
+    if op_code == -1:
+        left_nulls, right_nulls = _numba_not_equal_indices(left_c, right_c)
+        dummy = np.array([], dtype=int)
+        result = _numba_less_than_indices(left_c, right_c)
+        if result is None:
+            lt_left = dummy
+            lt_right = dummy
+        else:
+            lt_left, lt_right = _numba_generate_indices_ne(
+                *result, strict, keep, op_code=1
+            )
+        result = _numba_greater_than_indices(left_c, right_c)
+        if result is None:
+            gt_left = dummy
+            gt_right = dummy
+        else:
+            gt_left, gt_right = _numba_generate_indices_ne(
+                *result, strict, keep, op_code=0
+            )
+        left_c = np.concatenate([lt_left, gt_left, left_nulls])
+        right_c = np.concatenate([lt_right, gt_right, right_nulls])
+        if (not left_c.size) & (not right_c.size):
+            return None
+        if keep == _KeepTypes.ALL.value:
+            return left_c, right_c
+        indexer = np.argsort(left_c)
+        left_c, pos = np.unique(left_c[indexer], return_index=True)
+        if keep == _KeepTypes.FIRST.value:
+            right_c = np.minimum.reduceat(right_c[indexer], pos)
+        else:
+            right_c = np.maximum.reduceat(right_c[indexer], pos)
+        return left_c, right_c
+
+    if op_code == 1:
+        result = _numba_less_than_indices(left_c, right_c)
+    else:
+        result = _numba_greater_than_indices(left_c, right_c)
+    if result is None:
+        return None
+    result = _get_regions(*result, strict, op_code)
+    if result is None:
+        return None
+    if keep == _KeepTypes.ALL.value:
+        return _numba_single_non_equi(*result)
+    left_index, right_index, left_region, right_region = result
+    right_index, right_region = _prep_numba_first_last(
+        right_index, right_region
+    )
+    return _numba_single_non_equi_keep_first_last(
+        left_index, right_index, left_region, right_region, keep
+    )
+
+
+def _numba_generate_indices_ne(
+    left_c, left_index, right_c, right_index, strict, keep, op_code
+):
+    """
+    Generate indices for either greater or less than.
+    """
+    dummy = np.array([], dtype=int)
+    result = _get_regions(
+        left_c, left_index, right_c, right_index, strict, op_code
+    )
+    if result is None:
+        return dummy, dummy
+    if keep == _KeepTypes.ALL.value:
+        return _numba_single_non_equi(*result)
+    left_index, right_index, left_region, right_region = result
+    right_index, right_region = _prep_numba_first_last(
+        right_index, right_region
+    )
+    return _numba_single_non_equi_keep_first_last(
+        left_index, right_index, left_region, right_region, keep
+    )
+
+
+def _prep_numba_first_last(right_index, right_region):
+    """
+    Preparatory function if keep = 'first'/'last'
+    """
+    if not pd.Series(right_region).is_monotonic_increasing:
+        indexer = np.lexsort((right_index, right_region))
+        right_region = right_region[indexer]
+        right_index = right_index[indexer]
+    return right_index, right_region
+
+
+def _numba_not_equal_indices(left_c: pd.Series, right_c: pd.Series) -> tuple:
+    """
+    Preparatory function for _numba_single_join
+    """
+
+    dummy = np.array([], dtype=int)
+
+    # deal with nulls
+    l1_nulls = dummy
+    r1_nulls = dummy
+    l2_nulls = dummy
+    r2_nulls = dummy
+    any_left_nulls = left_c.isna()
+    any_right_nulls = right_c.isna()
+    if any_left_nulls.any():
+        l1_nulls = left_c.index[any_left_nulls]
+        l1_nulls = l1_nulls._values
+        r1_nulls = right_c.index
+        # avoid NAN duplicates
+        if any_right_nulls.any():
+            r1_nulls = r1_nulls[~any_right_nulls]
+        r1_nulls = r1_nulls._values
+        nulls_count = l1_nulls.size
+        # blow up nulls to match length of right
+        l1_nulls = np.tile(l1_nulls, r1_nulls.size)
+        # ensure length of right matches left
+        if nulls_count > 1:
+            r1_nulls = np.repeat(r1_nulls, nulls_count)
+    if any_right_nulls.any():
+        r2_nulls = right_c.index[any_right_nulls]
+        r2_nulls = r2_nulls._values
+        l2_nulls = left_c.index
+        nulls_count = r2_nulls.size
+        # blow up nulls to match length of left
+        r2_nulls = np.tile(r2_nulls, l2_nulls.size)
+        # ensure length of left matches right
+        if nulls_count > 1:
+            l2_nulls = np.repeat(l2_nulls, nulls_count)
+    l1_nulls = np.concatenate([l1_nulls, l2_nulls])
+    r1_nulls = np.concatenate([r1_nulls, r2_nulls])
+
+    return l1_nulls, r1_nulls
+
+
+def _numba_less_than_indices(
+    left_c: pd.Series,
+    right_c: pd.Series,
+) -> tuple:
+    """
+    Preparatory function for _numba_single_join
+    """
+
+    if left_c.min() > right_c.max():
+        return None
+    any_nulls = pd.isna(left_c)
+    if any_nulls.all():
+        return None
+    if any_nulls.any():
+        left_c = left_c[~any_nulls]
+    if not left_c.is_monotonic_increasing:
+        left_c = left_c.sort_values(kind="stable", ascending=True)
+    any_nulls = pd.isna(right_c)
+    if any_nulls.all():
+        return None
+    if any_nulls.any():
+        right_c = right_c[~any_nulls]
+    any_nulls = None
+    left_index = left_c.index._values
+    left_c = left_c._values
+    right_index = right_c.index._values
+    right_c = right_c._values
+    left_c, right_c = _convert_to_numpy_array(left_c, right_c)
+    return left_c, left_index, right_c, right_index
+
+
+def _numba_greater_than_indices(
+    left_c: pd.Series,
+    right_c: pd.Series,
+) -> tuple:
+    """
+    Preparatory function for _numba_single_join
+    """
+    if left_c.max() < right_c.min():
+        return None
+
+    any_nulls = pd.isna(left_c)
+    if any_nulls.all():
+        return None
+    if any_nulls.any():
+        left_c = left_c[~any_nulls]
+    if not left_c.is_monotonic_decreasing:
+        left_c = left_c.sort_values(kind="stable", ascending=False)
+    any_nulls = pd.isna(right_c)
+    if any_nulls.all():
+        return None
+    if any_nulls.any():
+        right_c = right_c[~any_nulls]
+
+    any_nulls = None
+    left_index = left_c.index._values
+    left_c = left_c._values
+    right_index = right_c.index._values
+    right_c = right_c._values
+
+    left_c, right_c = _convert_to_numpy_array(left_c, right_c)
+    return left_c, left_index, right_c, right_index
+
+
+@njit(parallel=True)
+def _numba_single_non_equi(left_index, right_index, left_region, right_region):
+    """
+    Generate all indices when keep = `all`.
+    Applies only to >, >= , <, <= operators.
+    """
+    length = right_index.size
+    counter = 0
+    positions = np.empty(length, np.intp)
+    # compute the exact length of the new indices
+    for num in loop_range(length):
+        val = right_region[num]
+        # left region is always sorted, take advantage of that
+        val = np.searchsorted(left_region, val, side="right")
+        counter += val
+        positions[num] = val
+    l_index = np.empty(counter, np.intp)
+    r_index = np.empty(counter, np.intp)
+    starts = np.empty(length, np.intp)
+    # capture the starts and ends for each sub range
+    starts[0] = 0
+    starts[1:] = np.cumsum(positions)[:-1]
+    # build the actual indices
+    for num in loop_range(length):
+        val = right_index[num]
+        pos = positions[num]
+        posn = starts[num]
+        for ind in range(pos):
+            l_index[posn] = left_index[ind]
+            r_index[posn] = val
+            posn += 1
+    return l_index, r_index
+
+
+@njit(parallel=True)
+def _numba_single_non_equi_keep_first_last(
+    left_index, right_index, left_region, right_region, keep
+):
+    """
+    Generate all indices when keep = `first` or `last`
+    Applies only to >, >= , <, <= operators.
+    """
+    length = left_index.size
+    positions = np.empty(length, np.intp)
+
+    for num in loop_range(length):
+        val = left_region[num]
+        val = np.searchsorted(right_region, val)
+        positions[num] = val
+
+    l_index = np.empty(length, np.intp)
+    r_index = np.empty(length, np.intp)
+
+    len_right = right_index.size
+    for num in loop_range(length):
+        val = left_index[num]
+        pos = positions[num]
+        base_val = right_index[pos]
+        for ind in range(pos + 1, len_right):
+            value = right_index[ind]
+            if keep == "first":
+                bool_scalar = value < base_val
+            else:
+                bool_scalar = value > base_val
+            if bool_scalar:
+                base_val = value
+        l_index[num] = val
+        r_index[num] = base_val
+    return l_index, r_index
+
+
+@njit()
+def _get_regions(
+    left_c: np.ndarray,
+    left_index: np.ndarray,
+    right_c: np.ndarray,
+    right_index: np.ndarray,
+    strict: int,
+    op_code: int,
+):
+    """
+    Get the regions where left_c and right_c converge.
+    Strictly for non-equi joins,
+    specifically  -->  >, >= , <, <= operators.
+    """
+    indices = _search_indices(left_c, right_c, strict, op_code)
+    left_region = np.empty(left_c.size, dtype=np.intp)
+    left_region[:] = -1
+    max_indices = indices.max() + 1
+    if max_indices < left_index.size:
+        left_region = left_region[:max_indices]
+        left_index = left_index[:max_indices]
+    mask = indices == -1
+    if mask.all():
+        return None
+    if mask.any():
+        right_index = right_index[~mask]
+        indices = indices[~mask]
+    left_region[indices] = 1
+    mask = left_region == 1
+    left_region[mask] = np.arange(len(set(indices)))
+    start = left_region[-1]
+    for num in range(left_region.size - 1, -1, -1):
+        if left_region[num] != -1:
+            start = left_region[num]
+        else:
+            left_region[num] = start
+    right_region = left_region[indices]
+    return left_index, right_index, left_region, right_region
+
+
+@njit(parallel=True)
+def _search_indices(
+    left_c: np.ndarray, right_c: np.ndarray, strict: int, op_code: int
+):
+    """
+    Get search indices for non-equi joins
+    """
+    indices = np.empty(right_c.size, dtype=np.intp)
+    for num in loop_range(right_c.size):
+        value = right_c[num]
+        if strict:
+            high = _searchsorted_left(left_c, value, op_code)
+        else:
+            high = _searchsorted_right(left_c, value, op_code)
+        indices[num] = high
+
+    return indices
+
+
+@njit()
+def _searchsorted_left(arr, value, op_code):
+    """
+    Modification of Python's bisect_left function.
+    Used to get the relevant region
+    within the _get_regions function.
+    """
+    high = len(arr)
+    low = 0
+    while low < high:
+        mid = (low + high) // 2
+        if op_code:
+            check = arr[mid] < value
+        else:
+            check = arr[mid] > value
+        if check:
+            low = mid + 1
+        else:
+            high = mid
+    return high - 1
+
+
+@njit()
+def _searchsorted_right(arr, value, op_code):
+    """
+    Modification of Python's bisect_right function.
+    Used to get the relevant region
+    within the _get_regions function.
+    """
+    high = len(arr)
+    low = 0
+    while low < high:
+        mid = (low + high) // 2
+        if op_code:
+            check = value < arr[mid]
+        else:
+            check = value > arr[mid]
+        if check:
+            high = mid
+        else:
+            low = mid + 1
+    return low - 1

--- a/janitor/functions/_numba.py
+++ b/janitor/functions/_numba.py
@@ -84,9 +84,9 @@ def _numba_single_join(
 
 
 def _numba_generate_indices_ne(
-    left_c: np.ndarray,
+    left: np.ndarray,
     left_index: np.ndarray,
-    right_c: np.ndarray,
+    right: np.ndarray,
     right_index: np.ndarray,
     strict: bool,
     keep: str,
@@ -100,7 +100,7 @@ def _numba_generate_indices_ne(
     """
     dummy = np.array([], dtype=int)
     result = _get_regions(
-        left_c, left_index, right_c, right_index, strict, op_code
+        left, left_index, right, right_index, strict, op_code
     )
     if result is None:
         return dummy, dummy
@@ -119,7 +119,7 @@ def _numba_generate_indices_ne(
 
 def _prep_numba_sort_right(right_index, right_region):
     """
-    Sort right_index and right_region for faster searching
+    Sort right_index and right_region for fast searching
     via binary search.
     """
     bools = np.all(right_region[1:] >= right_region[:-1])

--- a/janitor/functions/conditional_join.py
+++ b/janitor/functions/conditional_join.py
@@ -461,7 +461,7 @@ def _conditional_join_compute(
     )
 
 
-def _keep_output(keep: str, left_c: np.ndarray, right_c: np.ndarray):
+def _keep_output(keep: str, left: np.ndarray, right: np.ndarray):
     """return indices for left and right index based on the value of `keep`."""
     if keep == "all":
         return left, right

--- a/janitor/functions/conditional_join.py
+++ b/janitor/functions/conditional_join.py
@@ -464,7 +464,7 @@ def _conditional_join_compute(
 def _keep_output(keep: str, left_c: np.ndarray, right_c: np.ndarray):
     """return indices for left and right index based on the value of `keep`."""
     if keep == "all":
-        return left_c, right_c
+        return left, right
     grouped = pd.Series(right_c).groupby(left_c)
     if keep == "first":
         grouped = grouped.min()

--- a/janitor/functions/conditional_join.py
+++ b/janitor/functions/conditional_join.py
@@ -465,7 +465,7 @@ def _keep_output(keep: str, left: np.ndarray, right: np.ndarray):
     """return indices for left and right index based on the value of `keep`."""
     if keep == "all":
         return left, right
-    grouped = pd.Series(right_c).groupby(left_c)
+    grouped = pd.Series(right).groupby(left)
     if keep == "first":
         grouped = grouped.min()
         return grouped.index, grouped.array

--- a/janitor/functions/utils.py
+++ b/janitor/functions/utils.py
@@ -426,16 +426,16 @@ def _column_sel_dispatch(columns_to_select, df):  # noqa: F811
 
 
 def _convert_to_numpy_array(
-    left_c: np.ndarray, right_c: np.ndarray
+    left: np.ndarray, right: np.ndarray
 ) -> tuple[np.ndarray, np.ndarray]:
     """
     Convert array to numpy array for use in numba
     """
-    if is_extension_array_dtype(left_c):
-        numpy_dtype = left_c.dtype.numpy_dtype
-        left_c = left_c.to_numpy(dtype=numpy_dtype, copy=False)
-        right_c = right_c.to_numpy(dtype=numpy_dtype, copy=False)
-    elif isinstance(left_c, (ABCPandasArray, ABCExtensionArray)):
-        left_c = left_c.to_numpy(copy=False)
-        right_c = right_c.to_numpy(copy=False)
-    return left_c, right_c
+    if is_extension_array_dtype(left):
+        numpy_dtype = left.dtype.numpy_dtype
+        left = left.to_numpy(dtype=numpy_dtype, copy=False)
+        right = right.to_numpy(dtype=numpy_dtype, copy=False)
+    elif isinstance(left, (ABCPandasArray, ABCExtensionArray)):
+        left = left.to_numpy(copy=False)
+        right = right.to_numpy(copy=False)
+    return left, right

--- a/janitor/functions/utils.py
+++ b/janitor/functions/utils.py
@@ -2,10 +2,8 @@
 from itertools import chain
 import fnmatch
 import warnings
-from enum import Enum
 from collections.abc import Callable as dispatch_callable
 import re
-import importlib
 from typing import Hashable, Iterable, List, Optional, Pattern, Union
 from pandas.core.dtypes.generic import ABCPandasArray, ABCExtensionArray
 
@@ -441,89 +439,3 @@ def _convert_to_numpy_array(
         left_c = left_c.to_numpy(copy=False)
         right_c = right_c.to_numpy(copy=False)
     return left_c, right_c
-
-
-class _KeepTypes(Enum):
-    """
-    List of keep types for conditional_join.
-    """
-
-    ALL = "all"
-    FIRST = "first"
-    LAST = "last"
-
-
-def _import_numba():
-    """
-    Import numba if installed.
-    If not installed, an error message is raised.
-    """
-    # adapted from pandas.compat._optional.py
-    try:
-        module = importlib.import_module("numba")
-    except ImportError:
-        msg = (
-            "Missing optional dependency 'numba'. "
-            "Use pip or conda to install numba."
-        )
-        raise ImportError(msg) from None
-
-    return module
-
-
-def _numba_utils(
-    search_indices: np.ndarray,
-    right_index: np.ndarray,
-    len_right: int,
-    keep: str,
-):
-    """Utility functions for numba."""
-
-    numba = _import_numba()
-    loop_range = numba.prange
-
-    @numba.njit(cache=True, parallel=True)
-    def _numba_keep_first(
-        search_indices: np.ndarray, right_index: np.ndarray, len_right: int
-    ) -> np.ndarray:
-        """Parallelized output for first match."""
-
-        length_of_indices = search_indices.size
-        right_c = np.empty(shape=length_of_indices, dtype=np.intp)
-        if len_right:
-            for ind in loop_range(length_of_indices):
-                right_c[ind] = right_index[
-                    search_indices[ind] : len_right  # noqa:E203
-                ].min()
-        else:
-            for ind in loop_range(length_of_indices):
-                right_c[ind] = right_index[
-                    : search_indices[ind]
-                ].min()  # noqa:E203
-        return right_c
-
-    @numba.njit(cache=True, parallel=True)
-    def _numba_keep_last(
-        search_indices: np.ndarray, right_index: np.ndarray, len_right: int
-    ) -> np.ndarray:
-        """Parallelized output for last match."""
-
-        length_of_indices = search_indices.size
-        right_c = np.empty(shape=length_of_indices, dtype=np.intp)
-        if len_right:
-            for ind in loop_range(length_of_indices):
-                right_c[ind] = right_index[
-                    search_indices[ind] : len_right  # noqa:E203
-                ].max()
-        else:
-            for ind in loop_range(length_of_indices):
-                right_c[ind] = right_index[
-                    : search_indices[ind]
-                ].max()  # noqa:E203
-        return right_c
-
-    if keep == _KeepTypes.FIRST.value:
-        return _numba_keep_first(search_indices, right_index, len_right)
-
-    if keep == _KeepTypes.LAST.value:
-        return _numba_keep_last(search_indices, right_index, len_right)

--- a/tests/functions/test_conditional_join.py
+++ b/tests/functions/test_conditional_join.py
@@ -281,6 +281,7 @@ def test_dtype_category_non_equi():
 
 
 @pytest.mark.turtle
+@settings(deadline=None)
 @given(df=conditional_df(), right=conditional_right())
 def test_single_condition_less_than_floats_keep_first(df, right):
     """Test output for a single condition. "<"."""
@@ -307,6 +308,7 @@ def test_single_condition_less_than_floats_keep_first(df, right):
 
 
 @pytest.mark.turtle
+@settings(deadline=None)
 @given(df=conditional_df(), right=conditional_right())
 def test_single_condition_less_than_floats_keep_last(df, right):
     """Test output for a single condition. "<"."""
@@ -334,6 +336,7 @@ def test_single_condition_less_than_floats_keep_last(df, right):
 
 
 @pytest.mark.turtle
+@settings(deadline=None)
 @given(df=conditional_df(), right=conditional_right())
 def test_single_condition_less_than_floats(df, right):
     """Test output for a single condition. "<"."""
@@ -436,15 +439,20 @@ def test_single_condition_less_than_ints_extension_array_numba_first_match(
         .head(1)
         .drop(columns="index")
         .reset_index(drop=True)
+        .sort_values(["A", "Integers"], ignore_index=True)
     )
 
-    actual = df[["A"]].conditional_join(
-        right[["Integers"]],
-        ("A", "Integers", "<"),
-        how="inner",
-        keep="first",
-        sort_by_appearance=False,
-        use_numba=True,
+    actual = (
+        df[["A"]]
+        .conditional_join(
+            right[["Integers"]],
+            ("A", "Integers", "<"),
+            how="inner",
+            keep="first",
+            sort_by_appearance=False,
+            use_numba=True,
+        )
+        .sort_values(["A", "Integers"], ignore_index=True)
     )
 
     assert_frame_equal(expected, actual)
@@ -470,89 +478,27 @@ def test_single_condition_less_than_ints_extension_array_numba_last_match(
         .tail(1)
         .drop(columns="index")
         .reset_index(drop=True)
+        .sort_values(["A", "Integers"], ignore_index=True)
     )
 
-    actual = df[["A"]].conditional_join(
-        right[["Integers"]],
-        ("A", "Integers", "<"),
-        how="inner",
-        keep="last",
-        sort_by_appearance=False,
-        use_numba=True,
-    )
-
-    assert_frame_equal(expected, actual)
-
-
-@settings(deadline=None)
-@pytest.mark.turtle
-@given(df=conditional_df(), right=conditional_right())
-def test_single_condition_greater_than_ints_extension_array_numba_1st_match(
-    df, right
-):
-    """Test output for a single condition. ">"."""
-
-    df = df.assign(A=df["A"].astype("Int64"))
-    right = right.assign(Integers=right["Integers"].astype(pd.Int64Dtype()))
-
-    expected = (
+    actual = (
         df[["A"]]
-        .assign(index=df.index)
-        .merge(right[["Integers"]], how="cross")
-        .loc[lambda df: df.A > df.Integers]
-        .groupby("index")
-        .head(1)
-        .drop(columns="index")
-        .reset_index(drop=True)
-    )
-
-    actual = df[["A"]].conditional_join(
-        right[["Integers"]],
-        ("A", "Integers", ">"),
-        how="inner",
-        keep="first",
-        sort_by_appearance=False,
-        use_numba=True,
+        .conditional_join(
+            right[["Integers"]],
+            ("A", "Integers", "<"),
+            how="inner",
+            keep="last",
+            sort_by_appearance=False,
+            use_numba=True,
+        )
+        .sort_values(["A", "Integers"], ignore_index=True)
     )
 
     assert_frame_equal(expected, actual)
 
 
+@pytest.mark.turtle
 @settings(deadline=None)
-@pytest.mark.turtle
-@given(df=conditional_df(), right=conditional_right())
-def test_single_condition_greater_than_ints_extension_array_numba_last_match(
-    df, right
-):
-    """Test output for a single condition. ">"."""
-
-    df = df.assign(A=df["A"].astype("Int64"))
-    right = right.assign(Integers=right["Integers"].astype(pd.Int64Dtype()))
-
-    expected = (
-        df[["A"]]
-        .assign(index=df.index)
-        .merge(right[["Integers"]], how="cross")
-        .loc[lambda df: df.A > df.Integers]
-        .groupby("index")
-        .tail(1)
-        .drop(columns="index")
-        .reset_index(drop=True)
-    )
-
-    actual = df[["A"]].conditional_join(
-        right[["Integers"]],
-        ("A", "Integers", ">"),
-        how="inner",
-        keep="last",
-        sort_by_appearance=False,
-        use_numba=True,
-    )
-
-    assert_frame_equal(expected, actual)
-
-
-@pytest.mark.turtle
 @given(df=conditional_df(), right=conditional_right())
 def test_single_condition_less_than_ints(df, right):
     """Test output for a single condition. "<"."""
@@ -579,6 +525,35 @@ def test_single_condition_less_than_ints(df, right):
 
 
 @pytest.mark.turtle
+@settings(deadline=None)
+@given(df=conditional_df(), right=conditional_right())
+def test_single_condition_less_than_ints_numba(df, right):
+    """Test output for a single condition. "<"."""
+
+    expected = (
+        df[["A"]]
+        .merge(right[["Integers"]], how="cross")
+        .loc[lambda df: df.A.lt(df.Integers)]
+        .sort_values(["A", "Integers"], ignore_index=True)
+    )
+
+    actual = (
+        df[["A"]]
+        .conditional_join(
+            right[["Integers"]],
+            ("A", "Integers", "<"),
+            how="inner",
+            sort_by_appearance=False,
+            use_numba=True,
+        )
+        .sort_values(["A", "Integers"], ignore_index=True)
+    )
+
+    assert_frame_equal(expected, actual)
+
+
+@pytest.mark.turtle
+@settings(deadline=None)
 @given(df=conditional_df(), right=conditional_right())
 def test_single_condition_less_than_ints_extension_array(df, right):
     """Test output for a single condition. "<"."""
@@ -609,6 +584,44 @@ def test_single_condition_less_than_ints_extension_array(df, right):
 
 
 @pytest.mark.turtle
+@settings(deadline=None)
+@given(df=conditional_df(), right=conditional_right())
+def test_single_condition_less_than_ints_extension_array_numba(df, right):
+    """Test output for a single condition. "<"."""
+
+    df = df.assign(A=df["A"].astype("Int64"))
+    right = right.assign(Integers=right["Integers"].astype(pd.Int64Dtype()))
+
+    expected = (
+        df[["A"]]
+        .assign(index=df.index)
+        .merge(right[["Integers"]], how="cross")
+        .loc[lambda df: df.A < df.Integers]
+        .groupby("index")
+        .head(1)
+        .drop(columns="index")
+        .reset_index(drop=True)
+        .sort_values(["A", "Integers"], ignore_index=True)
+    )
+
+    actual = (
+        df[["A"]]
+        .conditional_join(
+            right[["Integers"]],
+            ("A", "Integers", "<"),
+            how="inner",
+            keep="first",
+            sort_by_appearance=False,
+            use_numba=True,
+        )
+        .sort_values(["A", "Integers"], ignore_index=True)
+    )
+
+    assert_frame_equal(expected, actual)
+
+
+@pytest.mark.turtle
+@settings(deadline=None)
 @given(df=conditional_df(), right=conditional_right())
 def test_single_condition_less_than_equal(df, right):
     """Test output for a single condition. "<=". DateTimes"""
@@ -636,6 +649,41 @@ def test_single_condition_less_than_equal(df, right):
 
 
 @pytest.mark.turtle
+@settings(deadline=None)
+@given(df=conditional_df(), right=conditional_right())
+def test_single_condition_less_than_equal_numba(df, right):
+    """Test output for a single condition. "<=". DateTimes"""
+
+    expected = (
+        df[["E"]]
+        .assign(index=df.index)
+        .merge(right[["Dates"]], how="cross")
+        .loc[lambda df: df.E.le(df.Dates)]
+        .groupby("index")
+        .tail(1)
+        .drop(columns="index")
+        .reset_index(drop=True)
+        .sort_values(["E", "Dates"], ignore_index=True)
+    )
+
+    actual = (
+        df[["E"]]
+        .conditional_join(
+            right[["Dates"]],
+            ("E", "Dates", "<="),
+            how="inner",
+            keep="last",
+            use_numba=True,
+            sort_by_appearance=False,
+        )
+        .sort_values(["E", "Dates"], ignore_index=True)
+    )
+
+    assert_frame_equal(expected, actual)
+
+
+@pytest.mark.turtle
+@settings(deadline=None)
 @given(df=conditional_df(), right=conditional_right())
 def test_single_condition_less_than_date(df, right):
     """Test output for a single condition. "<". Dates"""
@@ -661,6 +709,34 @@ def test_single_condition_less_than_date(df, right):
 
 
 @pytest.mark.turtle
+@settings(deadline=None)
+@given(df=conditional_df(), right=conditional_right())
+def test_single_condition_less_than_date_numba(df, right):
+    """Test output for a single condition. "<". Dates"""
+
+    expected = (
+        df[["E"]]
+        .merge(right[["Dates"]], how="cross")
+        .loc[lambda df: df.E.lt(df.Dates)]
+        .sort_values(["E", "Dates"], ignore_index=True)
+    )
+    actual = (
+        df[["E"]]
+        .conditional_join(
+            right[["Dates"]],
+            ("E", "Dates", "<"),
+            how="inner",
+            sort_by_appearance=False,
+            use_numba=True,
+        )
+        .sort_values(["E", "Dates"], ignore_index=True)
+    )
+
+    assert_frame_equal(expected, actual)
+
+
+@pytest.mark.turtle
+@settings(deadline=None)
 @given(df=conditional_df(), right=conditional_right())
 def test_single_condition_greater_than_datetime(df, right):
     """Test output for a single condition. ">". Datetimes"""
@@ -686,6 +762,34 @@ def test_single_condition_greater_than_datetime(df, right):
 
 
 @pytest.mark.turtle
+@settings(deadline=None)
+@given(df=conditional_df(), right=conditional_right())
+def test_single_condition_greater_than_datetime_numba(df, right):
+    """Test output for a single condition. ">". Datetimes"""
+
+    expected = (
+        df[["E"]]
+        .merge(right[["Dates"]], how="cross")
+        .loc[lambda df: df.E.gt(df.Dates)]
+        .sort_values(["E", "Dates"], ignore_index=True)
+    )
+    actual = (
+        df[["E"]]
+        .conditional_join(
+            right[["Dates"]],
+            ("E", "Dates", ">"),
+            how="inner",
+            use_numba=True,
+            sort_by_appearance=False,
+        )
+        .sort_values(["E", "Dates"], ignore_index=True)
+    )
+
+    assert_frame_equal(expected, actual)
+
+
+@pytest.mark.turtle
+@settings(deadline=None)
 @given(df=conditional_df(), right=conditional_right())
 def test_single_condition_greater_than_ints(df, right):
     """Test output for a single condition. ">="."""
@@ -713,6 +817,41 @@ def test_single_condition_greater_than_ints(df, right):
 
 
 @pytest.mark.turtle
+@settings(deadline=None)
+@given(df=conditional_df(), right=conditional_right())
+def test_single_condition_greater_than_ints_numba(df, right):
+    """Test output for a single condition. ">="."""
+
+    expected = (
+        df[["A"]]
+        .assign(index=df.index)
+        .merge(right[["Integers"]], how="cross")
+        .loc[lambda df: df.A.ge(df.Integers)]
+        .groupby("index")
+        .head(1)
+        .drop(columns="index")
+        .reset_index(drop=True)
+        .sort_values(["A", "Integers"], ignore_index=True)
+    )
+
+    actual = (
+        df[["A"]]
+        .conditional_join(
+            right[["Integers"]],
+            ("A", "Integers", ">="),
+            how="inner",
+            keep="first",
+            sort_by_appearance=False,
+            use_numba=True,
+        )
+        .sort_values(["A", "Integers"], ignore_index=True)
+    )
+
+    assert_frame_equal(expected, actual)
+
+
+@pytest.mark.turtle
+@settings(deadline=None)
 @given(df=conditional_df(), right=conditional_right())
 def test_single_condition_greater_than_floats_floats(df, right):
     """Test output for a single condition. ">"."""
@@ -726,19 +865,58 @@ def test_single_condition_greater_than_floats_floats(df, right):
         .tail(1)
         .drop(columns="index")
         .reset_index(drop=True)
+        .sort_values(["B", "Numeric"], ignore_index=True)
     )
-    actual = df[["B"]].conditional_join(
-        right[["Numeric"]],
-        ("B", "Numeric", ">"),
-        how="inner",
-        keep="last",
-        sort_by_appearance=False,
+    actual = (
+        df[["B"]]
+        .conditional_join(
+            right[["Numeric"]],
+            ("B", "Numeric", ">"),
+            how="inner",
+            keep="last",
+            sort_by_appearance=False,
+        )
+        .sort_values(["B", "Numeric"], ignore_index=True)
     )
 
     assert_frame_equal(expected, actual)
 
 
 @pytest.mark.turtle
+@settings(deadline=None)
+@given(df=conditional_df(), right=conditional_right())
+def test_single_condition_greater_than_floats_floats_numba(df, right):
+    """Test output for a single condition. ">"."""
+
+    expected = (
+        df[["B"]]
+        .assign(index=df.index)
+        .merge(right[["Numeric"]], how="cross")
+        .loc[lambda df: df.B.gt(df.Numeric)]
+        .groupby("index")
+        .tail(1)
+        .drop(columns="index")
+        .reset_index(drop=True)
+        .sort_values(["B", "Numeric"], ignore_index=True)
+    )
+    actual = (
+        df[["B"]]
+        .conditional_join(
+            right[["Numeric"]],
+            ("B", "Numeric", ">"),
+            how="inner",
+            keep="last",
+            sort_by_appearance=False,
+            use_numba=True,
+        )
+        .sort_values(["B", "Numeric"], ignore_index=True)
+    )
+
+    assert_frame_equal(expected, actual)
+
+
+@pytest.mark.turtle
+@settings(deadline=None)
 @given(df=conditional_df(), right=conditional_right())
 def test_single_condition_greater_than_ints_extension_array(df, right):
     """Test output for a single condition. ">"."""
@@ -767,6 +945,37 @@ def test_single_condition_greater_than_ints_extension_array(df, right):
 
 
 @pytest.mark.turtle
+@settings(deadline=None)
+@given(df=conditional_df(), right=conditional_right())
+def test_single_condition_greater_than_ints_extension_array_numba(df, right):
+    """Test output for a single condition. ">"."""
+
+    df = df.astype({"A": "Int64"})
+    right = right.astype({"Integers": "Int64"})
+    expected = (
+        df[["A"]]
+        .merge(right[["Integers"]], how="cross")
+        .loc[lambda df: df.A > df.Integers]
+        .sort_values(["A", "Integers"], ignore_index=True)
+    )
+
+    actual = (
+        df[["A"]]
+        .conditional_join(
+            right[["Integers"]],
+            ("A", "Integers", ">"),
+            how="inner",
+            sort_by_appearance=False,
+            use_numba=True,
+        )
+        .sort_values(["A", "Integers"], ignore_index=True)
+    )
+
+    assert_frame_equal(expected, actual)
+
+
+@pytest.mark.turtle
+@settings(deadline=None)
 @given(df=conditional_df(), right=conditional_right())
 def test_single_condition_not_equal_ints(df, right):
     """Test output for a single condition. "!="."""
@@ -793,6 +1002,35 @@ def test_single_condition_not_equal_ints(df, right):
 
 
 @pytest.mark.turtle
+@settings(deadline=None)
+@given(df=conditional_df(), right=conditional_right())
+def test_single_condition_not_equal_ints_numba(df, right):
+    """Test output for a single condition. "!="."""
+
+    expected = (
+        df[["A"]]
+        .merge(right[["Integers"]], how="cross")
+        .loc[lambda df: df.A != df.Integers]
+        .sort_values(["A", "Integers"], ignore_index=True)
+    )
+
+    actual = (
+        df[["A"]]
+        .conditional_join(
+            right[["Integers"]],
+            ("A", "Integers", "!="),
+            how="inner",
+            sort_by_appearance=False,
+            use_numba=True,
+        )
+        .sort_values(["A", "Integers"], ignore_index=True)
+    )
+
+    assert_frame_equal(expected, actual)
+
+
+@pytest.mark.turtle
+@settings(deadline=None)
 @given(df=conditional_df(), right=conditional_right())
 def test_single_condition_not_equal_floats_only(df, right):
     """Test output for a single condition. "!="."""
@@ -820,6 +1058,41 @@ def test_single_condition_not_equal_floats_only(df, right):
 
 
 @pytest.mark.turtle
+@settings(deadline=None)
+@given(df=conditional_df(), right=conditional_right())
+def test_single_condition_not_equal_floats_only_numba(df, right):
+    """Test output for a single condition. "!="."""
+
+    expected = (
+        df[["B"]]
+        .assign(index=df.index)
+        .merge(right[["Numeric"]], how="cross")
+        .loc[lambda df: df.B != df.Numeric]
+        .groupby("index")
+        .tail(1)
+        .drop(columns="index")
+        .reset_index(drop=True)
+        .sort_values(["B", "Numeric"], ignore_index=True)
+    )
+
+    actual = (
+        df[["B"]]
+        .conditional_join(
+            right[["Numeric"]],
+            ("B", "Numeric", "!="),
+            how="inner",
+            keep="last",
+            sort_by_appearance=False,
+            use_numba=True,
+        )
+        .sort_values(["B", "Numeric"], ignore_index=True)
+    )
+
+    assert_frame_equal(expected, actual)
+
+
+@pytest.mark.turtle
+@settings(deadline=None)
 @given(df=conditional_df(), right=conditional_right())
 def test_single_condition_not_equal_datetime(df, right):
     """Test output for a single condition. "!="."""
@@ -847,6 +1120,41 @@ def test_single_condition_not_equal_datetime(df, right):
 
 
 @pytest.mark.turtle
+@settings(deadline=None)
+@given(df=conditional_df(), right=conditional_right())
+def test_single_condition_not_equal_datetime_numba(df, right):
+    """Test output for a single condition. "!="."""
+
+    expected = (
+        df[["E"]]
+        .assign(index=df.index)
+        .merge(right[["Dates"]], how="cross")
+        .loc[lambda df: df.E != df.Dates]
+        .groupby("index")
+        .head(1)
+        .drop(columns="index")
+        .reset_index(drop=True)
+        .sort_values(["E", "Dates"], ignore_index=True)
+    )
+
+    actual = (
+        df[["E"]]
+        .conditional_join(
+            right[["Dates"]],
+            ("E", "Dates", "!="),
+            how="inner",
+            keep="first",
+            use_numba=True,
+            sort_by_appearance=False,
+        )
+        .sort_values(["E", "Dates"], ignore_index=True)
+    )
+
+    assert_frame_equal(expected, actual)
+
+
+@pytest.mark.turtle
+@settings(deadline=None)
 @given(df=conditional_df(), right=conditional_right())
 def test_how_left(df, right):
     """Test output when `how==left`. "<="."""
@@ -874,7 +1182,7 @@ def test_how_left(df, right):
     assert_frame_equal(expected, actual)
 
 
-@pytest.mark.turtle
+@settings(deadline=None)
 @given(df=conditional_df(), right=conditional_right())
 @pytest.mark.turtle
 def test_how_right(df, right):


### PR DESCRIPTION
# PR Description

Please describe the changes proposed in the pull request:

- Numba implementation for single non-equi joins (including support for first/last/all matches)
- Single file for all numba implementations, separate from the utils file
- Serves as a build layer for multiple non equi joins, with more efficiency

Speed tests ... YMMV ... usual disclaimer ... pinch of salt 

```py
In [47]: np.random.seed(3)
    ...: df = pd.DataFrame({'start':np.random.randint(100_000, size=1_000),
    ...:                    'end':np.random.randint(100_000, size=1_000)})
    ...: dd = pd.DataFrame({'ID':np.random.randint(100_000, size=50_000)})

In [48]: df.conditional_join(dd, ('start', 'ID', '<'), use_numba = True)
Out[48]: 
          start    end     ID
0            53  95502    110
1            53  95502     86
2            53  95502    121
3            53  95502     63
4            53  95502     72
...         ...    ...    ...
25318626  99838  92334  99892
25318627  99838  92334  99998
25318628  99838  92334  99999
25318629  99996  21475  99998
25318630  99996  21475  99999

[25318631 rows x 3 columns]

In [49]: %timeit df.conditional_join(dd, ('start', 'ID', '<'), use_numba = True)
502 ms ± 10.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [50]: %timeit df.conditional_join(dd, ('start', 'ID', '<'), use_numba = False)
685 ms ± 11.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [51]: %timeit df.merge(dd, how = 'cross').loc[lambda df: df.start < df.ID]
8.73 s ± 311 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [52]: A = df.conditional_join(dd, ('start', 'ID', '<'), use_numba = True)

In [53]: B = df.conditional_join(dd, ('start', 'ID', '<'), use_numba = False)

In [54]: C = df.merge(dd, how = 'cross').loc[lambda df: df.start < df.ID]

In [55]: A = A.sort_values(A.columns.tolist(), ignore_index = True)
    ...: C = C.sort_values(C.columns.tolist(), ignore_index=True)
    ...: B = B.sort_values(B.columns.tolist(), ignore_index = True)

In [56]:  B.equals(C)
Out[56]: True

In [57]: A.equals(C)
Out[57]: True

In [58]: A.equals(B)
Out[58]: True
```

**This PR is related to #1102 .**

<!-- As you go down the PR template, please feel free to delete sections that are irrelevant. -->

# PR Checklist

<!-- This checklist exists for newcomers who are not yet familiar with our requirements. If you are experienced with
the project, please feel free to delete this section. -->

Please ensure that you have done the following:

1. [ ] PR in from a fork off your branch. Do not PR from `<your_username>`:`dev`, but rather from `<your_username>`:`<feature-branch_name>`.
<!-- Doing this helps us keep the commit history much cleaner than it would otherwise be. -->
2. [ ] If you're not on the contributors list, add yourself to `AUTHORS.md`.
<!-- We'd like to acknowledge your contributions! -->
3. [ ] Add a line to `CHANGELOG.md` under the latest version header (i.e. the one that is "on deck") describing the contribution.
    - Do use some discretion here; if there are multiple PRs that are related, keep them in a single line.

# Automatic checks

There will be automatic checks run on the PR. These include:

- Building a preview of the docs on Netlify
- Automatically linting the code
- Making sure the code is documented
- Making sure that all tests are passed
- Making sure that code coverage doesn't go down.

# Relevant Reviewers

<!-- Finally, please tag relevant maintainers to review. -->

Please tag maintainers to review.

- @ericmjl
