### PR TITLE
[ENH] improved performance for `first/last` in `conditional_join`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [ENH] `xlsx_table` function now supports polars - Issue #1352 @samukweku
 - [ENH] Added a `pivot_longer` method, and a `pivot_longer_spec` function for polars - Issue #1352 @samukweku
 - [ENH] pandas Index,Series, DataFrame now supported in the `complete` method. - PR #1369 @samukweku
+- [ENH] Improve performance for `first/last` in `conditional_join, when the join columns in the right dataframe are sorted. - PR #1382 @samukweku
 
 ## [v0.27.0] - 2024-03-21
 

--- a/janitor/functions/utils.py
+++ b/janitor/functions/utils.py
@@ -814,6 +814,10 @@ def _less_than_indices(
 
     if multiple_conditions:
         return left_index, right_index, search_indices
+    if right_is_sorted and (keep == "last"):
+        indexer = np.empty_like(search_indices)
+        indexer[:] = len_right - 1
+        return left_index, right_index[indexer]
     if right_is_sorted and (keep == "first"):
         if any_nulls:
             return left_index, right_index[search_indices]
@@ -903,6 +907,9 @@ def _greater_than_indices(
 
     if multiple_conditions:
         return left_index, right_index, search_indices
+    if right_is_sorted and (keep == "first"):
+        indexer = np.zeros_like(search_indices)
+        return left_index, right_index[indexer]
     if right_is_sorted and (keep == "last"):
         if any_nulls:
             return left_index, right_index[search_indices - 1]
@@ -1044,9 +1051,9 @@ def _keep_output(keep: str, left: np.ndarray, right: np.ndarray):
     grouped = pd.Series(right).groupby(left)
     if keep == "first":
         grouped = grouped.min()
-        return grouped.index, grouped.array
+        return grouped.index, grouped._values
     grouped = grouped.max()
-    return grouped.index, grouped.array
+    return grouped.index, grouped._values
 
 
 class col:


### PR DESCRIPTION
# PR Description

Please describe the changes proposed in the pull request:

- improved performance for `first/last` in `conditional_join`
- applies if join columns on the right is already sorted 
-  limited to single non-equi joins or range joins (max two join columns)

**This PR improves conditional_join.**

Performance tests - YMMV: 

```py
import pandas as pd
import janitor
In [21]: df1 = pd.DataFrame({'id': [1,1,1,2,2,3], 'value_1': [2,5,7,1,3,4]})
    ...: df2 = pd.DataFrame({'id': [1,1,1,1,2,2,2,3], 'value_2A': [0,3,7,12,0,2,3,1], 'value_2B': [1,5,9,15,1,4,6,3]})

In [32]: df1 = pd.concat([df1]*10_000)

In [33]: df2 = pd.concat([df2]*200)

# this PR
In [37]: %timeit df1.conditional_join(df2.sort_values('value_2A'), ('value_1','value_2A','>='), keep='first')
3.35 ms ± 59.8 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
In [45]: %timeit df1.conditional_join(df2.sort_values(['value_2A','value_2B']), ('value_1','value_2A','>='), ('value_1','value_2B','<='),keep='first')
6.11 ms ± 19.6 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

# dev 
In [47]: %timeit df1.conditional_join(df2.sort_values(['value_2A','value_2B']), ('value_1','value_2A','>='), ('value_1','value_2B'
    ...: ,'<='),keep='first')
  def conditional_join(
300 ms ± 5.21 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [48]: %timeit df1.conditional_join(df2.sort_values('value_2A'), ('value_1','value_2A','>='), keep='first')
57.6 ms ± 630 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

- @ericmjl
