### PR TITLE
[enh] remove `by` feature of `summarise` and `mutate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 -   [ENH] Added `row_count` parameter for janitor.conditional_join - Issue #1269 @samukweku
 -   [ENH] Reverse deprecation of `pivot_wider()` -- Issue #1464
 -   [ENH] Add accessor and method for pandas DataFrameGroupBy objects. - Issue #587 @samukweku
--   [ENH] Call mutate/summarise directly on groupby objects instead. - Issue #1511 @samukweku
+-   [ENH] Call mutate/summarise directly on groupby objects instead. Also add `ungroup` method to expose underlying dataframe of a grouped object. - Issue #1511 @samukweku
 
 ## [v0.31.0] - 2025-03-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 -   [ENH] Added `row_count` parameter for janitor.conditional_join - Issue #1269 @samukweku
 -   [ENH] Reverse deprecation of `pivot_wider()` -- Issue #1464
 -   [ENH] Add accessor and method for pandas DataFrameGroupBy objects. - Issue #587 @samukweku
+-   [ENH] Call mutate/summarise directly on groupby objects instead. - Issue #1511 @samukweku
 
 ## [v0.31.0] - 2025-03-07
 

--- a/janitor/functions/mutate.py
+++ b/janitor/functions/mutate.py
@@ -3,24 +3,18 @@
 from __future__ import annotations
 
 from functools import singledispatch
-from typing import Any
 
 import pandas as pd
 import pandas_flavor as pf
-from pandas.api.types import is_scalar
 from pandas.core.common import apply_if_callable
-from pandas.core.groupby.generic import DataFrameGroupBy
 
 from janitor.functions.select import get_index_labels
-from janitor.utils import check
 
 
 @pf.register_dataframe_method
 def mutate(
     df: pd.DataFrame,
     *args: tuple[dict | tuple],
-    by: Any = None,
-    copy: bool = True,
 ) -> pd.DataFrame:
     """
 
@@ -94,21 +88,11 @@ def mutate(
 
     - **callable argument**:
     If the argument is a callable, the callable is applied
-    on the DataFrame or GroupBy object.
+    on the DataFrame.
     The result from the callable should be a pandas Series
     or DataFrame.
 
-    `by` can be a `DataFrameGroupBy` object; it is assumed that
-    `by` was created from `df` - the onus is on the user to
-    ensure that, or the aggregations may yield incorrect results.
-
-    `by` accepts anything supported by `pd.DataFrame.groupby`.
-
-    Arguments supported in `pd.DataFrame.groupby`
-    can also be passed to `by` via a dictionary.
-
-    Mutation does not occur on the original DataFrame;
-    change this behaviour by passing `copy=False`.
+    Mutation does not occur on the original DataFrame.
 
     Examples:
         >>> import pandas as pd
@@ -149,26 +133,9 @@ def mutate(
         1    10     6   100    116
         2    15     9  1000   1024
 
-        Transformation in the presence of a groupby:
-        >>> data = {'avg_jump': [3, 4, 1, 2, 3, 4],
-        ...         'avg_run': [3, 4, 1, 3, 2, 4],
-        ...         'combine_id': [100200, 100200,
-        ...                        101200, 101200,
-        ...                        102201, 103202]}
-        >>> df = pd.DataFrame(data)
-        >>> df.mutate({"avg_run_2":("avg_run","mean")}, by='combine_id')
-           avg_jump  avg_run  combine_id  avg_run_2
-        0         3        3      100200        3.5
-        1         4        4      100200        3.5
-        2         1        1      101200        2.0
-        3         2        3      101200        2.0
-        4         3        2      102201        2.0
-        5         4        4      103202        4.0
-
     Args:
         df: A pandas DataFrame.
         args: Either a dictionary or a tuple.
-        by: Column(s) to group by.
 
     Raises:
         ValueError: If a tuple is passed and the length is not 2.
@@ -176,33 +143,15 @@ def mutate(
     Returns:
         A pandas DataFrame or Series with aggregated columns.
     """  # noqa: E501
-    check("copy", copy, [bool])
-    if copy:
-        df = df.copy(deep=None)
-    if by is not None:
-        if isinstance(by, DataFrameGroupBy):
-            # it is assumed that by is created from df
-            # onus is on user to ensure that
-            pass
-        elif isinstance(by, dict):
-            by = df.groupby(**by)
-        else:
-            if is_scalar(by):
-                by = [by]
-            by = df.groupby(by, sort=False, observed=True)
-
+    df = df.copy(deep=None)
     for arg in args:
-        df = _mutator(arg, df=df, by=by)
+        df = _mutator(arg, df=df)
     return df
 
 
 @singledispatch
-def _mutator(arg, df, by):
-    if by is None:
-        val = df
-    else:
-        val = by
-    outcome = _process_maybe_callable(func=arg, obj=val)
+def _mutator(arg, df):
+    outcome = _process_maybe_callable(func=arg, obj=df)
     if isinstance(outcome, pd.Series):
         if not outcome.name:
             raise ValueError("Ensure the pandas Series object has a name")
@@ -218,31 +167,27 @@ def _mutator(arg, df, by):
 
 
 @_mutator.register(dict)
-def _(arg, df, by):
+def _(arg, df):
     """Dispatch function for dictionary"""
-    if by is None:
-        val = df
-    else:
-        val = by
     for column_name, mutator in arg.items():
         if isinstance(mutator, tuple):
             column, func = mutator
-            column = _apply_func_to_obj(mutator=func, obj=val[column])
+            column = _apply_func_to_obj(mutator=func, obj=df[column])
         else:
-            column = _apply_func_to_obj(mutator=mutator, obj=val[column_name])
+            column = _apply_func_to_obj(mutator=mutator, obj=df[column_name])
         df[column_name] = column
     return df
 
 
 @_mutator.register(tuple)
-def _(arg, df, by):
+def _(arg, df):
     """Dispatch function for tuple"""
     if len(arg) != 2:
         raise ValueError("the tuple has to be a length of 2")
     column_names, mutator = arg
     column_names = get_index_labels(arg=[column_names], df=df, axis="columns")
     mapping = {column_name: mutator for column_name in column_names}
-    return _mutator(mapping, df=df, by=by)
+    return _mutator(mapping, df=df)
 
 
 def _process_maybe_callable(func: callable, obj):

--- a/janitor/functions/mutate.py
+++ b/janitor/functions/mutate.py
@@ -7,13 +7,15 @@ from functools import singledispatch
 import pandas as pd
 import pandas_flavor as pf
 from pandas.core.common import apply_if_callable
+from pandas.core.groupby.generic import DataFrameGroupBy
 
 from janitor.functions.select import get_index_labels
 
 
+@pf.register_groupby_method
 @pf.register_dataframe_method
 def mutate(
-    df: pd.DataFrame,
+    df: pd.DataFrame | DataFrameGroupBy,
     *args: tuple[dict | tuple],
 ) -> pd.DataFrame:
     """
@@ -143,15 +145,25 @@ def mutate(
     Returns:
         A pandas DataFrame or Series with aggregated columns.
     """  # noqa: E501
+    if isinstance(df, DataFrameGroupBy):
+        df_ = df.obj.copy(deep=None)
+        for arg in args:
+            df_ = _mutator(arg, df=df_, by=df)
+        df.obj = df_
+        return df
     df = df.copy(deep=None)
     for arg in args:
-        df = _mutator(arg, df=df)
+        df = _mutator(arg, df=df, by=None)
     return df
 
 
 @singledispatch
-def _mutator(arg, df):
-    outcome = _process_maybe_callable(func=arg, obj=df)
+def _mutator(arg, df, by):
+    if by is None:
+        val = df
+    else:
+        val = by
+    outcome = _process_maybe_callable(func=arg, obj=val)
     if isinstance(outcome, pd.Series):
         if not outcome.name:
             raise ValueError("Ensure the pandas Series object has a name")
@@ -167,27 +179,31 @@ def _mutator(arg, df):
 
 
 @_mutator.register(dict)
-def _(arg, df):
+def _(arg, df, by):
     """Dispatch function for dictionary"""
+    if by is None:
+        val = df
+    else:
+        val = by
     for column_name, mutator in arg.items():
         if isinstance(mutator, tuple):
             column, func = mutator
-            column = _apply_func_to_obj(mutator=func, obj=df[column])
+            column = _apply_func_to_obj(mutator=func, obj=val[column])
         else:
-            column = _apply_func_to_obj(mutator=mutator, obj=df[column_name])
+            column = _apply_func_to_obj(mutator=mutator, obj=val[column_name])
         df[column_name] = column
     return df
 
 
 @_mutator.register(tuple)
-def _(arg, df):
+def _(arg, df, by):
     """Dispatch function for tuple"""
     if len(arg) != 2:
         raise ValueError("the tuple has to be a length of 2")
     column_names, mutator = arg
     column_names = get_index_labels(arg=[column_names], df=df, axis="columns")
     mapping = {column_name: mutator for column_name in column_names}
-    return _mutator(mapping, df=df)
+    return _mutator(mapping, df=df, by=by)
 
 
 def _process_maybe_callable(func: callable, obj):

--- a/janitor/functions/mutate.py
+++ b/janitor/functions/mutate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 from functools import singledispatch
 
 import pandas as pd
@@ -10,6 +11,51 @@ from pandas.core.common import apply_if_callable
 from pandas.core.groupby.generic import DataFrameGroupBy
 
 from janitor.functions.select import get_index_labels
+
+
+@pf.register_groupby_method
+def ungroup(
+    df: DataFrameGroupBy,
+) -> pd.DataFrame:
+    """
+
+    !!! info "New in version 0.32.0"
+
+    Ungroups a GroupBy object into a DataFrame.
+
+    Examples:
+        >>> import pandas as pd
+        >>> import janitor
+        >>> data = {'avg_jump': [3, 4, 1, 2, 3, 4],
+        ...         'avg_run': [3, 4, 1, 3, 2, 4],
+        ...         'combine_id': [100200, 100200,
+        ...                        101200, 101200,
+        ...                        102201, 103202]}
+        >>> df = pd.DataFrame(data)
+        >>> df
+           avg_jump  avg_run  combine_id
+        0         3        3      100200
+        1         4        4      100200
+        2         1        1      101200
+        3         2        3      101200
+        4         3        2      102201
+        5         4        4      103202
+        >>> df.groupby('combine_id').mutate('mean').ungroup()
+           avg_jump  avg_run  combine_id
+        0       3.5      3.5      100200
+        1       3.5      3.5      100200
+        2       1.5      2.0      101200
+        3       1.5      2.0      101200
+        4       3.0      2.0      102201
+        5       4.0      4.0      103202
+
+    Args:
+        df: A pandas GroupBy object.
+
+    Returns:
+        A pandas DataFrame.
+    """
+    return df.obj
 
 
 @pf.register_groupby_method
@@ -136,16 +182,17 @@ def mutate(
         2    15     9  1000   1024
 
     Args:
-        df: A pandas DataFrame.
+        df: A pandas DataFrame or GroupBy object.
         args: Either a dictionary or a tuple.
 
     Raises:
         ValueError: If a tuple is passed and the length is not 2.
 
     Returns:
-        A pandas DataFrame or Series with aggregated columns.
+        A pandas DataFrame or Series with possibly mutated columns.
     """  # noqa: E501
     if isinstance(df, DataFrameGroupBy):
+        df = copy.copy(df)
         df_ = df.obj.copy(deep=None)
         for arg in args:
             df_ = _mutator(arg, df=df_, by=df)

--- a/janitor/functions/mutate.py
+++ b/janitor/functions/mutate.py
@@ -63,7 +63,7 @@ def ungroup(
 def mutate(
     df: pd.DataFrame | DataFrameGroupBy,
     *args: tuple[dict | tuple],
-) -> pd.DataFrame:
+) -> pd.DataFrame | DataFrameGroupBy:
     """
 
     !!! info "New in version 0.31.0"
@@ -189,7 +189,7 @@ def mutate(
         ValueError: If a tuple is passed and the length is not 2.
 
     Returns:
-        A pandas DataFrame or Series with possibly mutated columns.
+        A pandas DataFrame, Series, or GroupBy object.
     """  # noqa: E501
     if isinstance(df, DataFrameGroupBy):
         df = copy.copy(df)

--- a/janitor/functions/summarise.py
+++ b/janitor/functions/summarise.py
@@ -120,23 +120,27 @@ def summarise(
         5         4        4      103202
 
         Aggregation on a DataFrame via a callable:
-        >>> df.summarise(lambda df: df.mean().rename("mean"))
+        >>> df.summarise(lambda df: df.select('avg*').mean().rename("mean"))
                              mean
         avg_jump         2.833333
         avg_run          2.833333
-        combine_id  101367.166667
+
         Aggregation on a DataFrame via a tuple:
         >>> df.summarise(("avg_*",'mean'))
               avg_jump   avg_run
         mean  2.833333  2.833333
+
         Aggregation on a DataFrame via a dictionary:
         >>> df.summarise({'avg_jump':'mean'})
               avg_jump
         mean  2.833333
+
         >>> df.summarise({"avg_run_2":("avg_run","mean")})
               avg_run_2
         mean   2.833333
+
         >>> grouped = df.groupby('combine_id')
+
         Aggregation on a grouped object via a callable:
         >>> grouped.summarise(lambda df: df.sum())
                     avg_jump  avg_run

--- a/janitor/functions/summarise.py
+++ b/janitor/functions/summarise.py
@@ -118,9 +118,20 @@ def summarise(
         3         2        3      101200
         4         3        2      102201
         5         4        4      103202
-
-        Aggregation via a callable:
-        >>> df.summarise(lambda df: df.sum(),by='combine_id')
+        Aggregation on a DataFrame via a tuple:
+        >>> df.summarise(("avg_*",'mean'))
+              avg_jump   avg_run
+        mean  2.833333  2.833333
+        Aggregation on a DataFrame via a dictionary:
+        >>> df.summarise({'avg_jump':'mean'})
+              avg_jump
+        mean  2.833333
+        >>> df.summarise({"avg_run_2":("avg_run","mean")})
+              avg_run_2
+        mean   2.833333
+        >>> grouped = df.groupby('combine_id')
+        Aggregation on a grouped object via a callable:
+        >>> grouped.summarise(lambda df: df.sum())
                     avg_jump  avg_run
         combine_id
         100200             7        7
@@ -128,8 +139,8 @@ def summarise(
         102201             3        2
         103202             4        4
 
-        Aggregation via a tuple:
-        >>> df.summarise(("avg_run","mean"), by='combine_id')
+        Aggregation on a grouped object via a tuple:
+        >>> grouped.summarise(("avg_run","mean"))
                     avg_run
         combine_id
         100200          3.5
@@ -137,15 +148,15 @@ def summarise(
         102201          2.0
         103202          4.0
 
-        Aggregation via a dictionary:
-        >>> df.summarise({"avg_run":"mean"}, by='combine_id')
+        Aggregation on a grouped object via a dictionary:
+        >>> grouped.summarise({"avg_run":"mean"})
                     avg_run
         combine_id
         100200          3.5
         101200          2.0
         102201          2.0
         103202          4.0
-        >>> df.summarise({"avg_run_2":("avg_run","mean")}, by='combine_id')
+        >>> grouped.summarise({"avg_run_2":("avg_run","mean")})
                     avg_run_2
         combine_id
         100200            3.5
@@ -156,7 +167,6 @@ def summarise(
     Args:
         df: A pandas DataFrame or DataFrameGroupBy object.
         args: Either a dictionary or a tuple.
-        by: Column(s) to group by.
 
     Raises:
         ValueError: If a tuple is passed and the length is not 2.

--- a/janitor/functions/summarise.py
+++ b/janitor/functions/summarise.py
@@ -19,7 +19,6 @@ from janitor.functions.select import get_index_labels
 def summarise(
     df: pd.DataFrame | DataFrameGroupBy,
     *args: tuple[dict | tuple],
-    by: Any = None,
 ) -> pd.DataFrame:
     """
 
@@ -99,16 +98,8 @@ def summarise(
     Aggregated columns cannot be reused in `summarise`.
 
 
-    `by` can be a `DataFrameGroupBy` object; it is assumed that
-    `by` was created from `df` - the onus is on the user to
-    ensure that, or the aggregations may yield incorrect results.
-
-    `by` accepts anything supported by `pd.DataFrame.groupby`.
-
     Arguments supported in `pd.DataFrame.groupby`
     can also be passed to `by` via a dictionary.
-
-    If `df` is a `DataFrameGroupBy` object, `by` is ignored.
 
     Examples:
         >>> import pandas as pd
@@ -177,17 +168,8 @@ def summarise(
     if isinstance(df, DataFrameGroupBy):
         by = df
         df = df.obj
-    elif by is not None:
-        # it is assumed that by is created from df
-        # onus is on user to ensure that
-        if isinstance(by, DataFrameGroupBy):
-            pass
-        elif isinstance(by, dict):
-            by = df.groupby(**by)
-        else:
-            if is_scalar(by):
-                by = [by]
-            by = df.groupby(by, sort=False, observed=True)
+    else:
+        by = None
     contents = []
     for arg in args:
         aggregate = _aggfunc(arg, df=df, by=by)

--- a/janitor/functions/summarise.py
+++ b/janitor/functions/summarise.py
@@ -118,6 +118,13 @@ def summarise(
         3         2        3      101200
         4         3        2      102201
         5         4        4      103202
+
+        Aggregation on a DataFrame via a callable:
+        >>> df.summarise(lambda df: df.mean().rename("mean"))
+                             mean
+        avg_jump         2.833333
+        avg_run          2.833333
+        combine_id  101367.166667
         Aggregation on a DataFrame via a tuple:
         >>> df.summarise(("avg_*",'mean'))
               avg_jump   avg_run

--- a/janitor/polars/dates_to_polars.py
+++ b/janitor/polars/dates_to_polars.py
@@ -92,7 +92,7 @@ def convert_matlab_date(expr: pl.Expr) -> pl.Expr:
         ┌───────────────┬─────────────────────────┐
         │ date          ┆ date_                   │
         │ ---           ┆ ---                     │
-        │ f64           ┆ datetime[μs]            │
+        │ f64           ┆ datetime[ms]            │
         ╞═══════════════╪═════════════════════════╡
         │ 737125.0      ┆ 2018-03-06 00:00:00     │
         │ 737124.815863 ┆ 2018-03-05 19:34:50.563 │
@@ -108,5 +108,5 @@ def convert_matlab_date(expr: pl.Expr) -> pl.Expr:
     # https://stackoverflow.com/questions/13965740/converting-matlabs-datenum-format-to-python
     expression = expr.sub(719529).mul(86_400_000)
     expression = pl.duration(milliseconds=expression)
-    expression += pl.datetime(year=1970, month=1, day=1)
+    expression += pl.datetime(year=1970, month=1, day=1, time_unit="ms")
     return expression

--- a/tests/functions/test_mutate.py
+++ b/tests/functions/test_mutate.py
@@ -97,3 +97,88 @@ def test_mutate_tuple_df_callable(df_mutate):
     actual = df_mutate.mutate(("avg_run", lambda df: df.sum()))
     expected = df_mutate.assign(avg_run=df_mutate["avg_run"].sum())
     assert_frame_equal(actual, expected)
+
+
+def test_mutate_callable_by_grouped_object(df_mutate):
+    """Test output for callable"""
+
+    actual = df_mutate.groupby("combine_id").mutate(
+        lambda df: df.avg_run.transform("sum")
+    )
+    grp = df_mutate.groupby("combine_id")
+    expected = df_mutate.assign(avg_run=grp["avg_run"].transform("sum"))
+    assert_frame_equal(actual.obj, expected)
+
+
+def test_mutate_dict_by_str(df_mutate):
+    """Test output for a dictionary"""
+    actual = df_mutate.groupby("combine_id").mutate({"avg_run": "mean"})
+    grp = df_mutate.groupby("combine_id")["avg_run"]
+    expected = df_mutate.assign(avg_run=grp.transform("mean"))
+    assert_frame_equal(actual.obj, expected)
+
+
+def test_mutate_dict_by_callable(df_mutate):
+    """Test output for a dictionary"""
+    actual = df_mutate.groupby("combine_id").mutate(
+        {"avg_run": lambda df: df.sum()}
+    )
+    expected = df_mutate.assign(
+        avg_run=df_mutate.groupby("combine_id")["avg_run"].transform("sum")
+    )
+    assert_frame_equal(actual.obj, expected)
+
+
+def test_mutate_dict_by_transform_callable(df_mutate):
+    """Test output for a dictionary"""
+    actual = df_mutate.groupby("combine_id").mutate(
+        {"avg_run": lambda df: df.transform("sum")}
+    )
+    expected = df_mutate.assign(
+        avg_run=df_mutate.groupby("combine_id")["avg_run"].transform("sum")
+    )
+    assert_frame_equal(actual.obj, expected)
+
+
+def test_mutate_dict_by_tuple(df_mutate):
+    """Test output for a dictionary"""
+    actual = df_mutate.groupby("combine_id").mutate(
+        {"avg_run_mean": ("avg_run", "mean")}
+    )
+    expected = df_mutate.assign(
+        avg_run_mean=df_mutate.groupby("combine_id")["avg_run"].transform(
+            "mean"
+        )
+    )
+    assert_frame_equal(actual.obj, expected)
+
+
+def test_mutate_by_tuple(df_mutate):
+    """Test output for a dictionary"""
+    actual = df_mutate.groupby("combine_id").mutate(("avg_run", "mean"))
+    expected = df_mutate.assign(
+        avg_run=df_mutate.groupby("combine_id")["avg_run"].transform("mean")
+    )
+    assert_frame_equal(actual.obj, expected)
+
+
+def test_mutate_tuple_by_callable(df_mutate):
+    """Test output for a dictionary"""
+    actual = df_mutate.groupby("combine_id").mutate(
+        ("avg_run", lambda df: df.sum())
+    )
+    expected = df_mutate.assign(
+        avg_run=df_mutate.groupby("combine_id")["avg_run"].transform("sum")
+    )
+    assert_frame_equal(actual.obj, expected)
+
+
+def test_mutate_tuple_by_grouped_object(df_mutate):
+    """Test output for a dictionary"""
+    actual = df_mutate.groupby("combine_id").mutate(
+        ("avg_run", lambda df: df.sum())
+    )
+    expected = df_mutate.assign(
+        avg_run=df_mutate.groupby("combine_id")["avg_run"].transform("sum")
+    )
+    assert_frame_equal(actual.obj, expected)

--- a/tests/functions/test_mutate.py
+++ b/tests/functions/test_mutate.py
@@ -107,7 +107,7 @@ def test_mutate_callable_by_grouped_object(df_mutate):
     )
     grp = df_mutate.groupby("combine_id")
     expected = df_mutate.assign(avg_run=grp["avg_run"].transform("sum"))
-    assert_frame_equal(actual.obj, expected)
+    assert_frame_equal(actual.ungroup(), expected)
 
 
 def test_mutate_dict_by_str(df_mutate):
@@ -115,7 +115,7 @@ def test_mutate_dict_by_str(df_mutate):
     actual = df_mutate.groupby("combine_id").mutate({"avg_run": "mean"})
     grp = df_mutate.groupby("combine_id")["avg_run"]
     expected = df_mutate.assign(avg_run=grp.transform("mean"))
-    assert_frame_equal(actual.obj, expected)
+    assert_frame_equal(actual.ungroup(), expected)
 
 
 def test_mutate_dict_by_callable(df_mutate):
@@ -126,7 +126,7 @@ def test_mutate_dict_by_callable(df_mutate):
     expected = df_mutate.assign(
         avg_run=df_mutate.groupby("combine_id")["avg_run"].transform("sum")
     )
-    assert_frame_equal(actual.obj, expected)
+    assert_frame_equal(actual.ungroup(), expected)
 
 
 def test_mutate_dict_by_transform_callable(df_mutate):
@@ -137,7 +137,7 @@ def test_mutate_dict_by_transform_callable(df_mutate):
     expected = df_mutate.assign(
         avg_run=df_mutate.groupby("combine_id")["avg_run"].transform("sum")
     )
-    assert_frame_equal(actual.obj, expected)
+    assert_frame_equal(actual.ungroup(), expected)
 
 
 def test_mutate_dict_by_tuple(df_mutate):
@@ -150,7 +150,7 @@ def test_mutate_dict_by_tuple(df_mutate):
             "mean"
         )
     )
-    assert_frame_equal(actual.obj, expected)
+    assert_frame_equal(actual.ungroup(), expected)
 
 
 def test_mutate_by_tuple(df_mutate):
@@ -159,7 +159,7 @@ def test_mutate_by_tuple(df_mutate):
     expected = df_mutate.assign(
         avg_run=df_mutate.groupby("combine_id")["avg_run"].transform("mean")
     )
-    assert_frame_equal(actual.obj, expected)
+    assert_frame_equal(actual.ungroup(), expected)
 
 
 def test_mutate_tuple_by_callable(df_mutate):
@@ -170,7 +170,7 @@ def test_mutate_tuple_by_callable(df_mutate):
     expected = df_mutate.assign(
         avg_run=df_mutate.groupby("combine_id")["avg_run"].transform("sum")
     )
-    assert_frame_equal(actual.obj, expected)
+    assert_frame_equal(actual.ungroup(), expected)
 
 
 def test_mutate_tuple_by_grouped_object(df_mutate):
@@ -181,4 +181,4 @@ def test_mutate_tuple_by_grouped_object(df_mutate):
     expected = df_mutate.assign(
         avg_run=df_mutate.groupby("combine_id")["avg_run"].transform("sum")
     )
-    assert_frame_equal(actual.obj, expected)
+    assert_frame_equal(actual.ungroup(), expected)

--- a/tests/functions/test_mutate.py
+++ b/tests/functions/test_mutate.py
@@ -36,14 +36,6 @@ def test_mutate_callable_unnamed_series(df_mutate):
         df_mutate.mutate(lambda df: df.sum(axis=1))
 
 
-def test_mutate_callable_by_grouped_object(df_mutate):
-    """Test output for callable"""
-    grp = df_mutate.groupby("combine_id")
-    actual = df_mutate.mutate(lambda df: df.avg_run.transform("sum"), by=grp)
-    expected = df_mutate.assign(avg_run=grp["avg_run"].transform("sum"))
-    assert_frame_equal(actual, expected)
-
-
 def test_mutate_callable(df_mutate):
     "Raise if output of callable is not a pandas Series/DataFrame"
     with pytest.raises(
@@ -51,12 +43,6 @@ def test_mutate_callable(df_mutate):
         match="The output from the mutation should be a named Series or a DataFrame",
     ):
         df_mutate.mutate(lambda df: np.sum(df["avg_run"]))
-
-
-def test_mutate_check_copy(df_mutate):
-    """Test copy argument is a boolean"""
-    with pytest.raises(TypeError, match="copy should be one of.+"):
-        df_mutate.mutate({"a": "b"}, copy=1)
 
 
 def test_mutate_wrong_arg(df_mutate):
@@ -77,41 +63,10 @@ def test_mutate_dict_df_str(df_mutate):
     assert_frame_equal(actual, expected)
 
 
-def test_mutate_dict_by_str(df_mutate):
-    """Test output for a dictionary"""
-    actual = df_mutate.mutate({"avg_run": "mean"}, by="combine_id")
-    expected = df_mutate.assign(
-        avg_run=df_mutate.groupby("combine_id")["avg_run"].transform("mean")
-    )
-    assert_frame_equal(actual, expected)
-
-
 def test_mutate_dict_df_callable(df_mutate):
     """Test output for a dictionary"""
     actual = df_mutate.mutate({"avg_run": lambda df: df.sum()})
     expected = df_mutate.assign(avg_run=df_mutate["avg_run"].sum())
-    assert_frame_equal(actual, expected)
-
-
-def test_mutate_dict_by_callable(df_mutate):
-    """Test output for a dictionary"""
-    actual = df_mutate.mutate(
-        {"avg_run": lambda df: df.sum()}, by="combine_id"
-    )
-    expected = df_mutate.assign(
-        avg_run=df_mutate.groupby("combine_id")["avg_run"].transform("sum")
-    )
-    assert_frame_equal(actual, expected)
-
-
-def test_mutate_dict_by_transform_callable(df_mutate):
-    """Test output for a dictionary"""
-    actual = df_mutate.mutate(
-        {"avg_run": lambda df: df.transform("sum")}, by="combine_id"
-    )
-    expected = df_mutate.assign(
-        avg_run=df_mutate.groupby("combine_id")["avg_run"].transform("sum")
-    )
     assert_frame_equal(actual, expected)
 
 
@@ -120,19 +75,6 @@ def test_mutate_dict_df_tuple(df_mutate):
     actual = df_mutate.mutate({"avg_run_sqrt": ("avg_run", "sqrt")})
     expected = df_mutate.assign(
         avg_run_sqrt=df_mutate["avg_run"].transform("sqrt")
-    )
-    assert_frame_equal(actual, expected)
-
-
-def test_mutate_dict_by_tuple(df_mutate):
-    """Test output for a dictionary"""
-    actual = df_mutate.mutate(
-        {"avg_run_mean": ("avg_run", "mean")}, by={"by": "combine_id"}
-    )
-    expected = df_mutate.assign(
-        avg_run_mean=df_mutate.groupby("combine_id")["avg_run"].transform(
-            "mean"
-        )
     )
     assert_frame_equal(actual, expected)
 
@@ -150,36 +92,8 @@ def test_mutate_df_tuple(df_mutate):
     assert_frame_equal(actual, expected)
 
 
-def test_mutate_by_tuple(df_mutate):
-    """Test output for a dictionary"""
-    actual = df_mutate.mutate(("avg_run", "mean"), by="combine_id")
-    expected = df_mutate.assign(
-        avg_run=df_mutate.groupby("combine_id")["avg_run"].transform("mean")
-    )
-    assert_frame_equal(actual, expected)
-
-
 def test_mutate_tuple_df_callable(df_mutate):
     """Test output for a dictionary"""
     actual = df_mutate.mutate(("avg_run", lambda df: df.sum()))
     expected = df_mutate.assign(avg_run=df_mutate["avg_run"].sum())
-    assert_frame_equal(actual, expected)
-
-
-def test_mutate_tuple_by_callable(df_mutate):
-    """Test output for a dictionary"""
-    actual = df_mutate.mutate(
-        ("avg_run", lambda df: df.sum()), by="combine_id"
-    )
-    expected = df_mutate.assign(
-        avg_run=df_mutate.groupby("combine_id")["avg_run"].transform("sum")
-    )
-    assert_frame_equal(actual, expected)
-
-
-def test_mutate_tuple_by_grouped_object(df_mutate):
-    """Test output for a dictionary"""
-    grp = df_mutate.groupby("combine_id")
-    actual = df_mutate.mutate(("avg_run", lambda df: df.sum()), by=grp)
-    expected = df_mutate.assign(avg_run=grp["avg_run"].transform("sum"))
     assert_frame_equal(actual, expected)

--- a/tests/functions/test_summarise.py
+++ b/tests/functions/test_summarise.py
@@ -69,14 +69,6 @@ def test_summarise_callable_series(df_summarise):
     assert_frame_equal(actual, expected)
 
 
-def test_summarise_by_callable_grp(df_summarise):
-    """Test output for a callable"""
-    grp = df_summarise.groupby("combine_id")
-    actual = df_summarise.summarise(lambda df: df.sum(), by=grp)
-    expected = grp.sum()
-    assert_frame_equal(actual, expected)
-
-
 def test_summarise_by_callable_grp_grouped(df_summarise):
     """Test output for a callable"""
     grp = df_summarise.groupby("combine_id")
@@ -92,37 +84,10 @@ def test_summarise_dict_df_str(df_summarise):
     assert_frame_equal(actual, expected)
 
 
-def test_summarise_dict_by_str(df_summarise):
-    """Test output for a dictionary"""
-    actual = df_summarise.summarise(
-        {"avg_run": "mean"}, by={"by": "combine_id"}
-    )
-    expected = df_summarise.groupby("combine_id").agg({"avg_run": "mean"})
-    assert_frame_equal(actual, expected)
-
-
 def test_summarise_dict_df_callable(df_summarise):
     """Test output for a dictionary"""
     actual = df_summarise.summarise({"avg_run": lambda df: df.sum()})
     expected = df_summarise.agg({"avg_run": [lambda df: df.sum()]})
-    assert_frame_equal(actual, expected)
-
-
-def test_summarise_dict_by_callable(df_summarise):
-    """Test output for a dictionary"""
-    actual = df_summarise.summarise(
-        {"avg_run": lambda df: df.sum()}, by="combine_id"
-    )
-    expected = df_summarise.groupby("combine_id").agg({"avg_run": "sum"})
-    assert_frame_equal(actual, expected)
-
-
-def test_summarise_dict_by_agg_callable(df_summarise):
-    """Test output for a dictionary"""
-    actual = df_summarise.summarise(
-        {"avg_run": lambda df: df.agg("sum")}, by="combine_id"
-    )
-    expected = df_summarise.groupby("combine_id").agg({"avg_run": "sum"})
     assert_frame_equal(actual, expected)
 
 
@@ -131,17 +96,6 @@ def test_summarise_dict_df_tuple(df_summarise):
     actual = df_summarise.summarise({"avg_run_sum": ("avg_run", "sum")})
     expected = df_summarise.agg(avg_run_sum=("avg_run", "sum")).T.rename(
         index={"avg_run": "sum"}
-    )
-    assert_frame_equal(actual, expected)
-
-
-def test_summarise_dict_by_tuple(df_summarise):
-    """Test output for a dictionary"""
-    actual = df_summarise.summarise(
-        {"avg_run_mean": ("avg_run", "mean")}, by="combine_id"
-    )
-    expected = df_summarise.groupby("combine_id").agg(
-        avg_run_mean=("avg_run", "mean")
     )
     assert_frame_equal(actual, expected)
 
@@ -165,13 +119,6 @@ def test_summarise_df_tuple(df_summarise):
     assert_frame_equal(actual, expected)
 
 
-def test_summarise_by_tuple(df_summarise):
-    """Test output for a tuple"""
-    actual = df_summarise.summarise(("avg_run", "mean"), by="combine_id")
-    expected = df_summarise.groupby("combine_id").agg({"avg_run": "mean"})
-    assert_frame_equal(actual, expected)
-
-
 def test_summarise_by_tuple_grouped(df_summarise):
     """Test output for a tuple"""
     actual = df_summarise.groupby("combine_id").summarise(("avg_run", "mean"))
@@ -183,15 +130,6 @@ def test_summarise_tuple_df_callable(df_summarise):
     """Test output for a tuple"""
     actual = df_summarise.summarise(("avg_run", lambda df: df.sum()))
     expected = df_summarise.agg({"avg_run": [lambda df: df.sum()]})
-    assert_frame_equal(actual, expected)
-
-
-def test_summarise_tuple_by_callable(df_summarise):
-    """Test output for a tuple"""
-    actual = df_summarise.summarise(
-        ("avg_run", lambda df: df.sum()), by="combine_id"
-    )
-    expected = df_summarise.groupby("combine_id").agg({"avg_run": "sum"})
     assert_frame_equal(actual, expected)
 
 
@@ -213,69 +151,6 @@ def test_summarise_MI(dfmi):
     assert_frame_equal(actual, expected)
 
 
-def test_summarise_MI_different_levels(dfmi):
-    """Test summarise on a MultiIndex"""
-    actual = dfmi.summarise(
-        {("a", "bar"): "sum", ("rar", "bla", "gah"): (("a", "foo"), "mean")},
-        ("b", "min"),
-        by={"level": "A"},
-    )
-    actual.columns = ["A", "B", "C", "D"]
-    grp = dfmi.groupby(level="A")
-    expected = grp.agg(
-        {
-            ("a", "bar"): "sum",
-            ("a", "foo"): "mean",
-            ("b", "bah"): "min",
-            ("b", "foo"): "min",
-        }
-    )
-    expected.columns = ["A", "B", "C", "D"]
-    assert_frame_equal(actual, expected)
-
-
-def test_summarise_MI_different_levels_dict(dfmi):
-    """Test summarise on a MultiIndex"""
-    actual = dfmi.summarise(
-        {("a", "bar"): "sum", "rar": (("a", "foo"), "mean")},
-        ("b", "min"),
-        by={"level": "A"},
-    )
-    actual.columns = ["A", "B", "C", "D"]
-    grp = dfmi.groupby(level="A")
-    expected = grp.agg(
-        {
-            ("a", "bar"): "sum",
-            ("a", "foo"): "mean",
-            ("b", "bah"): "min",
-            ("b", "foo"): "min",
-        }
-    )
-    expected.columns = ["A", "B", "C", "D"]
-    assert_frame_equal(actual, expected)
-
-
-def test_summarise_MI_different_levels_tuple(dfmi):
-    """Test summarise on a MultiIndex"""
-    actual = dfmi.summarise(
-        {("a", "bar"): "sum", ("rar",): (("a", "foo"), "mean")},
-        ("b", "min"),
-        by={"level": "A"},
-    )
-    actual.columns = ["A", "B", "C", "D"]
-    grp = dfmi.groupby(level="A")
-    expected = grp.agg(
-        {
-            ("a", "bar"): "sum",
-            ("a", "foo"): "mean",
-            ("b", "bah"): "min",
-            ("b", "foo"): "min",
-        }
-    )
-    expected.columns = ["A", "B", "C", "D"]
-    assert_frame_equal(actual, expected)
-
-
 def test_summarise_MI_different_levels_tuple_grouped(dfmi):
     """Test summarise on a MultiIndex"""
     actual = dfmi.groupby(level="A").summarise(
@@ -294,12 +169,3 @@ def test_summarise_MI_different_levels_tuple_grouped(dfmi):
     )
     expected.columns = ["A", "B", "C", "D"]
     assert_frame_equal(actual, expected)
-
-
-def test_summarise_MI_different_levels_dataframe(dfmi):
-    """raise if dictionary value is a tuple and the returned aggregate is a DataFrame"""
-    with pytest.raises(TypeError, match="Expected a pandas Series object;.+"):
-        dfmi.summarise(
-            {"rar": (("a", "foo"), ["min", "mean"])},
-            by={"level": "A"},
-        )


### PR DESCRIPTION
# PR Description

Please describe the changes proposed in the pull request:

- remove `by` feature of `summarise` and `mutate`
- explicitly call methods on the groupby object instead


**This PR resolves #1511.**



Please tag maintainers to review.

- @ericmjl
