### PR TITLE
[ENH] `pivot_longer` - named groups in regex and dictionary support 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 -   [INF] Extract docstrings tests from all tests. PR #1205 @Zeroto521
 -   [BUG] address the `TypeError` when importing v0.24.0 (issue #1201 @xujiboy and @joranbeasley)
 -   [INF] Fixed issue with missing PyPI README. PR #1216 @thatlittleboy
--   [ENH] `pivot_longer` now supports named groups where `names_pattern` is a string or regular expression. A dictionary can be passed to `names_pattern`, and is internally evaluated as a list/tuple of regular expressions. Issue #1209 @samukweku
+-   [ENH] `pivot_longer` now supports named groups where `names_pattern` is a string or regular expression. A dictionary can now be passed to `names_pattern`, and is internally evaluated as a list/tuple of regular expressions. Issue #1209 @samukweku
 
 
 ## [v0.24.0] - 2022-11-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 -   [INF] Extract docstrings tests from all tests. PR #1205 @Zeroto521
 -   [BUG] address the `TypeError` when importing v0.24.0 (issue #1201 @xujiboy and @joranbeasley)
 -   [INF] Fixed issue with missing PyPI README. PR #1216 @thatlittleboy
--   [ENH] `pivot_longer` now supports named groups where `names_pattern` is a string or regular expression. A dictionary can now be passed to `names_pattern`, and is internally evaluated as a list/tuple of regular expressions. Issue #1209 @samukweku
+-   [ENH] `pivot_longer` now supports named groups where `names_pattern` is a regular expression. A dictionary can now be passed to `names_pattern`, and is internally evaluated as a list/tuple of regular expressions. Issue #1209 @samukweku
 
 
 ## [v0.24.0] - 2022-11-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 -   [INF] Extract docstrings tests from all tests. PR #1205 @Zeroto521
 -   [BUG] address the `TypeError` when importing v0.24.0 (issue #1201 @xujiboy and @joranbeasley)
 -   [INF] Fixed issue with missing PyPI README. PR #1216 @thatlittleboy
--   [ENH] `pivot_longer` now supports named groups where `names_pattern` is a string or regular expression. Issue #1209 @samukweku
+-   [ENH] `pivot_longer` now supports named groups where `names_pattern` is a string or regular expression. A dictionary can be passed to `names_pattern`, and is internally evaluated as a list/tuple of regular expressions. Issue #1209 @samukweku
 
 
 ## [v0.24.0] - 2022-11-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 -   [INF] Extract docstrings tests from all tests. PR #1205 @Zeroto521
 -   [BUG] address the `TypeError` when importing v0.24.0 (issue #1201 @xujiboy and @joranbeasley)
 -   [INF] Fixed issue with missing PyPI README. PR #1216 @thatlittleboy
+-   [ENH] `pivot_longer` now supports named groups where `names_pattern` is a string or regular expression. Issue #1209 @samukweku
+
 
 ## [v0.24.0] - 2022-11-12
 

--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -135,12 +135,12 @@ def pivot_longer(
     Split the column labels for the above dataframe using named groups in `names_pattern`:
 
         >>> df.pivot_longer(
-            ...     index = 'id',
-            ...     names_pattern = r"new_?(?P<diagnosis>.+)_(?P<gender>.)(?P<age>\\d+)",
-            ... )
-               id diagnosis gender   age  value
-            0   1        sp      m  5564      2
-            1   1       rel      f    65      3
+        ...     index = 'id',
+        ...     names_pattern = r"new_?(?P<diagnosis>.+)_(?P<gender>.)(?P<age>\\d+)",
+        ... )
+            id diagnosis gender   age  value
+        0   1        sp      m  5564      2
+        1   1       rel      f    65      3
 
     Convert the dtypes of specific columns with `names_transform`:
 

--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -261,7 +261,7 @@ def pivot_longer(
         ...         column_names=slice("Mango", "Vodka"),
         ...         names_to=("Fruit", "Drink"),
         ...         values_to=("Pounds", "Ounces"),
-        ...         names_pattern=[r"M|O|W", r"G|V"],
+        ...         names_pattern=["M|O|W", "G|V"],
         ...     )
               City    State       Fruit  Pounds  Drink  Ounces
         0  Houston    Texas       Mango       4    Gin    16.0
@@ -280,8 +280,8 @@ def pivot_longer(
         ...     index=["City", "State"],
         ...     column_names=slice("Mango", "Vodka"),
         ...     names_pattern={
-        ...        "Fruit": {"Pounds": r"M|O|W"},
-        ...        "Drink": {"Fruit": r"G|V"},
+        ...        "Fruit": {"Pounds": "M|O|W"},
+        ...        "Drink": {"Ounces": "G|V"},
         ...    },
         ...     )
               City    State       Fruit  Pounds  Drink  Ounces

--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -183,6 +183,16 @@ def pivot_longer(
         0    50    1      10      30
         1    50    2      20      40
 
+    Replicate the above with named groups in `names_pattern`:
+
+        >>> df.pivot_longer(
+        ...     index="unit",
+        ...     names_pattern=r"(?P<_>x|y)_(?P<time>[0-9])(?P<__>_mean)",
+        ... )
+           unit time  x_mean  y_mean
+        0    50    1      10      30
+        1    50    2      20      40
+
     Multiple values_to:
 
         >>> df = pd.DataFrame(
@@ -490,7 +500,11 @@ def _data_checks_pivot_longer(
             regex = re.compile(names_pattern)
             if names_to is None:
                 if regex.groupindex:
-                    names_to = list(regex.groupindex.keys())
+                    names_to = regex.groupindex.keys()
+                    names_to = [
+                        ".value" if "".join(set(name)) == "_" else name
+                        for name in names_to
+                    ]
                     len_names_to = len(names_to)
                 else:
                     raise ValueError("Kindly provide values for names_to.")

--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -300,6 +300,12 @@ def pivot_longer(
         - 0.24.0
             - Added `dropna` parameter.
 
+    !!! abstract "Version Added"
+
+        - 0.24.1
+            - `names_pattern` can accept a dictionary.
+            - named groups supported in `names_pattern`.
+
 
     :param df: A pandas DataFrame.
     :param index: Name(s) of columns to use as identifier variables.

--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -576,7 +576,7 @@ def _data_checks_pivot_longer(
                     names_to = regex.groupindex.keys()
                     names_to = [
                         ".value"
-                        if "_" in name and len(set(name)) == 1
+                        if ("_" in name) and (len(set(name)) == 1)
                         else name
                         for name in names_to
                     ]

--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -280,10 +280,10 @@ def pivot_longer(
         ...     index=["City", "State"],
         ...     column_names=slice("Mango", "Vodka"),
         ...     names_pattern={
-        ...        "Fruit": {"Pounds": "M|O|W"},
-        ...        "Drink": {"Ounces": "G|V"},
-        ...    },
-        ...     )
+        ...         "Fruit": {"Pounds": "M|O|W"},
+        ...         "Drink": {"Ounces": "G|V"},
+        ...     },
+        ... )
               City    State       Fruit  Pounds  Drink  Ounces
         0  Houston    Texas       Mango       4    Gin    16.0
         1   Austin    Texas       Mango      10    Gin   200.0
@@ -299,9 +299,6 @@ def pivot_longer(
 
         - 0.24.0
             - Added `dropna` parameter.
-
-    !!! abstract "Version Added"
-
         - 0.24.1
             - `names_pattern` can accept a dictionary.
             - named groups supported in `names_pattern`.

--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -279,7 +279,10 @@ def pivot_longer(
         >>> df.pivot_longer(
         ...     index=["City", "State"],
         ...     column_names=slice("Mango", "Vodka"),
-        ...     names_pattern={"Fruit":{"Pounds":r"M|O|W"}, "Drink":{"Ounces":r"G|V"}},
+        ...     names_pattern={
+        ...        "Fruit": {"Pounds": r"M|O|W"},
+        ...        "Drink": {"Fruit": r"G|V"},
+        ...    },
         ...     )
               City    State       Fruit  Pounds  Drink  Ounces
         0  Houston    Texas       Mango       4    Gin    16.0

--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -575,7 +575,9 @@ def _data_checks_pivot_longer(
                 if regex.groupindex:
                     names_to = regex.groupindex.keys()
                     names_to = [
-                        ".value" if "".join(set(name)) == "_" else name
+                        ".value"
+                        if "_" in name and len(set(name)) == 1
+                        else name
                         for name in names_to
                     ]
                     len_names_to = len(names_to)

--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -183,7 +183,7 @@ def pivot_longer(
         0    50    1      10      30
         1    50    2      20      40
 
-    Replicate the above with named groups in `names_pattern`:
+    Replicate the above with named groups in `names_pattern` - use `_` instead of `.value`:
 
         >>> df.pivot_longer(
         ...     index="unit",
@@ -281,6 +281,10 @@ def pivot_longer(
         the same specification as pandas' `str.extract` method), or a
         list/tuple of regular expressions. If it is a single regex, the
         number of groups must match the length of `names_to`.
+        Named groups are supported, if `names_to` is none. `_` is used
+        instead of `.value` if part of the column name is to be retained
+        as a header in the new dataframe. `_` can be overloaded for
+        multiple `.value` calls - `_`, `__`, `___`, ...
         For a list/tuple of regular expressions,
         `names_to` must also be a list/tuple and the lengths of both
         arguments must match.

--- a/tests/functions/test_pivot_longer.py
+++ b/tests/functions/test_pivot_longer.py
@@ -105,6 +105,12 @@ def test_name_pattern_no_names_to(df_checks):
         df_checks.pivot_longer(names_to=None, names_pattern="(.+)(.)")
 
 
+def test_name_pattern_seq_no_names_to(df_checks):
+    """Raise ValueError if names_pattern is a sequence and names_to is None."""
+    with pytest.raises(ValueError):
+        df_checks.pivot_longer(names_to=None, names_pattern=[".{2}", "\\d"])
+
+
 def test_name_pattern_groups_len(df_checks):
     """
     Raise ValueError if names_pattern
@@ -854,6 +860,33 @@ def test_not_dot_value_pattern(not_dot_value):
         "country",
         names_to=("event", "year"),
         names_pattern=r"(.+)_(.+)",
+        values_to="score",
+        sort_by_appearance=True,
+    )
+    result = result.sort_values(
+        ["country", "event", "year"], ignore_index=True
+    )
+    actual = not_dot_value.set_index("country")
+    actual.columns = actual.columns.str.split("_", expand=True)
+    actual.columns.names = ["event", "year"]
+    actual = (
+        actual.stack(["event", "year"])
+        .rename("score")
+        .sort_index()
+        .reset_index()
+    )
+
+    assert_frame_equal(result, actual)
+
+
+def test_not_dot_value_pattern_named_groups(not_dot_value):
+    """
+    Test output when names_pattern has named groups
+    """
+
+    result = not_dot_value.pivot_longer(
+        "country",
+        names_pattern=r"(?P<event>.+)_(?P<year>.+)",
         values_to="score",
         sort_by_appearance=True,
     )

--- a/tests/functions/test_pivot_longer.py
+++ b/tests/functions/test_pivot_longer.py
@@ -101,13 +101,17 @@ def test_name_pattern_wrong_type(df_checks):
 
 def test_name_pattern_no_names_to(df_checks):
     """Raise ValueError if names_pattern and names_to is None."""
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="Kindly provide values for names_to."
+    ):
         df_checks.pivot_longer(names_to=None, names_pattern="(.+)(.)")
 
 
 def test_name_pattern_seq_no_names_to(df_checks):
     """Raise ValueError if names_pattern is a sequence and names_to is None."""
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="Kindly provide values for names_to."
+    ):
         df_checks.pivot_longer(names_to=None, names_pattern=[".{2}", "\\d"])
 
 

--- a/tests/functions/test_pivot_longer.py
+++ b/tests/functions/test_pivot_longer.py
@@ -6,6 +6,9 @@ from pandas.testing import assert_frame_equal
 from pandas import NA
 
 
+df = [1, 2, 3]
+
+
 @pytest.fixture
 def df_checks():
     """fixture dataframe"""


### PR DESCRIPTION
# PR Description

Please describe the changes proposed in the pull request:

- support for named groups in regex, making it easier to associate name with the sub regex
- support for dictionary in names_pattern

Example: 

```py
iris
   Sepal.Length  Sepal.Width  Petal.Length  Petal.Width    Species
0           5.1          3.5           1.4          0.2     setosa
1           5.9          3.0           5.1          1.8  virginica

In [6]: iris.pivot_longer(
   ...:         index = 'Species',
   ...:         names_to = None,
   ...:         names_pattern = r'(?P<part>.+)\.(?P<dimension>.+)'
   ...:         )
Out[6]: 
     Species   part dimension  value
0     setosa  Sepal    Length    5.1
1  virginica  Sepal    Length    5.9
2     setosa  Sepal     Width    3.5
3  virginica  Sepal     Width    3.0
4     setosa  Petal    Length    1.4
5  virginica  Petal    Length    5.1
6     setosa  Petal     Width    0.2
7  virginica  Petal     Width    1.8

# retain sub parts of the columns as new headers:
In [26]: iris.pivot_longer(
    ...:         index = 'Species',
    ...:         names_to = None,
    ...:         names_pattern = r'(?P<_>.+)\.(?P<dimension>.+)'
    ...:         )
Out[26]: 
     Species dimension  Sepal  Petal
0     setosa    Length    5.1    1.4
1  virginica    Length    5.9    5.1
2     setosa     Width    3.5    0.2
3  virginica     Width    3.0    1.8

# reshape with a dictionary: 

In [27]: iris.pivot_longer(
    ...:         index = 'Species',
    ...:         names_to = None,
    ...:         names_pattern = {'Sepal':'Sepal','Petal':'Petal'})
    ...: 
    ...: 
Out[27]: 
     Species  Sepal  Petal
0     setosa    5.1    1.4
1  virginica    5.9    5.1
2     setosa    3.5    0.2
3  virginica    3.0    1.8
```

**This PR resolves #1209 .**

- @ericmjl
