### PR TITLE
[DOC] Un-deprecate join_apply (#1399)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -113,3 +113,4 @@ Contributors
 - [@xujiboy](https://github.com/xujiboy) | [contributions](https://github.com/pyjanitor-devs/pyjanitor/issues?q=is%3Aclosed+mentions%xujiboy)
 - [@joranbeasley](https://github.com/joranbeasley) | [contributions](https://github.com/pyjanitor-devs/pyjanitor/issues?q=is%3Aclosed+mentions%joranbeasley)
 -[@kianmeng](https://github.com/kianmeng) | [contributions](https://github.com/pyjanitor-devs/pyjanitor/pull/1290#issue-1906020324)
+- [@lbeltrame](https://github.com/lbeltrame) | [contributions](https://github.com/pyjanitor-devs/pyjanitor/pull/1401)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+-   [DOC] Un-deprecate `join_apply` as no alternative currently exists - Issue #1399 @lbeltrame
+
 ## [v0.28.1] - 2024-08-09
 
 ## [v0.28.0] - 2024-08-03

--- a/janitor/functions/join_apply.py
+++ b/janitor/functions/join_apply.py
@@ -5,16 +5,8 @@ from typing import Callable
 import pandas as pd
 import pandas_flavor as pf
 
-from janitor.utils import refactored_function
-
 
 @pf.register_dataframe_method
-@refactored_function(
-    message=(
-        "This function will be deprecated in a 1.x release. "
-        "Please use `jn.transform_columns` instead."
-    )
-)
 def join_apply(
     df: pd.DataFrame,
     func: Callable,
@@ -28,12 +20,6 @@ def join_apply(
     that take any combination of information from any of the columns. The only
     requirement is that the function signature takes in a row from the
     DataFrame.
-
-    !!!note
-
-        This function will be deprecated in a 1.x release.
-        Please use [`jn.transform_column`][janitor.functions.transform_columns.transform_column]
-        instead.
 
     Examples:
         Sum the result of two columns into a new column.


### PR DESCRIPTION
# PR Description

There is no current alternative to row-wise operations, so revert the deprecation for now as discussed in issue #1399.

<!-- Doing so provides maintainers with context on what the PR is, and can help us more effectively review your PR. -->

<!-- Please also identify below which issue that has been raised that you are going to close. -->

**This PR resolves #1399 .**

# PR Checklist

Please ensure that you have done the following:

1. [x] PR in from a fork off your branch. Do not PR from `<your_username>`:`dev`, but rather from `<your_username>`:`<feature-branch_name>`.
2. [x] If you're not on the contributors list, add yourself to `AUTHORS.md`.
3. [x] Add a line to `CHANGELOG.md` under the latest version header (i.e. the one that is "on deck") describing the contribution.


# Relevant Reviewers

Please tag maintainers to review.

- @ericmjl
- @samukweku 
