### PR TITLE
[ENH] Numba support for multiple non-equi joins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 -   [INF] Set independent environment for building documentation. PR #1141 @Zeroto521
 -   [DOC] Add local documentation preview via github action artifact. PR #1149 @Zeroto521
 -   [ENH] Enable `encode_categorical` handle 2 (or more ) dimensions array. PR #1153 @Zeroto521
--   [ENH] Faster computation for a single non-equi join, with a numba engine. Issue #1102 @samukweku
+-   [ENH] Faster computation for non-equi joins, with a numba engine. Issue #1102 @samukweku
 
 ## [v0.23.1] - 2022-05-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 -   [DOC] Add local documentation preview via github action artifact. PR #1149 @Zeroto521
 -   [ENH] Enable `encode_categorical` handle 2 (or more ) dimensions array. PR #1153 @Zeroto521
 -   [INF] Cancel old workflow runs via Github Action `concurrency`. PR #1161 @Zeroto521
--   [ENH] Faster computation for a single non-equi join, with a numba engine. Issue #1102 @samukweku
+-   [ENH] Faster computation for non-equi join, with a numba engine. Issue #1102 @samukweku
 
 ## [v0.23.1] - 2022-05-03
 

--- a/janitor/functions/_numba.py
+++ b/janitor/functions/_numba.py
@@ -174,6 +174,7 @@ def _numba_pair_le_lt(df: pd.DataFrame, right: pd.DataFrame, pair: list):
     # there is no point searching within that space
     max_arr = np.maximum.accumulate(r_table2[::-1])[::-1]
     bools = l_table2 > max_arr[positions]
+    # there is no match
     if bools.all():
         return None
     if bools.any():
@@ -181,13 +182,9 @@ def _numba_pair_le_lt(df: pd.DataFrame, right: pd.DataFrame, pair: list):
         l_index = l_index[~bools]
         l_table2 = l_table2[~bools]
 
