### PR TITLE
[ENH] fill_direction

### DIFF
--- a/janitor/functions/fill.py
+++ b/janitor/functions/fill.py
@@ -65,7 +65,7 @@ def fill_direction(df: pd.DataFrame, **kwargs) -> pd.DataFrame:
 
     fill_types = {fill.name for fill in _FILLTYPE}
     for column_name, fill_type in kwargs.items():
-        check("column_name", column_name, [str])
+        check("column_name", column_name, [Hashable])
         check("fill_type", fill_type, [str])
         if fill_type.upper() not in fill_types:
             raise ValueError(
@@ -79,9 +79,9 @@ def fill_direction(df: pd.DataFrame, **kwargs) -> pd.DataFrame:
 
     new_values = {}
     for column_name, fill_type in kwargs.items():
-        direction = _FILLTYPE[f"{fill_type.upper()}"].value
-        if len(direction) == 1:
-            direction = methodcaller(direction[0])
+        direction = _FILLTYPE[fill_type.upper()].value
+        if isinstance(direction, str):
+            direction = methodcaller(direction)
             output = direction(df[column_name])
         else:
             direction = [methodcaller(entry) for entry in direction]
@@ -106,8 +106,8 @@ def _chain_func(column: pd.Series, *funcs):
 class _FILLTYPE(Enum):
     """List of fill types for fill_direction."""
 
-    UP = ("bfill",)
-    DOWN = ("ffill",)
+    UP = "bfill"
+    DOWN = "ffill"
     UPDOWN = "bfill", "ffill"
     DOWNUP = "ffill", "bfill"
 

--- a/tests/functions/test_fill_direction.py
+++ b/tests/functions/test_fill_direction.py
@@ -167,3 +167,36 @@ def test_wrong_type_limit(df):
 def test_empty_directions(df):
     """Return dataframe if `directions` is empty."""
     assert_frame_equal(df.fill_direction(), df)
+
+
+def test_tuple_wrong_length(df):
+    """Raise ValueError if value for kwarg is a tuple and not of length 2."""
+    with pytest.raises(ValueError):
+        df.fill_direction(pet_type=("up",))
+
+
+def test_tuple_second_argument(df):
+    """
+    Raise TypeError if the second argument "
+    in the tuple is not a dictionary.
+    """
+    with pytest.raises(TypeError):
+        df.fill_direction(pet_type=("up", "not a dict"))
+
+
+def test_tuple_second_argument_inplace_present(df):
+    """
+    Raise TypeError if the second argument in the tuple
+    is a dictionary and has inplace as one of its keys.
+    """
+    with pytest.raises(
+        ValueError, match="inplace is not accepted as a keyword argument"
+    ):
+        df.fill_direction(pet_type=("up", {"inplace": "not accepted"}))
+
+
+def test_extra_arguments(df):
+    """Test output for keyword arguments"""
+    actual = df.fill_direction(pet_type=("down", {"limit": 3}))
+    expected = df.assign(pet_type=df.pet_type.ffill(limit=3))
+    assert_frame_equal(actual, expected)


### PR DESCRIPTION
Updates to `fill_direction`
- allow a hashable for the column name
- allow extra keyword arguments to be passed to `ffill` or `bfill`

Please tag maintainers to review.

- @ericmjl
