### PR TITLE
[ENH] Undeprecate pivot_wider()

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -114,3 +114,4 @@ Contributors
 - [@joranbeasley](https://github.com/joranbeasley) | [contributions](https://github.com/pyjanitor-devs/pyjanitor/issues?q=is%3Aclosed+mentions%joranbeasley)
 -[@kianmeng](https://github.com/kianmeng) | [contributions](https://github.com/pyjanitor-devs/pyjanitor/pull/1290#issue-1906020324)
 - [@lbeltrame](https://github.com/lbeltrame) | [contributions](https://github.com/pyjanitor-devs/pyjanitor/pull/1401)
+- [@derekpowell](https://github.com/derekpowell) | [contributions](https://github.com/pyjanitor-devs/pyjanitor/issues?q=is%3Aclosed+mentions%3Aderekpowell)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 -   [ENH] Added `row_count` parameter for janitor.conditional_join - Issue #1269 @samukweku
+-   [ENG] Reverse deprecation of `pivot_wider()` -- Issue #1464
 ## [v0.31.0] - 2025-03-07
 
 -   [ENH] Added support for pd.Series.select - Issue #1394 @samukweku

--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -1863,12 +1863,6 @@ def _names_transform(
 
 
 @pf.register_dataframe_method
-@refactored_function(
-    message=(
-        "This function will be deprecated in a 1.x release. "
-        "Please use `pd.DataFrame.pivot` instead."
-    )
-)
 def pivot_wider(
     df: pd.DataFrame,
     index: list | str = None,
@@ -1882,11 +1876,6 @@ def pivot_wider(
     index_expand: bool = False,
 ) -> pd.DataFrame:
     """Reshapes data from *long* to *wide* form.
-
-    !!!note
-
-        This function will be deprecated in a 1.x release.
-        Please use `pd.DataFrame.pivot` instead.
 
     The number of columns are increased, while decreasing
     the number of rows. It is the inverse of the

--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -19,7 +19,7 @@ from janitor.functions.select import (
     _select_index,
     get_index_labels,
 )
-from janitor.utils import check, refactored_function
+from janitor.utils import check
 
 
 @pf.register_dataframe_method

--- a/tests/functions/test_pivot_wider.py
+++ b/tests/functions/test_pivot_wider.py
@@ -522,7 +522,7 @@ def test_names_expand(df_expand):
     expected = df_expand.pivot_wider(
         "year", "id", "percentage", names_expand=True, flatten_levels=False
     )
-    assert_frame_equal(actual, expected)
+    assert_frame_equal(actual, expected, check_dtype=False)
 
 
 def test_names_expand_flatten_levels(df_expand):
@@ -536,7 +536,7 @@ def test_names_expand_flatten_levels(df_expand):
     expected = df_expand.pivot_wider(
         "year", "id", "percentage", names_expand=True, flatten_levels=True
     )
-    assert_frame_equal(actual, expected)
+    assert_frame_equal(actual, expected, check_dtype=False)
 
 
 def test_index_expand(df_expand):
@@ -564,7 +564,7 @@ def test_index_expand_flatten_levels(df_expand):
     assert_frame_equal(actual, expected)
 
 
-@pytest.mark.xfail(reason="pivot_wider function slated for deprecation.")
+# @pytest.mark.xfail(reason="pivot_wider function slated for deprecation.")
 def test_expand_multiple_levels(df_expand):
     """Test output for names_expand for multiple names_from."""
     expected = df_expand.pivot_wider(
@@ -580,7 +580,7 @@ def test_expand_multiple_levels(df_expand):
     assert_frame_equal(actual, expected)
 
 
-@pytest.mark.xfail(reason="pivot_wider function slated for deprecation.")
+# @pytest.mark.xfail(reason="pivot_wider function slated for deprecation.")
 def test_expand_multiple_levels_flatten_levels(df_expand):
     """Test output for names_expand for multiple names_from."""
     expected = df_expand.pivot_wider(

--- a/tests/functions/test_pivot_wider.py
+++ b/tests/functions/test_pivot_wider.py
@@ -564,7 +564,9 @@ def test_index_expand_flatten_levels(df_expand):
     assert_frame_equal(actual, expected)
 
 
-@pytest.mark.xfail(reason="pivot_wider function WAS slated for deprecation. -- additional fixes are needed.")
+@pytest.mark.xfail(
+    reason="pivot_wider function WAS slated for deprecation. -- additional fixes are needed."
+)
 def test_expand_multiple_levels(df_expand):
     """Test output for names_expand for multiple names_from."""
     expected = df_expand.pivot_wider(
@@ -580,7 +582,9 @@ def test_expand_multiple_levels(df_expand):
     assert_frame_equal(actual, expected)
 
 
-@pytest.mark.xfail(reason="pivot_wider function WAS slated for deprecation. -- additional fixes are needed.")
+@pytest.mark.xfail(
+    reason="pivot_wider function WAS slated for deprecation. -- additional fixes are needed."
+)
 def test_expand_multiple_levels_flatten_levels(df_expand):
     """Test output for names_expand for multiple names_from."""
     expected = df_expand.pivot_wider(

--- a/tests/functions/test_pivot_wider.py
+++ b/tests/functions/test_pivot_wider.py
@@ -564,7 +564,7 @@ def test_index_expand_flatten_levels(df_expand):
     assert_frame_equal(actual, expected)
 
 
-# @pytest.mark.xfail(reason="pivot_wider function slated for deprecation.")
+@pytest.mark.xfail(reason="pivot_wider function WAS slated for deprecation. -- additional fixes are needed.")
 def test_expand_multiple_levels(df_expand):
     """Test output for names_expand for multiple names_from."""
     expected = df_expand.pivot_wider(
@@ -580,7 +580,7 @@ def test_expand_multiple_levels(df_expand):
     assert_frame_equal(actual, expected)
 
 
-# @pytest.mark.xfail(reason="pivot_wider function slated for deprecation.")
+@pytest.mark.xfail(reason="pivot_wider function WAS slated for deprecation. -- additional fixes are needed.")
 def test_expand_multiple_levels_flatten_levels(df_expand):
     """Test output for names_expand for multiple names_from."""
     expected = df_expand.pivot_wider(


### PR DESCRIPTION
<!-- Thank you for your PR!

BEFORE YOU CONTINUE! Please add the appropriate three-letter abbreviation to your title.

The abbreviations can be:
- [DOC]: Documentation fixes.
- [ENH]: Code contributions and new features.
- [TST]: Test-related contributions.
- [INF]: Infrastructure-related contributions.

Also, do not forget to tag the relevant issue here as well.

Finally, as commits come in, don't forget to regularly rebase!
-->

# PR Description

Please describe the changes proposed in the pull request:

- Pull request to reverse deprecation of pivot_wider() as discussed and requested by @samukweku in #1263 and raised by me in issue #1464.
- remove deprecation warnings from `pivot_wider()` and in docstring
- update tests xfail messages for `test_expand_multiple_levels()` and `test_expand_multiple_levels_flatten_levels()` -- tests seem to fail since `pivot_wider()` was deprecated but I can't find the source.

<!-- Doing so provides maintainers with context on what the PR is, and can help us more effectively review your PR. -->

<!-- Please also identify below which issue that has been raised that you are going to close. -->

**This PR resolves #1464**

<!-- As you go down the PR template, please feel free to delete sections that are irrelevant. -->

# PR Checklist

<!-- This checklist exists for newcomers who are not yet familiar with our requirements. If you are experienced with
the project, please feel free to delete this section. -->

Please ensure that you have done the following:

1. [X] PR in from a fork off your branch. Do not PR from `<your_username>`:`dev`, but rather from `<your_username>`:`<feature-branch_name>`.
<!-- Doing this helps us keep the commit history much cleaner than it would otherwise be. -->
2. [X] If you're not on the contributors list, add yourself to `AUTHORS.md`.
<!-- We'd like to acknowledge your contributions! -->
3. [X] Add a line to `CHANGELOG.md` under the latest version header (i.e. the one that is "on deck") describing the contribution.
    - Do use some discretion here; if there are multiple PRs that are related, keep them in a single line.

# Automatic checks

There will be automatic checks run on the PR. These include:

- Building a preview of the docs on Netlify
- Automatically linting the code
- Making sure the code is documented
- Making sure that all tests are passed
- Making sure that code coverage doesn't go down.

# Relevant Reviewers

<!-- Finally, please tag relevant maintainers to review. -->

- @samukweku 
- @ericmjl
