### PR TITLE
TST/ENH: Enabel `encode_categorical` handle 2 (or more ) dimensions array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 -   [BUG] Force `math.softmax` returning `Series`. PR #1139 @Zeroto521
 -   [INF] Set independent environment for building documentation. PR #1141 @Zeroto521
 -   [DOC] Add local documentation preview via github action artifact. PR #1149 @Zeroto521
+-   [ENH] Enabel `encode_categorical` handle 2 (or more ) dimensions array. PR #1153 @Zeroto521
 
 ## [v0.23.1] - 2022-05-03
 

--- a/janitor/functions/encode_categorical.py
+++ b/janitor/functions/encode_categorical.py
@@ -2,8 +2,9 @@ import warnings
 from enum import Enum
 from typing import Hashable, Iterable, Union
 
-import pandas_flavor as pf
+import numpy as np
 import pandas as pd
+import pandas_flavor as pf
 from pandas.api.types import is_list_like
 
 from janitor.utils import check, check_column, deprecated_alias
@@ -191,7 +192,7 @@ def _as_categorical_checks(df: pd.DataFrame, **kwargs) -> dict:
             raise TypeError(f"{value} should be list-like or a string.")
         if is_list_like(value):
             if not hasattr(value, "shape"):
-                value = pd.Index([*value])
+                value = np.asarray(value)
 
             arr_ndim = value.ndim
             if (arr_ndim != 1) or isinstance(value, pd.MultiIndex):

--- a/janitor/functions/encode_categorical.py
+++ b/janitor/functions/encode_categorical.py
@@ -194,8 +194,7 @@ def _as_categorical_checks(df: pd.DataFrame, **kwargs) -> dict:
             if not hasattr(value, "shape"):
                 value = np.asarray(value)
 
-            arr_ndim = value.ndim
-            if (arr_ndim != 1) or isinstance(value, pd.MultiIndex):
+            if (value.ndim != 1) or isinstance(value, pd.MultiIndex):
                 raise ValueError(
                     f"{value} is not a 1-D array. "
                     "Kindly provide a 1-D array-like object."


### PR DESCRIPTION
<!-- Thank you for your PR!

BEFORE YOU CONTINUE! Please add the appropriate three-letter abbreviation to your title.

The abbreviations can be:
- [DOC]: Documentation fixes.
- [ENH]: Code contributions and new features.
- [TST]: Test-related contributions.
- [INF]: Infrastructure-related contributions.

Also, do not forget to tag the relevant issue here as well.

Finally, as commits come in, don't forget to regularly rebase!
-->

# PR Description

Please describe the changes proposed in the pull request:

`test_categories_ndim_array_gt_1_in_kwargs` should raise error in https://github.com/pyjanitor-devs/pyjanitor/blob/ae01b7d1670460509d75839431707bd79a44b71d/janitor/functions/encode_categorical.py#L196-L201

when input is `array = [[1, 1, 2, 2], ["red", "blue", "red", "blue"]]` the `ndim` of `pd.Index(array)` is 1 not 2.
It's better to convert ndarray object first.

```python
__________________ test_categories_ndim_array_gt_1_in_kwargs ___________________
[gw0] linux -- Python 3.10.5 /usr/share/miniconda3/envs/test/bin/python

df_checks =                        region  2007  2009
0                     Pacific  1039  2587
1                   Southwest    51   176
2  Rocky Mountains and Plains   200   338

    def test_categories_ndim_array_gt_1_in_kwargs(df_checks):
        """
        Raise ValueError if categories is provided, but is not a 1D array.
        """
        arrays = [[1, 1, 2, 2], ["red", "blue", "red", "blue"]]
        with pytest.raises(ValueError):
>           df_checks.encode_categorical(region=arrays)

tests/functions/test_encode_categorical.py:125: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/share/miniconda3/envs/test/lib/python3.10/site-packages/pandas_flavor/register.py:29: in __call__
    return method(self._obj, *args, **kwargs)
janitor/utils.py:283: in wrapper
    return func(*args, **kwargs)
janitor/functions/encode_categorical.py:121: in encode_categorical
    return _computations_as_categorical(df, **kwargs)
janitor/functions/encode_categorical.py:136: in _computations_as_categorical
    categories_dict = _as_categorical_checks(df, **kwargs)
janitor/functions/encode_categorical.py:211: in _as_categorical_checks
    if not value.is_unique:
pandas/_libs/properties.pyx:37: in pandas._libs.properties.CachedProperty.__get__
    ???
/usr/share/miniconda3/envs/test/lib/python3.10/site-packages/pandas/core/indexes/base.py:2237: in is_unique
    return self._engine.is_unique
pandas/_libs/index.pyx:223: in pandas._libs.index.IndexEngine.is_unique.__get__
    ???
pandas/_libs/index.pyx:230: in pandas._libs.index.IndexEngine._do_unique_check
    ???
pandas/_libs/index.pyx:287: in pandas._libs.index.IndexEngine._ensure_mapping_populated
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   ???
E   TypeError: unhashable type: 'list'

pandas/_libs/hashtable_class_helper.pxi:5231: TypeError
```

<!-- Doing so provides maintainers with context on what the PR is, and can help us more effectively review your PR. -->

<!-- Please also identify below which issue that has been raised that you are going to close. -->

**This PR resolves #1143.**

<!-- As you go down the PR template, please feel free to delete sections that are irrelevant. -->

# PR Checklist

<!-- This checklist exists for newcomers who are not yet familiar with our requirements. If you are experienced with
the project, please feel free to delete this section. -->

Please ensure that you have done the following:

1. [x] PR in from a fork off your branch. Do not PR from `<your_username>`:`dev`, but rather from `<your_username>`:`<feature-branch_name>`.
<!-- Doing this helps us keep the commit history much cleaner than it would otherwise be. -->
2. [x] If you're not on the contributors list, add yourself to `AUTHORS.md`.
<!-- We'd like to acknowledge your contributions! -->
3. [x] Add a line to `CHANGELOG.md` under the latest version header (i.e. the one that is "on deck") describing the contribution.
    - Do use some discretion here; if there are multiple PRs that are related, keep them in a single line.

# Automatic checks

There will be automatic checks run on the PR. These include:

- Building a preview of the docs on Netlify
- Automatically linting the code
- Making sure the code is documented
- Making sure that all tests are passed
- Making sure that code coverage doesn't go down.

# Relevant Reviewers

<!-- Finally, please tag relevant maintainers to review. -->

Please tag maintainers to review.

- @ericmjl
