### PR TITLE
[ENH] Improve conditional join for range indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 -   [DEPR] Add deprecation warnings for `process_text`, `rename_column`, `rename_columns`, `filter_on`, `remove_columns`, `fill_direction`. #1045 @samukweku
 -   [ENH] `pivot_longer` now supports named groups where `names_pattern` is a regular expression. A dictionary can now be passed to `names_pattern`, and is internally evaluated as a list/tuple of regular expressions. Issue #1209 @samukweku
 -   [ENH] Improve selection in `conditional_join`. Issue #1223 @samukweku
+-   [ENH] Performance improvement for range joins in `conditional_join`, when `use_numba = False`. PR #1256 @samukweku
 
 ## [v0.24.0] - 2022-11-12
 

--- a/janitor/functions/_numba.py
+++ b/janitor/functions/_numba.py
@@ -494,13 +494,6 @@ def _get_indices_dual(
         # now we have our (pos_start, pos_end) -> (0, 1)
         # our search space is reduced, allowing us to do
         # less work with the comparison operation
-        # the advantage of this approach over a linear search ->
-        # the data is already sorted, we only need a binary search
-        # so we get a O(log n), compared to an O(n)
-        # this helps as the data size increases
-        # and the chunks (pos, pos_end) are relatively large
-        # a binary search will offer more performance
-        # relative to a linear search
         sliced = max_arr[slice(pos + 1, None)][::-1]
         pos_end = np.searchsorted(sliced, l2, side="left")
         pos_end = length - pos_end

--- a/janitor/functions/conditional_join.py
+++ b/janitor/functions/conditional_join.py
@@ -820,10 +820,6 @@ def _range_indices(
         if outcome is None:
             return None
         left_c, pos = outcome
-        if left_c.size < left_index.size:
-            keep_rows = np.isin(left_index, left_c, assume_unique=True)
-            search_indices = search_indices[keep_rows]
-            left_index = left_c
     else:
         # the aim here is to get the first match
         # where the left array is </<= than the right array
@@ -842,10 +838,10 @@ def _range_indices(
         if outcome is None:
             return None
         left_c, right_index, pos = outcome
-        if left_c.size < left_index.size:
-            keep_rows = np.isin(left_index, left_c, assume_unique=True)
-            search_indices = search_indices[keep_rows]
-            left_index = left_c
+    if left_c.size < left_index.size:
+        keep_rows = np.isin(left_index, left_c, assume_unique=True)
+        search_indices = search_indices[keep_rows]
+        left_index = left_c
     # no point searching within (a, b)
     # if a == b
     # since range(a, b) yields none

--- a/janitor/functions/conditional_join.py
+++ b/janitor/functions/conditional_join.py
@@ -681,9 +681,6 @@ def _multiple_conditional_join_le_lt(
         # within this space, as far as I know,
         # so a blowup of all the rows is unavoidable.
 
-        # The numba version offers optimisations
-        # for all types of non-equi joins
-
         # first step is to get two conditions, if possible
         # where one has a less than operator
         # and the other has a greater than operator

--- a/janitor/functions/conditional_join.py
+++ b/janitor/functions/conditional_join.py
@@ -683,7 +683,6 @@ def _multiple_conditional_join_le_lt(
 
         # The numba version offers optimisations
         # for all types of non-equi joins
-        # and is generally much faster
 
         # first step is to get two conditions, if possible
         # where one has a less than operator
@@ -741,7 +740,6 @@ def _multiple_conditional_join_le_lt(
                 multiple_conditions=False,
                 keep="all",
             )
-
     if not indices:
         return None
 

--- a/janitor/functions/conditional_join.py
+++ b/janitor/functions/conditional_join.py
@@ -56,7 +56,7 @@ def conditional_join(
     For strictly non-equi joins, particularly range joins,
     involving either `>`, `<`, `>=`, `<=` operators,
     where the columns on the right are not both monotonically increasing,
-    performance could be improved by setting `use_numba` to `True`.
+    performance might be improved by setting `use_numba` to `True`.
     This assumes that `numba` is installed.
 
     To preserve row order, set `sort_by_appearance` to `True`.

--- a/janitor/functions/conditional_join.py
+++ b/janitor/functions/conditional_join.py
@@ -309,10 +309,13 @@ def _conditional_join_type_check(
         is_datetime64_dtype,
         is_numeric_dtype,
         is_string_dtype,
-        is_categorical_dtype,
     }
     for func in permitted_types:
-        if func(left_column):
+        # change is based on this PR
+        # https://github.com/pandas-dev/pandas/pull/52527/files
+        if isinstance(left_column.dtype, pd.CategoricalDtype) or func(
+            left_column
+        ):
             break
     else:
         raise ValueError(

--- a/janitor/functions/conditional_join.py
+++ b/janitor/functions/conditional_join.py
@@ -55,7 +55,6 @@ def conditional_join(
 
     For strictly non-equi joins, particularly range joins,
     involving either `>`, `<`, `>=`, `<=` operators,
-    where the columns on the right are not both monotonically increasing,
     performance might be improved by setting `use_numba` to `True`.
     This assumes that `numba` is installed.
 

--- a/janitor/functions/conditional_join.py
+++ b/janitor/functions/conditional_join.py
@@ -829,10 +829,11 @@ def _range_indices(
     else:
         # the aim here is to get the first match
         # where the left array is </<= than the right array
-        # an efficient way to do that is via the
-        # cumulative max of the right array
-        # the initial route of a for loop was inefficient
-        # this is much more efficient
+        # this is solved by getting the cumulative max
+        # thus ensuring that the first match is obtained
+        # via a binary search
+        # this allows us to avoid the less efficient linear search
+        # of using a for loop with a break to get the first match
         outcome = _generic_func_cond_join(
             left=left_c,
             right=right_c.cummax(),
@@ -1016,6 +1017,7 @@ def _create_frame(
     arr_ = pd.DataFrame(arr_, copy=False)
     arr = _inner(df, right, left_index, right_index, indicator)
     df = pd.concat([arr, arr_], copy=False, sort=False)
+    df.index = range(len(df))
     return df
 
 
@@ -1027,8 +1029,10 @@ def _add_indicator(
     arr = pd.Categorical(
         [mapping[how]], categories=["left_only", "right_only", "both"]
     )
-    if isinstance(next(iter(df)), tuple):
-        indicator = (indicator, "")
+    first_key = next(iter(df))
+    if isinstance(first_key, tuple):
+        indicator = [indicator] + [""] * (len(first_key) - 1)
+        indicator = tuple(indicator)
     df[indicator] = arr.repeat(length)
     return df
 

--- a/janitor/functions/move.py
+++ b/janitor/functions/move.py
@@ -108,7 +108,6 @@ def move(
     names = getattr(df, mapping[axis])
 
     assert names.is_unique
-    assert not isinstance(names, pd.MultiIndex)
 
     index = np.arange(names.size)
     source = _select_index([source], df, mapping[axis])

--- a/janitor/functions/move.py
+++ b/janitor/functions/move.py
@@ -25,8 +25,7 @@ def move(
     This operation does not reset the index of the dataframe. User must
     explicitly do so.
 
-    This function does not apply to multilevel dataframes, and the dataframe
-    must have unique column names or indices.
+    The dataframe must have unique column names or indices.
 
     Examples:
         Move a row:

--- a/tests/functions/test_move.py
+++ b/tests/functions/test_move.py
@@ -184,6 +184,7 @@ def test_move_unique():
         df.move(source="a", axis=1)
 
 
+@pytest.mark.xfail(reason="allow MultiIndex move")
 def test_move_multiindex():
     """Raise if the axis is a MultiIndex"""
     df = pd.DataFrame(

--- a/tests/functions/test_move.py
+++ b/tests/functions/test_move.py
@@ -184,7 +184,7 @@ def test_move_unique():
         df.move(source="a", axis=1)
 
 
-@pytest.mark.xfail(reason="allow MultiIndex move")
+@pytest.mark.xfail(reason="move function supports MultiIndex labels")
 def test_move_multiindex():
     """Raise if the axis is a MultiIndex"""
     df = pd.DataFrame(

--- a/tests/timeseries/test_fill_missing_timestamps.py
+++ b/tests/timeseries/test_fill_missing_timestamps.py
@@ -53,6 +53,7 @@ def test__get_missing_timestamps(timeseries_dataframe):
     """Test utility function for identifying the missing timestamps."""
     from random import sample
 
+    timeseries_dataframe.index.freq = None
     timestamps_to_drop = sample(timeseries_dataframe.index.tolist(), 3)
     df = timeseries_dataframe.drop(index=timestamps_to_drop)
     missing_timestamps = _get_missing_timestamps(df, "1H")


### PR DESCRIPTION
- improve `range_indices` significantly, for scenarios where numba is not used
- 20-30x faster than current dev implementation 
- fix output when indicator is used and multiindex is returned

with this PR, numba  might not be required anymore. I think it's good to keep it though.

**This PR improves conditional_join.**

# performance test

```py
url = "https://raw.githubusercontent.com/samukweku/data-wrangling-blog/master/notebooks/Data_files/results.csv"
events = pd.read_csv(url, parse_dates=['start', 'end']).iloc[:, 1:]

# dev
In [25]: %%timeit
    ...: (events
    ...: .conditional_join(
    ...:     events,
    ...:     ('start', 'end', '<='),
    ...:     ('end', 'start', '>='),
    ...:     ('id', 'id', '!='),
    ...:     use_numba = False,
    ...:     df_columns = ['id', 'start', 'end'],
    ...:     right_columns = ['id', 'start', 'end'])
    ...: )
    ...: 
    ...: 
823 ms ± 2.35 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [26]: %%timeit
    ...: (events
    ...: .conditional_join(
    ...:     events,
    ...:     ('start', 'end', '<='),
    ...:     ('end', 'start', '>='),
    ...:     ('id', 'id', '!='),
    ...:     use_numba = True,
    ...:     df_columns = ['id', 'start', 'end'],
    ...:     right_columns = ['id', 'start', 'end'])
    ...: )
    ...: 
    ...: 
23.9 ms ± 567 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)


# this PR

# massive performance improvement when use_numba=False
In [20]: %%timeit
    ...: (events
    ...: .conditional_join(
    ...:     events,
    ...:     ('start', 'end', '<='),
    ...:     ('end', 'start', '>='),
    ...:     ('id', 'id', '!='),
    ...:     use_numba = False,
    ...:     df_columns = ['id', 'start', 'end'],
    ...:     right_columns = ['id', 'start', 'end'])
    ...: )
    ...: 
    ...: 
20.1 ms ± 109 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [21]: %%timeit
    ...: (events
    ...: .conditional_join(
    ...:     events,
    ...:     ('start', 'end', '<='),
    ...:     ('end', 'start', '>='),
    ...:     ('id', 'id', '!='),
    ...:     use_numba = True,
    ...:     df_columns = ['id', 'start', 'end'],
    ...:     right_columns = ['id', 'start', 'end'])
    ...: )
    ...: 
    ...: 
24 ms ± 955 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

Test on a larger dataset: 

Another test on a 10 million row; data also from [DuckDB](https://github.com/duckdb/duckdb/blob/master/benchmark/micro/join/iejoin_employees.benchmark)


```py

employees = pd.read_csv("../employees.csv")

# dev
In [27]: %%timeit
    ...: (employees
    ...: .conditional_join(
    ...:     employees,
    ...:     ('salary', 'salary', '<'),
    ...:     ('tax', 'tax', '>'),
    ...:     use_numba = True)
    ...: )
    ...: 
    ...: 
4.35 s ± 34.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)


# this PR
# massive performance improvement,
# as this could not be executed in dev
In [18]: %%timeit
    ...: (employees
    ...: .conditional_join(
    ...:     employees,
    ...:     ('salary', 'salary', '<'),
    ...:     ('tax', 'tax', '>'),
    ...:     use_numba = False)
    ...: )
    ...: 
    ...: 
1.79 s ± 3.16 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [19]: %%timeit
    ...: (employees
    ...: .conditional_join(
    ...:     employees,
    ...:     ('salary', 'salary', '<'),
    ...:     ('tax', 'tax', '>'),
    ...:     use_numba = True)
    ...: )
    ...: 
    ...: 
4.34 s ± 62.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

```
<!-- As you go down the PR template, please feel free to delete sections that are irrelevant. -->

# PR Checklist

<!-- This checklist exists for newcomers who are not yet familiar with our requirements. If you are experienced with
the project, please feel free to delete this section. -->

Please ensure that you have done the following:

1. [x] PR in from a fork off your branch. Do not PR from `<your_username>`:`dev`, but rather from `<your_username>`:`<feature-branch_name>`.
<!-- Doing this helps us keep the commit history much cleaner than it would otherwise be. -->
2. [x] If you're not on the contributors list, add yourself to `AUTHORS.md`.
<!-- We'd like to acknowledge your contributions! -->
3. [x] Add a line to `CHANGELOG.md` under the latest version header (i.e. the one that is "on deck") describing the contribution.
    - Do use some discretion here; if there are multiple PRs that are related, keep them in a single line.

# Automatic checks

There will be automatic checks run on the PR. These include:

- Building a preview of the docs on Netlify
- Automatically linting the code
- Making sure the code is documented
- Making sure that all tests are passed
- Making sure that code coverage doesn't go down.

# Relevant Reviewers

<!-- Finally, please tag relevant maintainers to review. -->

Please tag maintainers to review.

- @ericmjl
