### PR TITLE
[ENH] Fix polars deprecation warnings for `str.concat`

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -115,3 +115,4 @@ Contributors
 -[@kianmeng](https://github.com/kianmeng) | [contributions](https://github.com/pyjanitor-devs/pyjanitor/pull/1290#issue-1906020324)
 - [@lbeltrame](https://github.com/lbeltrame) | [contributions](https://github.com/pyjanitor-devs/pyjanitor/pull/1401)
 - [@derekpowell](https://github.com/derekpowell) | [contributions](https://github.com/pyjanitor-devs/pyjanitor/issues?q=is%3Aclosed+mentions%3Aderekpowell)
+- [@emmanuel-ferdman](https://github.com/emmanuel-ferdman) | [contributions](https://github.com/pyjanitor-devs/pyjanitor/issues?q=is%3Aclosed+mentions%3Aemmanuel-ferdman)

--- a/janitor/polars/pivot_longer.py
+++ b/janitor/polars/pivot_longer.py
@@ -534,7 +534,7 @@ def _pivot_longer_create_spec(
         expression = (
             pl.col(".name")
             .str.split(by=names_sep)
-            .list.to_struct(n_field_strategy="max_width")
+            .list.to_struct(upper_bound=len(names_to))
             .alias(variable_name)
         )
     else:

--- a/janitor/polars/row_to_names.py
+++ b/janitor/polars/row_to_names.py
@@ -162,7 +162,7 @@ def _row_to_names_dispatch(  # noqa: F811
             "The step argument for slice is not supported in row_to_names."
         )
     headers = df.slice(row_numbers.start, row_numbers.stop - row_numbers.start)
-    expression = pl.all().str.concat(delimiter=separator)
+    expression = pl.all().str.join(delimiter=separator)
     headers = headers.select(expression).row(0, named=True)
     headers = {col: str(repl) for col, repl in headers.items()}
     df = df.rename(mapping=headers)
@@ -193,7 +193,7 @@ def _row_to_names_dispatch(  # noqa: F811
         check("entry in the row_numbers argument", entry, [int])
 
     expression = pl.all().gather(row_numbers)
-    expression = expression.str.concat(delimiter=separator)
+    expression = expression.str.join(delimiter=separator)
     headers = df.select(expression).row(0, named=True)
     headers = {col: str(repl) for col, repl in headers.items()}
     df = df.rename(mapping=headers)


### PR DESCRIPTION
# PR Description

This PR replaces the deprecated `str.concat()` with `str.join()` in polars `row_to_names` function. The two methods are functionally identical when an explicit delimiter is provided, which is the case in all instances here.

Fixes #1495.

# PR Checklist

<!-- This checklist exists for newcomers who are not yet familiar with our requirements. If you are experienced with
the project, please feel free to delete this section. -->

Please ensure that you have done the following:

1. [x] PR in from a fork off your branch. Do not PR from `<your_username>`:`dev`, but rather from `<your_username>`:`<feature-branch_name>`.
<!-- Doing this helps us keep the commit history much cleaner than it would otherwise be. -->
2. [x] If you're not on the contributors list, add yourself to `AUTHORS.md`.
<!-- We'd like to acknowledge your contributions! -->
3. [ ] Add a line to `CHANGELOG.md` under the latest version header (i.e. the one that is "on deck") describing the contribution.
    - Do use some discretion here; if there are multiple PRs that are related, keep them in a single line.

# Automatic checks

There will be automatic checks run on the PR. These include:

- Building a preview of the docs on Netlify
- Automatically linting the code
- Making sure the code is documented
- Making sure that all tests are passed
- Making sure that code coverage doesn't go down.

# Relevant Reviewers

<!-- Finally, please tag relevant maintainers to review. -->

Please tag maintainers to review.

- @ericmjl
