### PR TITLE
refactor(api/functions)🔧: Refactor function name for clarity

### DIFF
--- a/mkdocs/api/functions.md
+++ b/mkdocs/api/functions.md
@@ -7,7 +7,7 @@
         - also
         - bin_numeric
         - case_when
-        - change_index_type
+        - change_index_dtype
         - change_type
         - clean_names
         - coalesce


### PR DESCRIPTION
- Rename 'change_index_type' to 'change_index_dtype' to better reflect its functionality.

Resolves #1412.