### PR TITLE
Update Python to be minimum 3.9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         test-subset: ["turtle", "not turtle"]
+        python-version: ["3.8", "3.9", "3.10"]
     runs-on: ubuntu-latest
     name: Run pyjanitor test suite
 
@@ -34,6 +35,7 @@ jobs:
       - name: Run unit tests
         run: |
           conda activate pyjanitor-dev
+          mamba install python=${{ matrix.python-version }}
           python -m pip install -e .
           pytest -m "${{ matrix.test-subset }}"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         test-subset: ["turtle", "not turtle"]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
     runs-on: ubuntu-latest
     name: Run pyjanitor test suite
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         test-subset: ["turtle", "not turtle"]
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
     runs-on: ubuntu-latest
     name: Run pyjanitor test suite
 

--- a/examples/notebooks/medium_franchise.ipynb
+++ b/examples/notebooks/medium_franchise.ipynb
@@ -585,7 +585,7 @@
     "\n",
     "# [pyjanitor + pandas-flavor]\n",
     "@pf.register_dataframe_method\n",
-    "def separate(df, column_name: str, into: List[str] = None, sep: str = ''):\n",
+    "def separate(df, column_name: str, into: list[str] = None, sep: str = ''):\n",
     "    \"\"\"Split a column into separate columns at separator specified by `sep`\n",
     "\n",
     "    Parameters\n",
@@ -1460,9 +1460,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "PyJanitor development",
+   "display_name": "Python 3.9.13 ('base')",
    "language": "python",
-   "name": "pyjanitor-dev"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1474,7 +1474,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.9.13"
   },
   "toc": {
    "base_numbering": 1,
@@ -1488,6 +1488,11 @@
    "toc_position": {},
    "toc_section_display": true,
    "toc_window_display": false
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "d4d1e4263499bec80672ea0156c357c1ee493ec2b1c70f0acce89fc37c4a6abe"
+   }
   }
  },
  "nbformat": 4,

--- a/janitor/functions/add_columns.py
+++ b/janitor/functions/add_columns.py
@@ -1,8 +1,10 @@
+"""Implementation of add_columns."""
+from __future__ import annotations
 import pandas_flavor as pf
 
 from janitor.utils import check, deprecated_alias
 import pandas as pd
-from typing import Union, List, Any, Tuple
+from typing import Any
 import numpy as np
 
 
@@ -11,7 +13,7 @@ import numpy as np
 def add_column(
     df: pd.DataFrame,
     column_name: str,
-    value: Union[List[Any], Tuple[Any], Any],
+    value: list[Any] | tuple[Any] | Any,
     fill_remaining: bool = False,
 ) -> pd.DataFrame:
     """Add a column to the dataframe.

--- a/janitor/functions/complete.py
+++ b/janitor/functions/complete.py
@@ -1,4 +1,5 @@
-from typing import Optional, Union, List, Tuple, Dict, Any
+from __future__ import annotations
+from typing import Optional, Any
 from pandas.core.common import apply_if_callable
 from pandas.core.construction import extract_array
 import pandas_flavor as pf
@@ -16,8 +17,8 @@ def complete(
     df: pd.DataFrame,
     *columns,
     sort: bool = False,
-    by: Optional[Union[list, str]] = None,
-    fill_value: Optional[Union[Dict, Any]] = None,
+    by: Optional[list | str] = None,
+    fill_value: Optional[dict | Any] = None,
     explicit: bool = True,
 ) -> pd.DataFrame:
     """
