### PR TITLE
ensure `select` returns dataframes

### DIFF
--- a/janitor/functions/utils.py
+++ b/janitor/functions/utils.py
@@ -661,15 +661,11 @@ def _select(
         if rows is None:
             rows = slice(None)
         else:
-            if not is_list_like(rows):
-                rows = [rows]
-            rows = _select_index(rows, df, axis="index")
+            rows = _select_index([rows], df, axis="index")
         if columns is None:
             columns = slice(None)
         else:
-            if not is_list_like(columns):
-                columns = [columns]
-            columns = _select_index(columns, df, axis="columns")
+            columns = _select_index([columns], df, axis="columns")
         return df.iloc[rows, columns]
     indices = _select_index(list(args), df, axis)
     if invert:

--- a/tests/functions/test_select.py
+++ b/tests/functions/test_select.py
@@ -55,6 +55,20 @@ def test_select_columns_only(dataframe):
     assert_frame_equal(actual, expected)
 
 
+def test_select_single_column(dataframe):
+    """Test output for columns only"""
+    actual = dataframe.select(columns="col1")
+    expected = dataframe.loc[:, ["col1"]]
+    assert_frame_equal(actual, expected)
+
+
+def test_select_single_row(dataframe):
+    """Test output for row only"""
+    actual = dataframe.select(rows=("bar", "one"))
+    expected = dataframe.loc[[("bar", "one")]]
+    assert_frame_equal(actual, expected)
+
+
 def test_select_columns_scalar(dataframe):
     """Test output for columns only"""
     actual = dataframe.select(columns="col*")


### PR DESCRIPTION
minor fix to ensure a dataframe is returned for `select`

# PR Description

Please describe the changes proposed in the pull request:

- ensure `select` always returns a dataframe

**This PR improves the `select` function.**

Example:

```
import pandas as pd
import numpy as np
import janitor

np.random.seed(0)
arrays = [
        ["bar", "bar", "baz", "baz", "foo", "foo", "qux", "qux"],
        ["one", "two", "one", "two", "one", "two", "one", "two"],
    ]
tuples = list(zip(*arrays))
index = pd.MultiIndex.from_tuples(tuples, names=["A", "B"])
df = pd.DataFrame(
    np.random.randint(9, size=(8, 2)),
    index=index,
    columns=["col1", "col2"],
)

df
         col1  col2
A   B              
bar one     5     0
    two     3     3
baz one     7     3
    two     5     2
foo one     4     7
    two     6     8
qux one     8     1
    two     6     7

# dev
df.select(rows=('bar','one'))
col1    5
col2    0
Name: (bar, one), dtype: int64

# PR
df.select(rows=('bar','one'))
         col1  col2
A   B              
bar one     5     0

```

<!-- As you go down the PR template, please feel free to delete sections that are irrelevant. -->

# PR Checklist

<!-- This checklist exists for newcomers who are not yet familiar with our requirements. If you are experienced with
the project, please feel free to delete this section. -->

Please ensure that you have done the following:

1. [ ] PR in from a fork off your branch. Do not PR from `<your_username>`:`dev`, but rather from `<your_username>`:`<feature-branch_name>`.
<!-- Doing this helps us keep the commit history much cleaner than it would otherwise be. -->
2. [ ] If you're not on the contributors list, add yourself to `AUTHORS.md`.
<!-- We'd like to acknowledge your contributions! -->
3. [ ] Add a line to `CHANGELOG.md` under the latest version header (i.e. the one that is "on deck") describing the contribution.
    - Do use some discretion here; if there are multiple PRs that are related, keep them in a single line.

# Automatic checks

There will be automatic checks run on the PR. These include:

- Building a preview of the docs on Netlify
- Automatically linting the code
- Making sure the code is documented
- Making sure that all tests are passed
- Making sure that code coverage doesn't go down.

# Relevant Reviewers

<!-- Finally, please tag relevant maintainers to review. -->

Please tag maintainers to review.

- @ericmjl
