### PR TITLE
Samukweku/pivot longer simple

### DIFF
--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -606,20 +606,19 @@ def _data_checks_pivot_longer(
 
     elif (index is None) and (column_names is not None):
         column_names = _select_index([column_names], df, axis="columns")
-        index = np.setdiff1d(
-            np.arange(df.columns.size),
-            pd.unique(_index_converter(column_names, df.columns)),
-            assume_unique=True,
-        )
+        index = _index_converter(column_names, df.columns)
+        index = pd.Index(pd.unique(index))
+        index = index.get_indexer(np.arange(df.columns.size)) == -1
         index = df.columns[index]
 
     elif (index is not None) and (column_names is None):
         index = _select_index([index], df, axis="columns")
-        column_names = np.setdiff1d(
-            np.arange(df.columns.size),
-            pd.unique(_index_converter(index, df.columns)),
-            assume_unique=True,
+        column_names = _index_converter(index, df.columns)
+        column_names = pd.Index(pd.unique(column_names))
+        column_names = (
+            column_names.get_indexer(np.arange(df.columns.size)) == -1
         )
+        column_names = column_names.nonzero()[0]
         if not column_names.size:
             column_names = None
         index = df.columns[index]

--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -1555,6 +1555,14 @@ def reshape_by_spec_others(
             df_index = df.index[indexer]
         else:
             df_index = range(total)
+        shape = (len_df, len_cols)
+        indexer = np.empty(shape=shape, dtype=np.intp)
+        arr = np.arange(len_cols).reshape((1, len_cols))
+        indexer[:] = arr
+        indexer = indexer.ravel(order="C")
+        for key, value in spec.items():
+            value = value._values[indexer]
+            data[key] = value
         if dot_value_is_one & (not any_extension_array):
             for key, value in dictionary.items():
                 value = value.ravel(order="C")
@@ -1566,14 +1574,7 @@ def reshape_by_spec_others(
             for key, value in dictionary.items():
                 value = value[indexer]
                 data[key] = value
-        shape = (len_df, len_cols)
-        indexer = np.empty(shape=shape, dtype=np.intp)
-        arr = np.arange(len_cols).reshape((1, len_cols))
-        indexer[:] = arr
-        indexer = indexer.ravel(order="C")
-        for key, value in spec.items():
-            value = value._values[indexer]
-            data[key] = value
+
         return pd.DataFrame(data, index=df_index, copy=False)
     if index or (ignore_index is False):
         shape = (len_cols, len_df)
@@ -1590,13 +1591,6 @@ def reshape_by_spec_others(
     else:
         total = len_df * len_cols
         df_index = range(total)
-    if dot_value_is_one & (not any_extension_array):
-        for key, value in dictionary.items():
-            value = value.ravel(order="F")
-            data[key] = value
-    else:
-        for key, value in dictionary.items():
-            data[key] = value
     shape = (len_df, len_cols)
     indexer = np.empty(shape=shape, dtype=np.intp)
     arr = np.arange(len_cols).reshape((1, len_cols))
@@ -1605,6 +1599,14 @@ def reshape_by_spec_others(
     for key, value in spec.items():
         value = value._values[indexer]
         data[key] = value
+    if dot_value_is_one & (not any_extension_array):
+        for key, value in dictionary.items():
+            value = value.ravel(order="F")
+            data[key] = value
+    else:
+        for key, value in dictionary.items():
+            data[key] = value
+
     return pd.DataFrame(data, index=df_index, copy=False)
 
 

--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -1479,9 +1479,8 @@ def reshape_by_spec_others(
     dot_value_is_one = spec[".value"].nunique() == 1
     any_extension_array = None
     if dot_value_is_one:
-        any_extension_array = df.dtypes.map(is_extension_array_dtype).any(
-            axis=None
-        )
+        any_extension_array = df.dtypes.map(is_extension_array_dtype)
+        any_extension_array = any_extension_array.any(axis=None)
         if any_extension_array:
             contents = [arr._values for _, arr in df.items()]
             contents = concat_compat(contents)

--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -1504,9 +1504,8 @@ def reshape_by_spec_others(
         cols = range(df.columns.size)
         zipped = zip(group_pos, spec[".value"], cols)
         data = defaultdict(dict)
-        headers = (
-            {}
-        )  # use a dict, instead of a set to maintain insertion order
+        # use a dict, instead of a set to maintain insertion order
+        headers = {}
         for pos, header, col_pos in zipped:
             headers[header] = 1
             arr = df.iloc[:, col_pos]._values

--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -556,7 +556,7 @@ def pivot_longer_spec(
     others = [label for label in spec if label not in {".name", ".value"}]
 
     if others:
-        return reshape_by_spec_others(
+        return _reshape_by_spec_others(
             df=df,
             spec=spec.drop(columns=".name"),
             index=index,
@@ -564,7 +564,7 @@ def pivot_longer_spec(
             ignore_index=ignore_index,
             sort_by_appearance=sort_by_appearance,
         )
-    return reshape_by_spec(
+    return _reshape_by_spec(
         df=df,
         spec=spec[".value"],
         index=index,
@@ -1010,7 +1010,7 @@ def _computations_pivot_longer(
             spec = _names_transform(
                 spec=spec, others=others, names_transform=names_transform
             )
-        return reshape_by_spec_others(
+        return _reshape_by_spec_others(
             df=df,
             index=index,
             others=others,
@@ -1173,7 +1173,7 @@ def _pivot_longer_values_to_sequence(
         spec = _names_transform(
             spec=spec, others=others, names_transform=names_transform
         )
-    return reshape_by_spec_others(
+    return _reshape_by_spec_others(
         df=df,
         index=index,
         others=others,
@@ -1213,7 +1213,7 @@ def _pivot_longer_names_pattern_sequence(
     df = df.loc[:, booleans]
     values = values[booleans]
     spec = pd.Series(values, name=".value")
-    return reshape_by_spec(
+    return _reshape_by_spec(
         df=df,
         spec=spec,
         index=index,
@@ -1262,7 +1262,7 @@ def _pivot_longer_names_pattern_str(
             spec=spec, others=others, names_transform=names_transform
         )
     if others:
-        return reshape_by_spec_others(
+        return _reshape_by_spec_others(
             df=df,
             index=index,
             others=others,
@@ -1270,7 +1270,7 @@ def _pivot_longer_names_pattern_str(
             ignore_index=ignore_index,
             spec=spec,
         )
-    return reshape_by_spec(
+    return _reshape_by_spec(
         df=df,
         spec=spec[".value"],
         index=index,
@@ -1320,7 +1320,7 @@ def _pivot_longer_names_sep(
             spec=spec, others=others, names_transform=names_transform
         )
     if others:
-        return reshape_by_spec_others(
+        return _reshape_by_spec_others(
             df=df,
             index=index,
             others=others,
@@ -1328,7 +1328,7 @@ def _pivot_longer_names_sep(
             ignore_index=ignore_index,
             spec=spec,
         )
-    return reshape_by_spec(
+    return _reshape_by_spec(
         df=df,
         spec=spec[".value"],
         index=index,
@@ -1415,7 +1415,7 @@ def _names_transform(
     return spec
 
 
-def reshape_by_spec(
+def _reshape_by_spec(
     df: pd.DataFrame,
     spec: pd.DataFrame,
     index: dict,
@@ -1468,7 +1468,7 @@ def reshape_by_spec(
     # then x2 will pair with y1 and x1 will pair with y2
     # this is because `others` does not exist here -
     # `others` would have acted as a guard/combiner
-    # which is what happens in reshape_by_spec_others
+    # which is what happens in _reshape_by_spec_others
 
     # phase 1 - group labels, and get the counts per label
     cols = range(df.columns.size)
@@ -1581,7 +1581,7 @@ def reshape_by_spec(
     return pd.DataFrame(data, index=df_index, copy=False)
 
 
-def reshape_by_spec_others(
+def _reshape_by_spec_others(
     df: pd.DataFrame,
     spec: pd.DataFrame,
     index: dict,
@@ -1607,7 +1607,7 @@ def reshape_by_spec_others(
     # 2   Sepal.Width   Width  Sepal
     # 3   Petal.Width   Width  Petal
     #
-    # just like with reshape_by_spec, we can see the pairing
+    # just like with _reshape_by_spec, we can see the pairing
     # between .value and the the column names('.name')
     # but also, we have a pairing for others -
     # in the spec dataframe above, it is `part`
@@ -1728,7 +1728,7 @@ def reshape_by_spec_others(
         spec = spec.loc[:, others].drop_duplicates()
     data = {}
     if sort_by_appearance:
-        # same concept used in reshape_by_spec applies here
+        # same concept used in _reshape_by_spec applies here
         shape = (len_df, len_cols)
         total = len_df * len_cols
         if index or (ignore_index is False):

--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -1211,15 +1211,6 @@ def _computations_pivot_longer(
             ignore_index=ignore_index,
             spec=spec,
         )
-        return _pivot_longer_dot_value(
-            df=df,
-            index=index,
-            others=others,
-            sort_by_appearance=sort_by_appearance,
-            ignore_index=ignore_index,
-            dropna=dropna,
-            spec=spec,
-        )
 
     if names_sep is not None:
         return _pivot_longer_names_sep(
@@ -1429,14 +1420,21 @@ def _pivot_longer_names_pattern_str(
         spec = _names_transform(
             spec=spec, others=others, names_transform=names_transform
         )
-    return _pivot_longer_dot_value(
+    if others:
+        return reshape_by_spec_others(
+            df=df,
+            index=index,
+            others=others,
+            sort_by_appearance=sort_by_appearance,
+            ignore_index=ignore_index,
+            spec=spec,
+        )
+    return reshape_by_spec(
         df=df,
+        spec=spec[".value"],
         index=index,
-        others=others,
-        sort_by_appearance=sort_by_appearance,
         ignore_index=ignore_index,
-        dropna=dropna,
-        spec=spec,
+        sort_by_appearance=sort_by_appearance,
     )
 
 
@@ -1481,14 +1479,21 @@ def _pivot_longer_names_sep(
         spec = _names_transform(
             spec=spec, others=others, names_transform=names_transform
         )
-    return _pivot_longer_dot_value(
+    if others:
+        return reshape_by_spec_others(
+            df=df,
+            index=index,
+            others=others,
+            sort_by_appearance=sort_by_appearance,
+            ignore_index=ignore_index,
+            spec=spec,
+        )
+    return reshape_by_spec(
         df=df,
+        spec=spec[".value"],
         index=index,
-        others=others,
-        sort_by_appearance=sort_by_appearance,
         ignore_index=ignore_index,
-        dropna=dropna,
-        spec=spec,
+        sort_by_appearance=sort_by_appearance,
     )
 
 

--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -1028,7 +1028,6 @@ def _computations_pivot_longer(
             names_sep=names_sep,
             names_transform=names_transform,
             values_to=values_to,
-            dropna=dropna,
             sort_by_appearance=sort_by_appearance,
             ignore_index=ignore_index,
         )
@@ -1041,7 +1040,6 @@ def _computations_pivot_longer(
             names_pattern=names_pattern,
             names_transform=names_transform,
             values_to=values_to,
-            dropna=dropna,
             sort_by_appearance=sort_by_appearance,
             ignore_index=ignore_index,
         )
@@ -1053,7 +1051,6 @@ def _computations_pivot_longer(
             names_to=names_to,
             names_pattern=names_pattern,
             names_transform=names_transform,
-            dropna=dropna,
             sort_by_appearance=sort_by_appearance,
             values_to=values_to,
             ignore_index=ignore_index,
@@ -1064,7 +1061,6 @@ def _computations_pivot_longer(
         index=index,
         names_to=names_to,
         names_pattern=names_pattern,
-        dropna=dropna,
         sort_by_appearance=sort_by_appearance,
         ignore_index=ignore_index,
     )
@@ -1076,7 +1072,6 @@ def _pivot_longer_values_to_sequence(
     names_to: list,
     names_pattern: list | tuple,
     names_transform: str | Callable | dict | None,
-    dropna: bool,
     sort_by_appearance: bool,
     values_to: list | tuple,
     ignore_index: bool,
@@ -1151,7 +1146,6 @@ def _pivot_longer_names_pattern_sequence(
     index: dict,
     names_to: list,
     names_pattern: list | tuple,
-    dropna: bool,
     sort_by_appearance: bool,
     ignore_index: bool,
 ) -> pd.DataFrame:
@@ -1194,7 +1188,6 @@ def _pivot_longer_names_pattern_str(
     names_pattern: str | Pattern,
     names_transform: bool,
     values_to: str,
-    dropna: bool,
     sort_by_appearance: bool,
     ignore_index: bool,
 ) -> pd.DataFrame:
@@ -1252,7 +1245,6 @@ def _pivot_longer_names_sep(
     names_sep: str | Pattern,
     values_to: str,
     names_transform: str | dict | Callable | None,
-    dropna: bool,
     sort_by_appearance: bool,
     ignore_index: bool,
 ) -> pd.DataFrame:

--- a/tests/functions/test_pivot_longer.py
+++ b/tests/functions/test_pivot_longer.py
@@ -808,7 +808,7 @@ def test_names_pattern_list():
         .set_axis(["Task", "M"], axis="columns")
         .droplevel(-1)
         .reset_index()
-    )
+    ).loc[:, ["Activity", "General", "Task", "M"]]
 
     assert_frame_equal(result, actual)
 
@@ -1478,7 +1478,7 @@ def test_output_values_to_seq(multiple_values_to):
         names_pattern=[r"M|O|W"],
     )
 
-    assert_frame_equal(expected, actual)
+    assert_frame_equal(expected.loc[:, actual.columns.tolist()], actual)
 
 
 def test_output_values_to_seq1(multiple_values_to):
@@ -1706,6 +1706,7 @@ def test_preserve_extension_types():
     assert_frame_equal(expected, actual.loc[:, expected.columns.tolist()])
 
 
+@pytest.mark.xfail(reason="dropna deprecated")
 def test_dropna_sort_by_appearance():
     """
     Test output when `dropna=True` and

--- a/tests/functions/test_pivot_longer.py
+++ b/tests/functions/test_pivot_longer.py
@@ -523,7 +523,7 @@ def test_pivot_index_only(df_checks):
         ["famid", "birth"], var_name="dim", value_name="num"
     )
 
-    assert_frame_equal(result, actual)
+    assert_frame_equal(result.loc[:, actual.columns.tolist()], actual)
 
 
 def test_pivot_column_only(df_checks):
@@ -542,7 +542,7 @@ def test_pivot_column_only(df_checks):
         ignore_index=False,
     )
 
-    assert_frame_equal(result, actual)
+    assert_frame_equal(result.loc[:, actual.columns.tolist()], actual)
 
 
 def test_pivot_sort_by_appearance(df_checks):
@@ -565,7 +565,7 @@ def test_pivot_sort_by_appearance(df_checks):
         .reset_index(drop=True)
     )
 
-    assert_frame_equal(result, actual)
+    assert_frame_equal(result.loc[:, actual.columns.tolist()], actual)
 
 
 def test_names_pat_str(df_checks):
@@ -602,7 +602,9 @@ def test_multiindex_column_level(df_multi):
     expected_output = df_multi.melt(
         id_vars="name", value_vars="names", col_level=0
     )
-    assert_frame_equal(result, expected_output)
+    assert_frame_equal(
+        result.loc[:, expected_output.columns.tolist()], expected_output
+    )
 
 
 def test_multiindex(df_multi):
@@ -613,7 +615,9 @@ def test_multiindex(df_multi):
     """
     result = df_multi.pivot_longer(index=[("name", "a")])
     expected_output = df_multi.melt(id_vars=[("name", "a")])
-    assert_frame_equal(result, expected_output)
+    assert_frame_equal(
+        result.loc[:, expected_output.columns.tolist()], expected_output
+    )
 
 
 def test_multiindex_names_to(df_multi):
@@ -627,7 +631,9 @@ def test_multiindex_names_to(df_multi):
         index=[("name", "a")], names_to=["variable_0", "variable_1"]
     )
     expected_output = df_multi.melt(id_vars=[("name", "a")])
-    assert_frame_equal(result, expected_output)
+    assert_frame_equal(
+        result.loc[:, expected_output.columns.tolist()], expected_output
+    )
 
 
 def test_multiindex_names_to_length_mismatch(df_multi):
@@ -1221,6 +1227,7 @@ def test_dropna_multiple_columns(df_null):
     assert_frame_equal(result, actual)
 
 
+@pytest.mark.xfail(reason="dropna deprecated")
 def test_dropna_single_column():
     """
     Test output if dropna = True,
@@ -1573,7 +1580,11 @@ def test_categorical(df_checks):
         ["famid", "birth"], names_transform="category"
     )
 
-    assert_frame_equal(actual, expected, check_categorical=False)
+    assert_frame_equal(
+        actual,
+        expected.loc[:, actual.columns.tolist()],
+        check_categorical=False,
+    )
 
 
 def test_names_transform_numeric():
@@ -1684,7 +1695,7 @@ def test_preserve_extension_types():
         .reset_index()
     )
 
-    assert_frame_equal(expected, actual)
+    assert_frame_equal(expected, actual.loc[:, expected.columns.tolist()])
 
 
 def test_dropna_sort_by_appearance():

--- a/tests/functions/test_pivot_longer.py
+++ b/tests/functions/test_pivot_longer.py
@@ -747,7 +747,7 @@ def test_names_pattern_str(test_df):
     )
     actual = actual.sort_values(actual.columns.tolist(), ignore_index=True)
 
-    assert_frame_equal(result, actual)
+    assert_frame_equal(result.loc[:, actual.columns.tolist()], actual)
 
 
 def test_names_sep(test_df):
@@ -775,7 +775,7 @@ def test_names_sep(test_df):
     result = result.sort_values(result.columns.tolist(), ignore_index=True)
     actual = actual.sort_values(actual.columns.tolist(), ignore_index=True)
 
-    assert_frame_equal(result, actual)
+    assert_frame_equal(result.loc[:, actual.columns.tolist()], actual)
 
 
 def test_names_pattern_list():
@@ -884,7 +884,7 @@ def test_not_dot_value_sep(not_dot_value):
         .reset_index()
     )
 
-    assert_frame_equal(result, actual)
+    assert_frame_equal(result.loc[:, actual.columns.tolist()], actual)
 
 
 def test_not_dot_value_sep2(not_dot_value):
@@ -901,7 +901,7 @@ def test_not_dot_value_sep2(not_dot_value):
         "country", var_name="event", value_name="score"
     )
 
-    assert_frame_equal(result, actual)
+    assert_frame_equal(result.loc[:, actual.columns.tolist()], actual)
 
 
 def test_not_dot_value_pattern(not_dot_value):
@@ -927,7 +927,7 @@ def test_not_dot_value_pattern(not_dot_value):
         .reset_index()
     )
 
-    assert_frame_equal(result, actual)
+    assert_frame_equal(result.loc[:, actual.columns.tolist()], actual)
 
 
 def test_not_dot_value_pattern_named_groups(not_dot_value):
@@ -954,7 +954,7 @@ def test_not_dot_value_pattern_named_groups(not_dot_value):
         .reset_index()
     )
 
-    assert_frame_equal(result, actual)
+    assert_frame_equal(result.loc[:, actual.columns.tolist()], actual)
 
 
 def test_not_dot_value_sep_single_column(not_dot_value):
@@ -983,7 +983,7 @@ def test_not_dot_value_sep_single_column(not_dot_value):
         .reset_index()
     )
 
-    assert_frame_equal(result, actual)
+    assert_frame_equal(result.loc[:, actual.columns.tolist()], actual)
 
 
 def test_multiple_dot_value():
@@ -1022,7 +1022,9 @@ def test_multiple_dot_value():
         .reset_index()
     )
 
-    assert_frame_equal(result, actual, check_dtype=False)
+    assert_frame_equal(
+        result.loc[:, actual.columns.tolist()], actual, check_dtype=False
+    )
 
 
 def test_multiple_dot_value_named_group():
@@ -1060,7 +1062,9 @@ def test_multiple_dot_value_named_group():
         .reset_index()
     )
 
-    assert_frame_equal(result, actual, check_dtype=False)
+    assert_frame_equal(
+        result.loc[:, actual.columns.tolist()], actual, check_dtype=False
+    )
 
 
 @pytest.fixture
@@ -1136,7 +1140,9 @@ def test_names_pattern_single_column_not_dot_value(single_val):
     df = single_val[["x1"]]
     result = df.pivot_longer(names_to="yA", names_pattern="(.+)")
 
-    assert_frame_equal(result, df.melt(var_name="yA"))
+    actual = df.melt(var_name="yA")
+
+    assert_frame_equal(result.loc[:, actual.columns.tolist()], actual)
 
 
 def test_names_pattern_single_column_not_dot_value1(single_val):
@@ -1145,8 +1151,9 @@ def test_names_pattern_single_column_not_dot_value1(single_val):
     """
     df = single_val[["id", "x1"]]
     result = df.pivot_longer(index="id", names_to="yA", names_pattern="(.+)")
+    actual = df.melt("id", var_name="yA")
 
-    assert_frame_equal(result, df.melt("id", var_name="yA"))
+    assert_frame_equal(result.loc[:, actual.columns.tolist()], actual)
 
 
 def test_names_pattern_seq_single_column(single_val):
@@ -1198,9 +1205,10 @@ def test_names_pattern_nulls_in_data(df_null):
         df_null, ["dob", "gender"], i="family", j="child", sep="_", suffix=".+"
     ).reset_index()
 
-    assert_frame_equal(result, actual)
+    assert_frame_equal(result.loc[:, actual.columns.tolist()], actual)
 
 
+@pytest.mark.xfail(reason="dropna deprecated")
 def test_dropna_multiple_columns(df_null):
     """Test output if dropna = True."""
     result = df_null.pivot_longer(

--- a/tests/functions/test_pivot_longer_spec.py
+++ b/tests/functions/test_pivot_longer_spec.py
@@ -128,12 +128,6 @@ def test_df_columns_is_unique(df_checks):
         df_checks.pipe(pivot_longer_spec, spec=spec, df_columns_is_unique=1)
 
 
-def test_dropna(df_checks):
-    """Raise error if dropna is not boolean."""
-    with pytest.raises(TypeError, match="dropna should be one of.+"):
-        df_checks.pipe(pivot_longer_spec, spec=spec, dropna=1)
-
-
 def test_pivot_longer_spec(df_checks):
     """
     Test output if a specification is passed.
@@ -143,7 +137,9 @@ def test_pivot_longer_spec(df_checks):
         df_checks, stubnames="ht", i=["famid", "birth"], j="age"
     ).reset_index()
     assert_frame_equal(
-        actual.sort_values(actual.columns.tolist(), ignore_index=True),
+        actual.loc[:, expected.columns.tolist()].sort_values(
+            actual.columns.tolist(), ignore_index=True
+        ),
         expected.sort_values(actual.columns.tolist(), ignore_index=True),
     )
 

--- a/tests/functions/test_pivot_longer_spec.py
+++ b/tests/functions/test_pivot_longer_spec.py
@@ -66,24 +66,6 @@ def test_spec_columns_has_dot_value(df_checks):
         )
 
 
-def test_spec_columns_name_value_order(df_checks):
-    """
-    Raise ValueError if '.name' and '.value'
-    are not the first two labels
-    in spec's columns.
-    """
-    msg = "The first two columns of the spec DataFrame "
-    msg += "should be '.name' and '.value',.+"
-    with pytest.raises(
-        ValueError,
-        match=msg,
-    ):
-        df_checks.pipe(
-            pivot_longer_spec,
-            spec=spec.loc[:, [".value", ".name", "age"]],
-        )
-
-
 def test_spec_columns_dot_name_unique(df_checks):
     """Raise ValueError if '.name' column is not unique."""
     with pytest.raises(


### PR DESCRIPTION
# PR Description

Please describe the changes proposed in the pull request:

- all forms of pivot_longer handled by two major functions `reshape_by_spec` and `reshape_by_spec_others`
- at its core, any pivot_longer function has to create a spec and pass to one of the two functions above.
- add lots of comments on the implementation logic (for future me or others)
- deprecate `dropna` - no perf difference if user does it, and is not needed within `pivot_longer`, plus we avoid the complexity of determing which NA rows to drop

**This PR improves pivot_longer.**


Please tag maintainers to review.

- @ericmjl