-    out = _get_matching_indices(
+    return _get_matching_indices(
         l_index, l_table2, r_index, r_table2, positions, max_arr
     )
-
-    if out[0] is None:
-        return None
-    return out
 
 
 def _numba_single_join(

--- a/janitor/functions/_numba.py
+++ b/janitor/functions/_numba.py
@@ -45,10 +45,10 @@ def _numba_pair_le_lt(df: pd.DataFrame, right: pd.DataFrame, pair: list):
     # get regions for first and second conditions in the pair
     # (l_col1, r_col1, op1), (l_col2, r_col2, op2)
     # the idea is that r_col1 should always be ahead of the
-    # appropriate valye from lcol1; same applies to l_col2 & r_col2.
+    # appropriate value from lcol1; same applies to l_col2 & r_col2.
     # if the operator is in less than join types
     # the l_col should be in ascending order
-    # if in greater than join types, it should be
+    # if in greater than join types, l_col should be
     # in descending order
     # Example :
     #     df1:
@@ -145,13 +145,13 @@ def _numba_pair_le_lt(df: pd.DataFrame, right: pd.DataFrame, pair: list):
     # pair1 <= pair1 and pair2 <= pair2
     # Starting from the highest region in value_1
     # 5 in pair1 is not less than any in value_2A/2B, so we discard
-    # 4 in pair1 is matched to 4 in pair 1
+    # 4 in pair1 is matched to 4 in pair1 of value_2A/2B
     # we look at the equivalent value in pair2 for 4, which is 2
-    # 2 matches 2 in pair 2, so we have a complete match -> (0, 7)
-    # 3 in pair 1 from value_1 matches 3 and 4 in pair1 for value_2A/2b
+    # 2 matches 2 in pair 2, so we have a match -> (0, 7)
+    # 3 in pair 1 from value_1 matches 3 and 4 in pair1 for value_2A/2B
     # next we compare the equivalent value from pair2, which is 3
-    # 3 matches only 3, so our only match is  -> (4, 5)
-    # next is 2 (we have 3 2s in value_1)
+    # 3 matches only 3 in value_2A/2B, so our only match is  -> (4, 5)
+    # next is 2 (we have 3 2s in value_1 for pair1)
     # they all match 2, 2, 3, 4 in pair1 of value_2A/2B
     # compare the first equivalent in pair2 -> 4
     # 4 matches only 4, 5 in pair2 of value_2A/2B
@@ -170,7 +170,7 @@ def _numba_pair_le_lt(df: pd.DataFrame, right: pd.DataFrame, pair: list):
     #     5              6
     #     1              6
     ########################################################
-    # and if we index the dataframes should give the output below:
+    # and if we index the dataframes, we should get the output below:
     #################################
     #    value_1  value_2A  value_2B
     # 0        2         1         3

--- a/janitor/functions/conditional_join.py
+++ b/janitor/functions/conditional_join.py
@@ -957,7 +957,7 @@ def _multiple_conditional_join_le_lt(
             # finally unionize the outcome of the pairs
             # this only works if there is no null in the != condition
             # thanks to Hypothesis tests for pointing this out
-            (left_on, right_on, op), *conditions = conditions
+            left_on, right_on, op = conditions[0]
             # check for nulls in the patch
             # and follow this path, only if there are no nulls
             if df[left_on].notna().all() & right[right_on].notna().all():
@@ -984,7 +984,9 @@ def _multiple_conditional_join_le_lt(
                 else:
                     indices = zip(*indices)
                     indices = map(np.concatenate, indices)
+                conditions = conditions[1:]
             else:
+                left_on, right_on, op = pairs[0]
                 indices = _generic_func_cond_join(
                     df[left_on],
                     right[right_on],

--- a/janitor/functions/conditional_join.py
+++ b/janitor/functions/conditional_join.py
@@ -49,8 +49,10 @@ def conditional_join(
     Column selection in `df_columns` and `right_columns` is possible using the
     [`select_columns`][janitor.functions.select_columns.select_columns] syntax.
 
-    For possible performance improvement, set `use_numba` to `True`,
-    if `numba` is installed.
+    For strictly non-equi joins,
+    involving either `>`, `<`, `>=`, `<=` operators,
+    performance could be improved by setting `use_numba` to `True`.
+    This assumes that `numba` is installed.
 
     This function returns rows, if any, where values from `df` meet the
     condition(s) for values from `right`. The conditions are passed in
@@ -453,7 +455,6 @@ def _conditional_join_compute(
         return _create_conditional_join_empty_frame(
             df, right, how, df_columns, right_columns
         )
-
     return _create_conditional_join_frame(
         df,
         right,
@@ -982,7 +983,7 @@ def _multiple_conditional_join_le_lt(
             indices = [arr for arr in indices if arr is not None]
             if not indices:
                 indices = None
-            elif indices == 1:
+            elif len(indices) == 1:
                 indices = indices[0]
             else:
                 indices = zip(*indices)

--- a/tests/functions/test_case_when.py
+++ b/tests/functions/test_case_when.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 import pytest
-from hypothesis import assume, given
+from hypothesis import assume, given, settings
 from pandas.testing import assert_frame_equal
 
 from janitor.testing_utils.strategies import (
@@ -75,6 +75,8 @@ def test_default_ndim(df):
         df.case_when(df.a < 10, "less_than_10", df, column_name="a")
 
 
+@pytest.mark.turtle
+@settings(deadline=None)
 @given(df=df_strategy())
 def test_default_length(df):
     """Raise ValueError if `default` length != len(df)."""

--- a/tests/functions/test_conditional_join.py
+++ b/tests/functions/test_conditional_join.py
@@ -2219,38 +2219,6 @@ def test_eq_ge_and_le_numbers(df, right):
     assert_frame_equal(expected, actual)
 
 
-# @pytest.mark.turtle
-# @settings(deadline=None)
-# @given(df=conditional_df(), right=conditional_right())
-# def test_eq_ge_and_le_numbers_numba(df, right):
-#     """Test output for multiple conditions."""
-
-#     columns = ["B", "A", "E", "Floats", "Integers", "Dates"]
-#     expected = (
-#         df.merge(
-#             right, left_on="B", right_on="Floats", how="inner", sort=False
-#         )
-#         .loc[lambda df: df.A.ge(df.Integers) & df.E.le(df.Dates), columns]
-#         .sort_values(columns, ignore_index=True)
-#     )
-
-#     actual = (
-#         df[["B", "A", "E"]]
-#         .conditional_join(
-#             right[["Floats", "Integers", "Dates"]],
-#             ("B", "Floats", "=="),
-#             ("A", "Integers", ">="),
-#             ("E", "Dates", "<="),
-#             use_numba=True,
-#             how="inner",
-#             sort_by_appearance=False,
-#         )
-#         .sort_values(columns, ignore_index=True)
-#     )
-
-#     assert_frame_equal(expected, actual)
-
-
 @pytest.mark.turtle
 @settings(deadline=None)
 @given(df=conditional_df(), right=conditional_right())
@@ -2585,36 +2553,36 @@ def test_ge_eq_and_le_numbers(df, right):
     assert_frame_equal(expected, actual)
 
 
-# @settings(deadline=None)
-# @given(df=conditional_df(), right=conditional_right())
-# @pytest.mark.turtle
-# def test_ge_eq_and_le_numbers_numba(df, right):
-#     """Test output for multiple conditions."""
+@settings(deadline=None)
+@given(df=conditional_df(), right=conditional_right())
+@pytest.mark.turtle
+def test_ge_eq_and_le_numbers_numba(df, right):
+    """Test output for multiple conditions."""
 
-#     columns = ["B", "A", "E", "Floats", "Integers", "Dates"]
-#     expected = (
-#         df.merge(
-#             right, left_on="B", right_on="Floats", how="inner", sort=False
-#         )
-#         .loc[lambda df: df.A.ge(df.Integers) & df.E.le(df.Dates), columns]
-#         .sort_values(columns, ignore_index=True)
-#     )
+    columns = ["B", "A", "E", "Floats", "Integers", "Dates"]
+    expected = (
+        df.merge(
+            right, left_on="B", right_on="Floats", how="inner", sort=False
+        )
+        .loc[lambda df: df.A.ge(df.Integers) & df.E.le(df.Dates), columns]
+        .sort_values(columns, ignore_index=True)
+    )
 
-#     actual = (
-#         df[["B", "A", "E"]]
-#         .conditional_join(
-#             right[["Floats", "Integers", "Dates"]],
-#             ("A", "Integers", ">="),
-#             ("E", "Dates", "<="),
-#             ("B", "Floats", "=="),
-#             how="inner",
-#             use_numba=True,
-#             sort_by_appearance=False,
-#         )
-#         .sort_values(columns, ignore_index=True)
-#     )
-#     actual = actual.filter(columns)
-#     assert_frame_equal(expected, actual)
+    actual = (
+        df[["B", "A", "E"]]
+        .conditional_join(
+            right[["Floats", "Integers", "Dates"]],
+            ("A", "Integers", ">="),
+            ("E", "Dates", "<="),
+            ("B", "Floats", "=="),
+            how="inner",
+            use_numba=True,
+            sort_by_appearance=False,
+        )
+        .sort_values(columns, ignore_index=True)
+    )
+    actual = actual.filter(columns)
+    assert_frame_equal(expected, actual)
 
 
 @pytest.mark.turtle
@@ -2899,52 +2867,6 @@ def test_multiple_eqs(df, right):
 @pytest.mark.turtle
 @settings(deadline=None)
 @given(df=conditional_df(), right=conditional_right())
-def test_multiple_eqs_extension_array(df, right):
-    """Test output for multiple conditions."""
-
-    columns = [
-        "B",
-        "A",
-        "E",
-        "Floats",
-        "Integers",
-        "Dates",
-        "index",
-        "indexer",
-    ]
-    df = df.assign(A=df["A"].astype("Int64"))
-    right = right.assign(Integers=right["Integers"].astype(pd.Int64Dtype()))
-    expected = df.assign(index=df.index).merge(
-        right.assign(indexer=right.index),
-        left_on=["B", "E"],
-        right_on=["Floats", "Dates"],
-        how="inner",
-        sort=False,
-    )
-    expected = (
-        expected.loc[expected.A != expected.Integers, columns]
-        .groupby(["index", "indexer"])
-        .tail(1)
-        .drop(columns=["index", "indexer"])
-        .reset_index(drop=True)
-    )
-
-    actual = df[["B", "A", "E"]].conditional_join(
-        right[["Floats", "Integers", "Dates"]],
-        ("E", "Dates", "=="),
-        ("B", "Floats", "=="),
-        ("A", "Integers", "!="),
-        how="inner",
-        keep="last",
-        sort_by_appearance=False,
-    )
-
-    assert_frame_equal(expected, actual)
-
-
-@pytest.mark.turtle
-@settings(deadline=None)
-@given(df=conditional_df(), right=conditional_right())
 def test_eq_strings(df, right):
     """Test output for joins on strings."""
 
@@ -2991,6 +2913,7 @@ def test_extension_array_eq():
         df2,
         ("id", "id", "=="),
         ("value_1", "value_2A", ">"),
+        use_numba=False,
         sort_by_appearance=False,
     )
     expected = (

--- a/tests/functions/test_conditional_join.py
+++ b/tests/functions/test_conditional_join.py
@@ -1614,6 +1614,34 @@ def test_dual_ne(df, right):
 @pytest.mark.turtle
 @settings(deadline=None)
 @given(df=conditional_df(), right=conditional_right())
+def test_dual_ne_numba_extension(df, right):
+    """
+    Test output for multiple conditions. Extension Arrays. `!=`
+    """
+
+    filters = ["A", "Integers", "B", "Numeric"]
+    df = df.astype({"A": "Int64"})
+    right = right.astype({"Integers": "Int64"})
+    expected = df.merge(right, how="cross")
+    expected = expected.loc[
+        expected.A.ne(expected.Integers) & expected.B.ne(expected.Numeric),
+        filters,
+    ].reset_index(drop=True)
+
+    actual = df.conditional_join(
+        right,
+        ("A", "Integers", "!="),
+        ("B", "Numeric", "!="),
+        how="inner",
+        use_numba=True,
+        sort_by_appearance=True,
+    ).filter(filters)
+    assert_frame_equal(expected, actual)
+
+
+@pytest.mark.turtle
+@settings(deadline=None)
+@given(df=conditional_df(), right=conditional_right())
 def test_dual_ne_dates(df, right):
     """
     Test output for multiple conditions. `!=`
@@ -1634,6 +1662,38 @@ def test_dual_ne_dates(df, right):
             ("A", "Integers", "!="),
             ("E", "Dates", "!="),
             how="inner",
+            sort_by_appearance=False,
+        )
+        .sort_values(filters, ignore_index=True)
+    )
+
+    assert_frame_equal(expected, actual)
+
+
+@pytest.mark.turtle
+@settings(deadline=None)
+@given(df=conditional_df(), right=conditional_right())
+def test_dual_ne_numba_dates(df, right):
+    """
+    Test output for multiple conditions. `!=`
+    """
+
+    filters = ["A", "Integers", "E", "Dates"]
+    expected = (
+        df[["A", "E"]]
+        .merge(right[["Integers", "Dates"]], how="cross")
+        .loc[lambda df: df.A.ne(df.Integers) & df.E.ne(df.Dates)]
+        .sort_values(filters, ignore_index=True)
+    )
+
+    actual = (
+        df[["A", "E"]]
+        .conditional_join(
+            right[["Integers", "Dates"]],
+            ("A", "Integers", "!="),
+            ("E", "Dates", "!="),
+            how="inner",
+            use_numba=True,
             sort_by_appearance=False,
         )
         .sort_values(filters, ignore_index=True)
@@ -1775,6 +1835,43 @@ def test_gt_lt_ne_conditions(df, right):
     assert_frame_equal(expected, actual)
 
 
+@settings(deadline=None)
+@given(df=conditional_df(), right=conditional_right())
+@pytest.mark.turtle
+def test_gt_lt_ne_numba_conditions(df, right):
+    """
+    Test output for multiple conditions.
+    """
+
+    filters = ["A", "B", "E", "Integers", "Numeric", "Dates"]
+    expected = (
+        df[["A", "B", "E"]]
+        .merge(right[["Integers", "Numeric", "Dates"]], how="cross")
+        .loc[
+            lambda df: df.A.gt(df.Integers)
+            & df.B.lt(df.Numeric)
+            & df.E.ne(df.Dates)
+        ]
+        .sort_values(filters, ignore_index=True)
+    )
+
+    actual = (
+        df[["A", "B", "E"]]
+        .conditional_join(
+            right[["Integers", "Numeric", "Dates"]],
+            ("A", "Integers", ">"),
+            ("B", "Numeric", "<"),
+            ("E", "Dates", "!="),
+            how="inner",
+            use_numba=True,
+            sort_by_appearance=False,
+        )
+        .sort_values(filters, ignore_index=True)
+    )
+
+    assert_frame_equal(expected, actual)
+
+
 @pytest.mark.turtle
 @settings(deadline=None)
 @given(df=conditional_df(), right=conditional_right())
@@ -1809,6 +1906,38 @@ def test_gt_ne_conditions(df, right):
 @pytest.mark.turtle
 @settings(deadline=None)
 @given(df=conditional_df(), right=conditional_right())
+def test_gt_ne_numba_conditions(df, right):
+    """
+    Test output for multiple conditions.
+    """
+
+    filters = ["A", "E", "Integers", "Dates"]
+    expected = (
+        df[["A", "E"]]
+        .merge(right[["Integers", "Dates"]], how="cross")
+        .loc[lambda df: df.A.gt(df.Integers) & df.E.ne(df.Dates)]
+        .sort_values(filters, ignore_index=True)
+    )
+
+    actual = (
+        df[["A", "E"]]
+        .conditional_join(
+            right[["Integers", "Dates"]],
+            ("A", "Integers", ">"),
+            ("E", "Dates", "!="),
+            how="inner",
+            use_numba=True,
+            sort_by_appearance=False,
+        )
+        .sort_values(filters, ignore_index=True)
+    )
+
+    assert_frame_equal(expected, actual)
+
+
+@pytest.mark.turtle
+@settings(deadline=None)
+@given(df=conditional_df(), right=conditional_right())
 def test_le_ne_conditions(df, right):
     """
     Test output for multiple conditions.
@@ -1829,6 +1958,38 @@ def test_le_ne_conditions(df, right):
             ("A", "Integers", "<="),
             ("E", "Dates", "!="),
             how="inner",
+            sort_by_appearance=False,
+        )
+        .sort_values(filters, ignore_index=True)
+    )
+
+    assert_frame_equal(expected, actual)
+
+
+@pytest.mark.turtle
+@settings(deadline=None)
+@given(df=conditional_df(), right=conditional_right())
+def test_le_ne_numba_conditions(df, right):
+    """
+    Test output for multiple conditions.
+    """
+
+    filters = ["A", "E", "Integers", "Dates"]
+    expected = (
+        df[["A", "E"]]
+        .merge(right[["Integers", "Dates"]], how="cross")
+        .loc[lambda df: df.A.le(df.Integers) & df.E.ne(df.Dates)]
+        .sort_values(filters, ignore_index=True)
+    )
+
+    actual = (
+        df[["A", "E"]]
+        .conditional_join(
+            right[["Integers", "Dates"]],
+            ("A", "Integers", "<="),
+            ("E", "Dates", "!="),
+            how="inner",
+            use_numba=True,
             sort_by_appearance=False,
         )
         .sort_values(filters, ignore_index=True)
@@ -1910,6 +2071,44 @@ def test_ge_le_ne_extension_array(df, right):
     assert_frame_equal(expected, actual)
 
 
+@settings(deadline=None)
+@given(df=conditional_df(), right=conditional_right())
+@pytest.mark.turtle
+def test_ge_le_ne_extension_array_numba(df, right):
+    """
+    Test output for multiple conditions.
+    """
+
+    filters = ["A", "B", "E", "Integers", "Numeric", "Dates"]
+    df = df.assign(A=df["A"].astype("Int64"))
+    right = right.assign(Integers=right["Integers"].astype(pd.Int64Dtype()))
+
+    expected = df[["A", "B", "E"]].merge(
+        right[["Integers", "Numeric", "Dates"]], how="cross"
+    )
+    expected = expected.loc[
+        expected.A.ne(expected.Integers)
+        & expected.B.lt(expected.Numeric)
+        & expected.E.ge(expected.Dates),
+    ].sort_values(filters, ignore_index=True)
+
+    actual = (
+        df[["A", "B", "E"]]
+        .conditional_join(
+            right[["Integers", "Numeric", "Dates"]],
+            ("E", "Dates", ">="),
+            ("A", "Integers", "!="),
+            ("B", "Numeric", "<"),
+            how="inner",
+            use_numba=True,
+            sort_by_appearance=False,
+        )
+        .sort_values(filters, ignore_index=True)
+    )
+
+    assert_frame_equal(expected, actual)
+
+
 @pytest.mark.turtle
 @settings(deadline=None)
 @given(df=conditional_df(), right=conditional_right())
@@ -1952,6 +2151,46 @@ def test_ge_lt_ne_extension(df, right):
 @pytest.mark.turtle
 @settings(deadline=None)
 @given(df=conditional_df(), right=conditional_right())
+def test_ge_lt_ne_numba_extension(df, right):
+    """
+    Test output for multiple conditions.
+    """
+
+    filters = ["A", "B", "E", "Integers", "Numeric", "Dates", "Dates_Right"]
+    df = df.assign(A=df["A"].astype("Int64"))
+    right = right.assign(Integers=right["Integers"].astype(pd.Int64Dtype()))
+
+    expected = df[["A", "B", "E"]].merge(
+        right[["Integers", "Numeric", "Dates", "Dates_Right"]], how="cross"
+    )
+    expected = expected.loc[
+        expected.A.lt(expected.Integers)
+        & expected.B.ne(expected.Numeric)
+        & expected.E.ge(expected.Dates)
+        & expected.E.ne(expected.Dates_Right),
+    ].sort_values(filters, ignore_index=True)
+
+    actual = (
+        df[["A", "B", "E"]]
+        .conditional_join(
+            right[["Integers", "Numeric", "Dates", "Dates_Right"]],
+            ("E", "Dates", ">="),
+            ("B", "Numeric", "!="),
+            ("A", "Integers", "<"),
+            ("E", "Dates_Right", "!="),
+            how="inner",
+            use_numba=True,
+            sort_by_appearance=False,
+        )
+        .sort_values(filters, ignore_index=True)
+    )
+
+    assert_frame_equal(expected, actual)
+
+
+@pytest.mark.turtle
+@settings(deadline=None)
+@given(df=conditional_df(), right=conditional_right())
 def test_eq_ge_and_le_numbers(df, right):
     """Test output for multiple conditions."""
 
@@ -1972,6 +2211,70 @@ def test_eq_ge_and_le_numbers(df, right):
             ("A", "Integers", ">="),
             ("E", "Dates", "<="),
             how="inner",
+            sort_by_appearance=False,
+        )
+        .sort_values(columns, ignore_index=True)
+    )
+
+    assert_frame_equal(expected, actual)
+
+
+# @pytest.mark.turtle
+# @settings(deadline=None)
+# @given(df=conditional_df(), right=conditional_right())
+# def test_eq_ge_and_le_numbers_numba(df, right):
+#     """Test output for multiple conditions."""
+
+#     columns = ["B", "A", "E", "Floats", "Integers", "Dates"]
+#     expected = (
+#         df.merge(
+#             right, left_on="B", right_on="Floats", how="inner", sort=False
+#         )
+#         .loc[lambda df: df.A.ge(df.Integers) & df.E.le(df.Dates), columns]
+#         .sort_values(columns, ignore_index=True)
+#     )
+
+#     actual = (
+#         df[["B", "A", "E"]]
+#         .conditional_join(
+#             right[["Floats", "Integers", "Dates"]],
+#             ("B", "Floats", "=="),
+#             ("A", "Integers", ">="),
+#             ("E", "Dates", "<="),
+#             use_numba=True,
+#             how="inner",
+#             sort_by_appearance=False,
+#         )
+#         .sort_values(columns, ignore_index=True)
+#     )
+
+#     assert_frame_equal(expected, actual)
+
+
+@pytest.mark.turtle
+@settings(deadline=None)
+@given(df=conditional_df(), right=conditional_right())
+def test_dual_ge_and_le_diff_numbers_numba(df, right):
+    """Test output for multiple conditions."""
+
+    columns = ["A", "E", "Integers", "Dates"]
+    expected = (
+        df.merge(
+            right,
+            how="cross",
+        )
+        .loc[lambda df: df.A.le(df.Integers) & df.E.gt(df.Dates), columns]
+        .sort_values(columns, ignore_index=True)
+    )
+
+    actual = (
+        df[["A", "E"]]
+        .conditional_join(
+            right[["Integers", "Dates"]],
+            ("A", "Integers", "<="),
+            ("E", "Dates", ">"),
+            how="inner",
+            use_numba=True,
             sort_by_appearance=False,
         )
         .sort_values(columns, ignore_index=True)
@@ -2051,6 +2354,44 @@ def test_ge_lt_ne_extension_variant(df, right):
 @pytest.mark.turtle
 @settings(deadline=None)
 @given(df=conditional_df(), right=conditional_right())
+def test_ge_lt_ne_extension_variant_numba(df, right):
+    """
+    Test output for multiple conditions.
+    """
+
+    filters = ["A", "Integers", "B", "Numeric", "E", "Dates", "Dates_Right"]
+    df = df.assign(A=df["A"].astype("Int64"))
+    right = right.assign(Integers=right["Integers"].astype(pd.Int64Dtype()))
+
+    expected = df.merge(right, how="cross")
+    expected = expected.loc[
+        expected.A.ne(expected.Integers)
+        & expected.B.lt(expected.Numeric)
+        & expected.E.ge(expected.Dates)
+        & expected.E.ne(expected.Dates_Right),
+        filters,
+    ].sort_values(filters, ignore_index=True)
+
+    actual = (
+        df.conditional_join(
+            right,
+            ("E", "Dates", ">="),
+            ("B", "Numeric", "<"),
+            ("A", "Integers", "!="),
+            ("E", "Dates_Right", "!="),
+            how="inner",
+            use_numba=True,
+            sort_by_appearance=False,
+        )
+        .filter(filters)
+        .sort_values(filters, ignore_index=True)
+    )
+    assert_frame_equal(expected, actual)
+
+
+@pytest.mark.turtle
+@settings(deadline=None)
+@given(df=conditional_df(), right=conditional_right())
 def test_ge_eq_and_le_numbers_variant(df, right):
     """Test output for multiple conditions."""
 
@@ -2114,6 +2455,42 @@ def test_multiple_eqs_variant(df, right):
     assert_frame_equal(expected, actual)
 
 
+@settings(deadline=None)
+@given(df=conditional_df(), right=conditional_right())
+@pytest.mark.turtle
+def test_multiple_eqs_variant_numba(df, right):
+    """Test output for multiple conditions."""
+
+    columns = ["B", "A", "E", "Floats", "Integers", "Dates"]
+    expected = (
+        df.merge(
+            right,
+            left_on=["B", "A"],
+            right_on=["Floats", "Integers"],
+            how="inner",
+            sort=False,
+        )
+        .loc[lambda df: df.E.ne(df.Dates), columns]
+        .sort_values(columns, ignore_index=True)
+    )
+
+    actual = (
+        df[["B", "A", "E"]]
+        .conditional_join(
+            right[["Floats", "Integers", "Dates"]],
+            ("E", "Dates", "!="),
+            ("B", "Floats", "=="),
+            ("A", "Integers", "=="),
+            how="inner",
+            use_numba=True,
+            sort_by_appearance=False,
+        )
+        .sort_values(columns, ignore_index=True)
+    )
+
+    assert_frame_equal(expected, actual)
+
+
 @pytest.mark.turtle
 @settings(deadline=None)
 @given(df=conditional_df(), right=conditional_right())
@@ -2137,6 +2514,38 @@ def test_dual_ge_and_le_range_numbers(df, right):
             ("E", "Dates", "<"),
             ("A", "Integers", ">="),
             how="inner",
+            sort_by_appearance=False,
+        )
+        .sort_values(columns, ignore_index=True)
+    )
+
+    assert_frame_equal(expected, actual)
+
+
+@pytest.mark.turtle
+@settings(deadline=None)
+@given(df=conditional_df(), right=conditional_right())
+def test_dual_ge_and_le_range_numbers_numba(df, right):
+    """Test output for multiple conditions."""
+
+    columns = ["A", "E", "Integers", "Dates"]
+    expected = (
+        df.merge(
+            right,
+            how="cross",
+        )
+        .loc[lambda df: df.A.ge(df.Integers) & df.E.lt(df.Dates), columns]
+        .sort_values(columns, ignore_index=True)
+    )
+
+    actual = (
+        df[["A", "E"]]
+        .conditional_join(
+            right[["Integers", "Dates"]],
+            ("E", "Dates", "<"),
+            ("A", "Integers", ">="),
+            how="inner",
+            use_numba=True,
             sort_by_appearance=False,
         )
         .sort_values(columns, ignore_index=True)
@@ -2174,6 +2583,38 @@ def test_ge_eq_and_le_numbers(df, right):
     )
     actual = actual.filter(columns)
     assert_frame_equal(expected, actual)
+
+
+# @settings(deadline=None)
+# @given(df=conditional_df(), right=conditional_right())
+# @pytest.mark.turtle
+# def test_ge_eq_and_le_numbers_numba(df, right):
+#     """Test output for multiple conditions."""
+
+#     columns = ["B", "A", "E", "Floats", "Integers", "Dates"]
+#     expected = (
+#         df.merge(
+#             right, left_on="B", right_on="Floats", how="inner", sort=False
+#         )
+#         .loc[lambda df: df.A.ge(df.Integers) & df.E.le(df.Dates), columns]
+#         .sort_values(columns, ignore_index=True)
+#     )
+
+#     actual = (
+#         df[["B", "A", "E"]]
+#         .conditional_join(
+#             right[["Floats", "Integers", "Dates"]],
+#             ("A", "Integers", ">="),
+#             ("E", "Dates", "<="),
+#             ("B", "Floats", "=="),
+#             how="inner",
+#             use_numba=True,
+#             sort_by_appearance=False,
+#         )
+#         .sort_values(columns, ignore_index=True)
+#     )
+#     actual = actual.filter(columns)
+#     assert_frame_equal(expected, actual)
 
 
 @pytest.mark.turtle
@@ -2296,6 +2737,49 @@ def test_multiple_non_eqi(df, right):
 @pytest.mark.turtle
 @settings(deadline=None)
 @given(df=conditional_df(), right=conditional_right())
+def test_multiple_non_eqi_numba(df, right):
+    """Test output for multiple conditions."""
+
+    columns = ["B", "A", "E", "Floats", "Integers", "Dates"]
+    expected = (
+        df.merge(
+            right,
+            how="cross",
+        )
+        .loc[
+            lambda df: df.A.ge(df.Integers)
+            & df.E.gt(df.Dates)
+            & df.B.gt(df.Floats)
+        ]
+        .sort_values(columns, ignore_index=True)
+        .filter(columns)
+        .rename(columns={"B": "b", "Floats": "floats"})
+    )
+
+    actual = df.conditional_join(
+        right,
+        ("A", "Integers", ">="),
+        ("E", "Dates", ">"),
+        ("B", "Floats", ">"),
+        how="inner",
+        use_numba=True,
+        sort_by_appearance=False,
+        df_columns={"B": "b", "A": "A", "E": "E"},
+        right_columns={
+            "Floats": "floats",
+            "Integers": "Integers",
+            "Dates": "Dates",
+        },
+    ).sort_values(
+        ["b", "A", "E", "floats", "Integers", "Dates"], ignore_index=True
+    )
+
+    assert_frame_equal(expected, actual)
+
+
+@pytest.mark.turtle
+@settings(deadline=None)
+@given(df=conditional_df(), right=conditional_right())
 def test_multiple_non_eq(df, right):
     """Test output for multiple conditions."""
 
@@ -2325,6 +2809,53 @@ def test_multiple_non_eq(df, right):
         how="inner",
         keep="first",
         sort_by_appearance=False,
+    )
+
+    assert_frame_equal(expected, actual)
+
+
+@pytest.mark.turtle
+@settings(deadline=None)
+@given(df=conditional_df(), right=conditional_right())
+def test_multiple_non_eq_numba(df, right):
+    """Test output for multiple conditions."""
+
+    expected = (
+        df[["B", "A", "E"]]
+        .assign(index=df.index)
+        .merge(
+            right[["Floats", "Integers", "Dates"]],
+            how="cross",
+        )
+        .loc[
+            lambda df: df.B.le(df.Floats)
+            & df.A.lt(df.Integers)
+            & df.E.lt(df.Dates)
+        ]
+        .groupby("index")
+        .head(1)
+        .drop(columns="index")
+        .reset_index(drop=True)
+        .sort_values(
+            ["B", "A", "E", "Floats", "Integers", "Dates"], ignore_index=True
+        )
+    )
+
+    actual = (
+        df[["B", "A", "E"]]
+        .conditional_join(
+            right[["Floats", "Integers", "Dates"]],
+            ("B", "Floats", "<="),
+            ("A", "Integers", "<"),
+            ("E", "Dates", "<"),
+            how="inner",
+            keep="first",
+            use_numba=True,
+            sort_by_appearance=False,
+        )
+        .sort_values(
+            ["B", "A", "E", "Floats", "Integers", "Dates"], ignore_index=True
+        )
     )
 
     assert_frame_equal(expected, actual)


### PR DESCRIPTION
# PR Description

Please describe the changes proposed in the pull request:

- Numba implementation for multiple non-equi joins
- Much faster than the existing `_range_indices` implementation (which is limited to range joins)

### Speed Tests 
Disclaimer: take with a pinch of salt ... YMMV

data taken from [DuckDB](https://github.com/duckdb/duckdb/blob/master/benchmark/micro/join/iejoin_events.benchmark), which was referenced in this [DuckDB article](https://duckdb.org/2022/05/27/iejoin.html#simple-measurements)

```py
In [14]: events = pd.read_csv('https://github.com/samukweku/data-wrangling-blog/raw/master/_notebooks/Data_files/results.csv', parse_dates=['start', 'end'])

In [15]: events = events.iloc[:, 1:]

In [25]: (events
    ...: .conditional_join(
    ...:     events,
    ...:     ('start', 'end', '<='),
    ...:     ('end', 'start', '>='),
    ...:     ('id', 'id', '!='),
    ...:     df_columns='id',
    ...:     right_columns='id',
    ...:     use_numba=False)
    ...: )
Out[25]:
       left  right
         id     id
0        10   2345
1        15  11178
2        17  19605
3        26   8218
4        35   6916
...     ...    ...
3697  29966  29375
3698  29971  24173
3699  29978    981
3700  29984  19051
3701  29995  12296

[3702 rows x 2 columns]

In [26]: %%timeit
    ...: (events
    ...: .conditional_join(
    ...:     events,
    ...:     ('start', 'end', '<='),
    ...:     ('end', 'start', '>='),
    ...:     ('id', 'id', '!='),
    ...:     df_columns='id',
    ...:     right_columns='id',
    ...:     use_numba=False)
    ...: )
    ...:
    ...:
1.55 s ± 67.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [27]: %%timeit
    ...: (events
    ...: .conditional_join(
    ...:     events,
    ...:     ('start', 'end', '<='),
    ...:     ('end', 'start', '>='),
    ...:     ('id', 'id', '!='),
    ...:     df_columns='id',
    ...:     right_columns='id',
    ...:     use_numba=True)
    ...: )
    ...:
    ...:
21.1 ms ± 245 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [28]: (events
    ...: .conditional_join(
    ...:     events,
    ...:     ('start', 'end', '<='),
    ...:     ('end', 'start', '>='),
    ...:     ('id', 'id', '!='),
    ...:     df_columns='id',
    ...:     right_columns='id',
    ...:     use_numba=True)
    ...: )
Out[28]:
       left  right
         id     id
0     23159  16937
1     16937  23159
2      2803  28422
3     28422   2803
4      4275   8446
...     ...    ...
3697  29901   6562
3698   4041  17095
3699  17095   4041
3700  12631  22787
3701  22787  12631

[3702 rows x 2 columns]
```
DuckDB output and timings
```py
In [29]: duckdb.query("""select r.id, s.id
    ...:                 from events r
    ...:                 join events s
    ...:                 on r.start <= s.end
    ...:                 and r.end >= s.start
    ...:                 and r.id != s.id""").df()
Out[29]:
         id   id_2
0     12631  22787
1     22787  12631
2      4041  17095
3     17095   4041
4      6562  29901
...     ...    ...
3697   8446   4275
3698  28422   2803
3699   2803  28422
3700  16937  23159
3701  23159  16937

[3702 rows x 2 columns]

# relatively slow when materialised into a pandas dataframe
In [30]: %%timeit
    ...: duckdb.query("""select r.id, s.id
    ...:                 from events r
    ...:                 join events s
    ...:                 on r.start <= s.end
    ...:                 and r.end >= s.start
    ...:                 and r.id != s.id""").df()
    ...:
27.4 ms ± 1.67 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

# very fast engine
# significantly faster when not materialised into pandas
In [31]: %%timeit
    ...: duckdb.query("""select r.id, s.id
    ...:                 from events r
    ...:                 join events s
    ...:                 on r.start <= s.end
    ...:                 and r.end >= s.start
    ...:                 and r.id != s.id""")
    ...:
1.54 ms ± 127 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

Another test on a 10 million row; data also from [DuckDB](https://github.com/duckdb/duckdb/blob/master/benchmark/micro/join/iejoin_employees.benchmark)

DuckDB output and timings
```py
In [33]: employees = pd.read_csv('/Users/samuel.oranyeli/pyjanitor/employees.csv')

In [42]: employees.shape
Out[42]: (9999999, 5)

# speed super fast when not materialised
In [35]: %%timeit
    ...: duckdb.query("""SELECT
    ...:     r.id,
    ...:     s.id
    ...: FROM employees r
    ...: JOIN employees s
    ...:     ON r.salary < s.salary
    ...:     AND r.tax > s.tax;""")
    ...:
1.06 ms ± 23.2 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [36]: %%timeit
    ...: duckdb.query("""SELECT
    ...:     r.id,
    ...:     s.id
    ...: FROM employees r
    ...: JOIN employees s
    ...:     ON r.salary < s.salary
    ...:     AND r.tax > s.tax;""").df()
    ...:
43.2 s ± 859 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [41]: duckdb.query("""SELECT COUNT(*) FROM (
    ...: ^ISELECT r.id, s.id
    ...: ^IFROM employees r, employees s
    ...: ^IWHERE r.salary < s.salary AND r.tax > s.tax
    ...: ) q1;""")
Out[41]:
---------------------
--- Relation Tree ---
---------------------
Subquery

---------------------
-- Result Columns  --
---------------------
- count_star() (BIGINT)

---------------------
-- Result Preview  --
---------------------
count_star()
BIGINT
[ Rows: 1]
98805
```

Output for this PR, when numba is used:

```py
In [38]: (employees
    ...: .conditional_join(
    ...:     employees,
    ...:     ('salary', 'salary', '<'),
    ...:     ('tax', 'tax', '>'),
    ...:     df_columns='id',
    ...:     right_columns='id',
    ...:     use_numba=True)
    ...: )
Out[38]:
          left    right
            id       id
0           39       40
1           95       96
2          294      295
3          319      320
4          478      479
...        ...      ...
98800  9999250  9999251
98801  9999256  9999257
98802  9999437  9999438
98803  9999439  9999440
98804  9999733  9999734

[98805 rows x 2 columns]

In [39]: %%timeit
    ...: (employees
    ...: .conditional_join(
    ...:     employees,
    ...:     ('salary', 'salary', '<'),
    ...:     ('tax', 'tax', '>'),
    ...:     df_columns='id',
    ...:     right_columns='id',
    ...:     use_numba=True)
    ...: )
    ...:
    ...:
4.97 s ± 176 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```


Machine specs on which the tests were run:
```py
  Model Name:	MacBook Pro
  Processor Name:	6-Core Intel Core i7
  Processor Speed:	2.6 GHz
  Number of Processors:	1
  Total Number of Cores:	6
  L2 Cache (per Core):	256 KB
  L3 Cache:	12 MB
  Hyper-Threading Technology:	Enabled
  Memory:	16 GB
```


**This PR relates to #1102.**

<!-- As you go down the PR template, please feel free to delete sections that are irrelevant. -->

# PR Checklist

<!-- This checklist exists for newcomers who are not yet familiar with our requirements. If you are experienced with
the project, please feel free to delete this section. -->

Please ensure that you have done the following:

1. [ ] PR in from a fork off your branch. Do not PR from `<your_username>`:`dev`, but rather from `<your_username>`:`<feature-branch_name>`.
<!-- Doing this helps us keep the commit history much cleaner than it would otherwise be. -->
2. [ ] If you're not on the contributors list, add yourself to `AUTHORS.md`.
<!-- We'd like to acknowledge your contributions! -->
3. [ ] Add a line to `CHANGELOG.md` under the latest version header (i.e. the one that is "on deck") describing the contribution.
    - Do use some discretion here; if there are multiple PRs that are related, keep them in a single line.

# Automatic checks

There will be automatic checks run on the PR. These include:

- Building a preview of the docs on Netlify
- Automatically linting the code
- Making sure the code is documented
- Making sure that all tests are passed
- Making sure that code coverage doesn't go down.

# Relevant Reviewers

<!-- Finally, please tag relevant maintainers to review. -->

Please tag maintainers to review.

- @ericmjl
