### PR TITLE
[ENH] Avoid explicit copy in `pivot_longer`

### DIFF
--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -856,13 +856,9 @@ def _computations_pivot_longer(
     if len(column_names) != len(set(column_names)):
         column_names = pd.unique(column_names)
 
-    # creates a new object - essentially a copy
-    # for large dataframes, it would be more efficient
-    # to build a new dataframe from a dictionary comprehension
-    # with copy=False
-    # but that could have adverse effects downstream
-    # if the user executes a computation that mutates the
-    # original dataframe - how to act as a copy without being a copy?
+    # this is the reason why there is no explicit copy (df.copy())
+    # at the very beginning for `pivot_longer`,
+    # because `.loc` makes a copy of the dataframe
     out = df.loc[:, column_names]
 
     if all((names_pattern is None, names_sep is None)):

--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -858,7 +858,7 @@ def _computations_pivot_longer(
 
     # creates a new object - essentially a copy
     # for large dataframes, it would be more efficient
-    # to build a new dataframes from a dictionary comprehension
+    # to build a new dataframe from a dictionary comprehension
     # with copy=False
     # but that could have adverse effects downstream
     # if the user executes a computation that mutates the

--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -857,6 +857,12 @@ def _computations_pivot_longer(
         column_names = pd.unique(column_names)
 
     # creates a new object - essentially a copy
+    # for large dataframes, it would be more efficient
+    # to build a new dataframes from a dictionary comprehension
+    # with copy=False
+    # but that could have adverse effects downstream
+    # if the user executes a computation that mutates the
+    # original dataframe - how to act as a copy without being a copy?
     out = df.loc[:, column_names]
 
     if all((names_pattern is None, names_sep is None)):

--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -399,8 +399,6 @@ def pivot_longer(
     # this code builds on the wonderful work of @benjaminjack’s PR
     # https://github.com/benjaminjack/pyjanitor/commit/e3df817903c20dd21634461c8a92aec137963ed0
 
-    df = df.copy()
-
     (
         df,
         index,
@@ -469,6 +467,10 @@ def _data_checks_pivot_longer(
     Type annotations are not provided because this function is where type
     checking happens.
     """
+
+    # checks here are only on the columns
+    # a slice is safe
+    df = df[:]
 
     if column_level is not None:
         check("column_level", column_level, [int, str])
@@ -780,11 +782,12 @@ def _data_checks_pivot_longer(
     if isinstance(df.columns, pd.MultiIndex):
         if not any(df.columns.names):
             if len(names_to) == 1:
-                df.columns.names = [
+                names = [
                     f"{names_to[0]}_{i}" for i in range(df.columns.nlevels)
                 ]
+                df.columns = df.columns.set_names(names)
             elif len(names_to) == df.columns.nlevels:
-                df.columns.names = names_to
+                df.columns = df.columns.set_names(names_to)
             else:
                 raise ValueError(
                     "The length of names_to does not match "
@@ -803,7 +806,7 @@ def _data_checks_pivot_longer(
         and not any((names_sep, names_pattern))
         and (not df.columns.names[0])
     ):
-        df.columns.names = names_to
+        df.columns = pd.Index(df.columns, name=names_to[0])
 
     return (
         df,
@@ -852,11 +855,12 @@ def _computations_pivot_longer(
 
     if len(column_names) != len(set(column_names)):
         column_names = pd.unique(column_names)
-    df = df.loc[:, column_names]
+
+    out = df.loc[:, column_names]
 
     if all((names_pattern is None, names_sep is None)):
         return _base_melt(
-            df=df,
+            df=out,
             index=index,
             values_to=values_to,
             names_transform=names_transform,
@@ -867,7 +871,7 @@ def _computations_pivot_longer(
 
     if names_sep is not None:
         return _pivot_longer_names_sep(
-            df=df,
+            df=out,
             index=index,
             names_to=names_to,
             names_sep=names_sep,
@@ -880,7 +884,7 @@ def _computations_pivot_longer(
 
     if isinstance(names_pattern, (str, Pattern)):
         return _pivot_longer_names_pattern_str(
-            df=df,
+            df=out,
             index=index,
             names_to=names_to,
             names_pattern=names_pattern,
@@ -892,7 +896,7 @@ def _computations_pivot_longer(
         )
 
     return _pivot_longer_names_pattern_sequence(
-        df=df,
+        df=out,
         index=index,
         names_to=names_to,
         names_pattern=names_pattern,
@@ -1677,7 +1681,6 @@ def _data_checks_pivot_wider(
     names_expand,
     index_expand,
 ):
-
     """
     This function raises errors if the arguments have the wrong
     python type, or if the column does not exist in the dataframe.

--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -856,6 +856,7 @@ def _computations_pivot_longer(
     if len(column_names) != len(set(column_names)):
         column_names = pd.unique(column_names)
 
+    # creates a new object - essentially a copy
     out = df.loc[:, column_names]
 
     if all((names_pattern is None, names_sep is None)):


### PR DESCRIPTION

# PR Description

Please describe the changes proposed in the pull request:

- Avoid explicit copy `df.copy`, since copy is already invoked when selecting the columns (line 866)
- Minor change, perf not affected

**This PR relates to #1250 .**

- @ericmjl
