### PR TITLE
[ENH] improve perf for `collapse_levels`; avoid explicit copy in `pivot_wider`

### DIFF
--- a/janitor/functions/collapse_levels.py
+++ b/janitor/functions/collapse_levels.py
@@ -88,17 +88,15 @@ def collapse_levels(df: pd.DataFrame, sep: str = "_") -> pd.DataFrame:
     if all_strings:
         no_empty_string = all((entry != "").all() for entry in levels)
         if no_empty_string:
-            start, *levels = levels
-            for entry in levels:
-                start = start + sep + entry
-            df.columns = start
+            df.columns = new_columns.map(sep.join)
             return df
     new_columns = (map(str, entry) for entry in new_columns)
-    df.columns = [
+    new_columns = [
         # faster to use a list comprehension within string.join
         # compared to a generator
         # https://stackoverflow.com/a/37782238
-        sep.join([entry for entry in word if entry != ""])
+        sep.join([entry for entry in word if entry])
         for word in new_columns
     ]
+    df.columns = new_columns
     return df

--- a/janitor/functions/collapse_levels.py
+++ b/janitor/functions/collapse_levels.py
@@ -82,6 +82,11 @@ def collapse_levels(df: pd.DataFrame, sep: str = "_") -> pd.DataFrame:
     # TODO: Pyarrow offers faster string computations
     # future work should take this into consideration,
     # which would require a different route from python's string.join
+
+    # since work is only on the columns
+    # it is safe, and more efficient to slice/view the dataframe
+    # plus Pandas creates a new Index altogether
+    # as such, the original dataframe is not modified
     df = df[:]
     new_columns = df.columns
     levels = [

--- a/janitor/functions/collapse_levels.py
+++ b/janitor/functions/collapse_levels.py
@@ -79,6 +79,9 @@ def collapse_levels(df: pd.DataFrame, sep: str = "_") -> pd.DataFrame:
     if not isinstance(df.columns, pd.MultiIndex):
         return df
 
+    # TODO: Pyarrow offers faster string computations
+    # future work should take this into consideration,
+    # which would require a different route from python's string.join
     df = df[:]
     new_columns = df.columns
     levels = [

--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -1605,16 +1605,8 @@ def _computations_pivot_wider(
 
     if isinstance(df.columns, pd.MultiIndex):
         new_columns = df.columns
-        all_strings = (
-            new_columns.get_level_values(num)
-            for num in range(new_columns.nlevels)
-        )
-        all_strings = all(map(is_string_dtype, all_strings))
-        if not all_strings:
-            new_columns = (tuple(map(str, entry)) for entry in new_columns)
-
         if names_glue is not None:
-            if ("_value" in names_from) and (None in df.columns.names):
+            if ("_value" in names_from) and (None in new_columns.names):
                 warnings.warn(
                     "For names_glue, _value is used as a placeholder "
                     "for the values_from section. "
@@ -1639,6 +1631,13 @@ def _computations_pivot_wider(
                     f"{error} is not a column label in names_from."
                 ) from error
         else:
+            all_strings = (
+                new_columns.get_level_values(num)
+                for num in range(new_columns.nlevels)
+            )
+            all_strings = all(map(is_string_dtype, all_strings))
+            if not all_strings:
+                new_columns = (tuple(map(str, entry)) for entry in new_columns)
             if names_sep is None:
                 names_sep = "_"
             new_columns = [names_sep.join(entry) for entry in new_columns]
@@ -1677,7 +1676,6 @@ def _data_checks_pivot_wider(
     names_expand,
     index_expand,
 ):
-
     """
     This function raises errors if the arguments have the wrong
     python type, or if the column does not exist in the dataframe.


### PR DESCRIPTION
Please describe the changes proposed in the pull request:

- improve performance for `collapse_levels` especially if all levels in the MultiIndex are strings, and there are no empty strings
- avoid explicit copy in `pivot_wider`, since `pd.pivot` already makes a copy

**This PR relates to #1250 .**

Performance comparison this PR vs dev: 

dataframe with relatively small number of columns : [source](https://pandas.pydata.org/docs/user_guide/advanced.html#using-slicers)

```py

def mklbl(prefix, n):
    return ["%s%s" % (prefix, i) for i in range(n)]


miindex = pd.MultiIndex.from_product(
    [mklbl("A", 4), mklbl("B", 2), mklbl("C", 4), mklbl("D", 2)]
)


micolumns = pd.MultiIndex.from_tuples(
    [("a", "foo"), ("a", "bar"), ("b", "foo"), ("b", "bah")], names=["lvl0", "lvl1"]
)


dfmi = (
    pd.DataFrame(
        np.arange(len(miindex) * len(micolumns)).reshape(
            (len(miindex), len(micolumns))
        ),
        index=miindex,
        columns=micolumns,
    )
    .sort_index()
    .sort_index(axis=1)
)


m = dfmi.T

print(m.columns.size)
64

# this PR:
%timeit m.collapse_levels()
414 µs ± 8.14 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

# dev:
%timeit m.collapse_levels()
84.7 µs ± 531 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

- dataframe with a lot more columns:
```py

def mklbl(prefix, n):
    return ["%s%s" % (prefix, i) for i in range(n)]


miindex = pd.MultiIndex.from_product(
    [mklbl("A", 40), mklbl("B", 20), mklbl("C", 40), mklbl("D", 20)]
)


micolumns = pd.MultiIndex.from_tuples(
    [("a", "foo"), ("a", "bar"), ("b", "foo"), ("b", "bah")], names=["lvl0", "lvl1"]
)


dfmi = (
    pd.DataFrame(
        np.arange(len(miindex) * len(micolumns)).reshape(
            (len(miindex), len(micolumns))
        ),
        index=miindex,
        columns=micolumns,
    )
    .sort_index()
    .sort_index(axis=1)
)


m = dfmi.T

print(m.columns.size)
64000

# this PR:
%timeit m.collapse_levels()
27.2 ms ± 250 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

# dev:
%timeit m.collapse_levels()
48.7 ms ± 211 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

Test when columns have integers: 

```py
m.columns = [m.columns.get_level_values(n) for n in range(3)] + [np.arange(1, m.columns.size + 1)]
38.5 ms ± 487 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

# dev:
%timeit m.collapse_levels()
55.3 ms ± 2.82 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

add a float column:

```py
m = dfmi.T
m.columns = [m.columns.get_level_values(n) for n in range(2)] + [np.arange(1, m.columns.size + 1), np.arange(1, m.columns.size + 1).astype(float)]

# PR:
%timeit m.collapse_levels()
44.9 ms ± 203 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

# dev
%timeit m.collapse_levels()
66.6 ms ± 461 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

- @ericmjl