@@ -170,10 +171,10 @@ def complete(
 
 def _computations_complete(
     df: pd.DataFrame,
-    columns: List[Union[List, Tuple, Dict, str]],
+    columns: list[list | tuple | dict | str],
     sort: bool,
-    by: Optional[Union[list, str]],
-    fill_value: Optional[Union[Dict, Any]],
+    by: Optional[list | str],
+    fill_value: Optional[dict | Any],
     explicit: bool,
 ) -> pd.DataFrame:
     """
@@ -427,10 +428,10 @@ def _sub_complete_column(column, df, sort):  # noqa: F811
 
 def _data_checks_complete(
     df: pd.DataFrame,
-    columns: List[Union[List, Tuple, Dict, str]],
+    columns: list[list | tuple | dict | str],
     sort: Optional[bool],
-    by: Optional[Union[list, str]],
-    fill_value: Optional[Union[Dict, Any]],
+    by: Optional[list | str],
+    fill_value: Optional[dict | Any],
     explicit: bool,
 ):
     """

--- a/janitor/functions/concatenate_columns.py
+++ b/janitor/functions/concatenate_columns.py
@@ -1,4 +1,4 @@
-from typing import Hashable, List
+from typing import Hashable
 import pandas_flavor as pf
 import pandas as pd
 from janitor.errors import JanitorError
@@ -10,7 +10,7 @@ from janitor.utils import deprecated_alias
 @deprecated_alias(columns="column_names")
 def concatenate_columns(
     df: pd.DataFrame,
-    column_names: List[Hashable],
+    column_names: list[Hashable],
     new_column_name: Hashable,
     sep: str = "-",
     ignore_empty: bool = True,

--- a/janitor/functions/conditional_join.py
+++ b/janitor/functions/conditional_join.py
@@ -1,6 +1,6 @@
 import operator
 from enum import Enum
-from typing import Union, Any, Optional, Hashable
+from typing import Union, Any, Optional, Hashable, Tuple
 from janitor.functions.utils import _numba_utils, _KeepTypes
 
 import numpy as np
@@ -501,7 +501,7 @@ def _keep_output(keep: str, left_c: np.ndarray, right_c: np.ndarray):
 
 def _convert_to_numpy_array(
     left_c: np.ndarray, right_c: np.ndarray
-) -> tuple[np.ndarray, np.ndarray]:
+) -> Tuple[np.ndarray, np.ndarray]:
     """
     Convert array to numpy array for use in numba
     """

--- a/janitor/functions/deconcatenate_column.py
+++ b/janitor/functions/deconcatenate_column.py
@@ -1,5 +1,6 @@
 """Implementation of deconcatenating columns."""
-from typing import Hashable, List, Optional, Tuple, Union
+from __future__ import annotations
+from typing import Hashable, Optional
 import pandas_flavor as pf
 import pandas as pd
 from janitor.errors import JanitorError
@@ -13,7 +14,7 @@ def deconcatenate_column(
     df: pd.DataFrame,
     column_name: Hashable,
     sep: Optional[str] = None,
-    new_column_names: Optional[Union[List[str], Tuple[str]]] = None,
+    new_column_names: Optional[list[str] | tuple[str]] = None,
     autoname: str = None,
     preserve_position: bool = False,
 ) -> pd.DataFrame:

--- a/janitor/functions/transform_columns.py
+++ b/janitor/functions/transform_columns.py
@@ -1,4 +1,5 @@
-from typing import Callable, Dict, Hashable, List, Optional, Tuple, Union
+from __future__ import annotations
+from typing import Callable, Hashable, Optional
 import pandas_flavor as pf
 import pandas as pd
 
@@ -121,11 +122,11 @@ def transform_column(
 @deprecated_alias(columns="column_names", new_names="new_column_names")
 def transform_columns(
     df: pd.DataFrame,
-    column_names: Union[List[str], Tuple[str]],
+    column_names: list[str] | tuple[str],
     function: Callable,
     suffix: Optional[str] = None,
     elementwise: bool = True,
-    new_column_names: Optional[Dict[str, str]] = None,
+    new_column_names: Optional[dict[str, str]] = None,
 ) -> pd.DataFrame:
     """Transform multiple columns through the same transformation.
 

--- a/janitor/functions/utils.py
+++ b/janitor/functions/utils.py
@@ -6,7 +6,7 @@ from enum import Enum
 from collections.abc import Callable as dispatch_callable
 import re
 import importlib
-from typing import Hashable, Iterable, List, Optional, Pattern, Union
+from typing import Hashable, Iterable, Optional, Pattern, Union
 
 import pandas as pd
 from janitor.utils import check, _expand_grid
@@ -26,7 +26,7 @@ import functools
 
 def unionize_dataframe_categories(
     *dataframes, column_names: Optional[Iterable[pd.CategoricalDtype]] = None
-) -> List[pd.DataFrame]:
+) -> list[pd.DataFrame]:
     """
     Given a group of dataframes which contain some categorical columns, for
     each categorical column present, find all the possible categories across

--- a/janitor/utils.py
+++ b/janitor/utils.py
@@ -1,11 +1,12 @@
 """Miscellaneous internal PyJanitor helper functions."""
 
+from __future__ import annotations
 import os
 import socket
 import sys
 from warnings import warn
 from functools import singledispatch, wraps
-from typing import Callable, Dict, Iterable, Union
+from typing import Callable, Dict, Iterable
 
 import numpy as np
 import pandas as pd
@@ -348,7 +349,7 @@ def rename_kwargs(func_name: str, kwargs: Dict, aliases: Dict):
 
 
 def check_column(
-    df: pd.DataFrame, column_names: Union[Iterable, str], present: bool = True
+    df: pd.DataFrame, column_names: Iterable | str, present: bool = True
 ):
     """
     One-liner syntactic sugar for checking the presence or absence

--- a/mkdocs/devguide.md
+++ b/mkdocs/devguide.md
@@ -228,7 +228,7 @@ can help you with reviewing the code checks.
 
 ## Code Compatibility
 
-pyjanitor supports Python 3.8+,
+pyjanitor supports Python 3.9+,
 so all contributed code must maintain this compatibility.
 
 ## Tips

--- a/mkdocs/devguide.md
+++ b/mkdocs/devguide.md
@@ -228,7 +228,7 @@ can help you with reviewing the code checks.
 
 ## Code Compatibility
 
-pyjanitor supports Python 3.6+,
+pyjanitor supports Python 3.8+,
 so all contributed code must maintain this compatibility.
 
 ## Tips

--- a/mkdocs/index.md
+++ b/mkdocs/index.md
@@ -177,7 +177,7 @@ conda install pyjanitor -c conda-forge
 pipenv install --pre pyjanitor
 ```
 
-`pyjanitor` requires Python 3.6+.
+`pyjanitor` requires Python 3.8+.
 
 ## Functionality
 

--- a/mkdocs/index.md
+++ b/mkdocs/index.md
@@ -177,7 +177,7 @@ conda install pyjanitor -c conda-forge
 pipenv install --pre pyjanitor
 ```
 
-`pyjanitor` requires Python 3.8+.
+`pyjanitor` requires Python 3.9+.
 
 ## Functionality
 

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ setup(
     packages=find_packages(),
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRA_REQUIRES,
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     long_description=generate_long_description(),
     long_description_content_type="text/x-rst",
 )

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ setup(
     packages=find_packages(),
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRA_REQUIRES,
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     long_description=generate_long_description(),
     long_description_content_type="text/x-rst",
 )

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ setup(
     packages=find_packages(),
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRA_REQUIRES,
-    python_requires=">=3.9",
+    python_requires=">=3.8",
     long_description=generate_long_description(),
     long_description_content_type="text/x-rst",
 )


### PR DESCRIPTION
This PR updates our minimum Python version to be 3.9.

Key changes:

- We matrix Python version testing across 3.9, and 3.10 (current stable version and two before).
- We note everywhere relevant that the minimum Python version should be 3.9.