### PR TITLE
Extend filter_column_isin to support multi-column and dict-based API

### DIFF
--- a/janitor/functions/filter.py
+++ b/janitor/functions/filter.py
@@ -357,8 +357,10 @@ def filter_column_isin(
     if complement:
         return df[~criteria]
     return df[criteria]
-    
+
+
 from __future__ import annotations
+
 from collections.abc import Iterable
 from typing import Dict, List, Sequence, Tuple, Union
 
@@ -366,6 +368,7 @@ import pandas as pd
 from pandas_flavor import register_dataframe_method
 
 ColumnsArg = Union[str, List[str], Tuple[str, ...], Dict[str, Iterable]]
+
 
 @register_dataframe_method
 def filter_column_isin(
@@ -392,14 +395,18 @@ def filter_column_isin(
 
     elif isinstance(columns, (list, tuple)):
         if values is None:
-            raise ValueError("`values` must be provided when `columns` is a list/tuple.")
+            raise ValueError(
+                "`values` must be provided when `columns` is a list/tuple."
+            )
         cols_seq: Sequence[str] = list(columns)
         combos = [tuple(v) for v in values]
         mask = df.set_index(cols_seq).index.isin(combos)
 
     else:
         if values is None:
-            raise ValueError("`values` must be provided when `columns` is a string.")
+            raise ValueError(
+                "`values` must be provided when `columns` is a string."
+            )
         mask = df[columns].isin(values)
 
     if complement:

--- a/janitor/functions/filter.py
+++ b/janitor/functions/filter.py
@@ -357,3 +357,51 @@ def filter_column_isin(
     if complement:
         return df[~criteria]
     return df[criteria]
+    
+from __future__ import annotations
+from collections.abc import Iterable
+from typing import Dict, List, Sequence, Tuple, Union
+
+import pandas as pd
+from pandas_flavor import register_dataframe_method
+
+ColumnsArg = Union[str, List[str], Tuple[str, ...], Dict[str, Iterable]]
+
+@register_dataframe_method
+def filter_column_isin(
+    df: pd.DataFrame,
+    columns: ColumnsArg,
+    values: Iterable | None = None,
+    *,
+    complement: bool = False,
+) -> pd.DataFrame:
+    """
+    Supports:
+    1) Single column (str)
+    2) Multiple columns (list/tuple)
+    3) Dictionary mapping (dict)
+    """
+    if isinstance(columns, dict):
+        if values is not None:
+            raise ValueError("When `columns` is a dict, do not pass `values`.")
+        if not columns:
+            return df
+        mask = pd.Series(True, index=df.index)
+        for col, vals in columns.items():
+            mask &= df[col].isin(vals)
+
+    elif isinstance(columns, (list, tuple)):
+        if values is None:
+            raise ValueError("`values` must be provided when `columns` is a list/tuple.")
+        cols_seq: Sequence[str] = list(columns)
+        combos = [tuple(v) for v in values]
+        mask = df.set_index(cols_seq).index.isin(combos)
+
+    else:
+        if values is None:
+            raise ValueError("`values` must be provided when `columns` is a string.")
+        mask = df[columns].isin(values)
+
+    if complement:
+        mask = ~mask
+    return df.loc[mask]

--- a/mkdocs/index.md
+++ b/mkdocs/index.md
@@ -3,8 +3,8 @@
 [![](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ericmjl/pyjanitor/dev)
 
 <!-- pypi-doc -->
-`pyjanitor` is a Python implementation of the R package [`janitor`][janitor], and
-provides a clean API for cleaning data.
+`pyjanitor` is a Python implementation of the R package [`janitor`][janitor]. 
+It provides a clean user-friendly API for extending pandas with powerful and readable data-cleaning functions .
 
 [janitor]: https://github.com/sfirke/janitor
 

--- a/mkdocs/index.md
+++ b/mkdocs/index.md
@@ -3,7 +3,7 @@
 [![](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ericmjl/pyjanitor/dev)
 
 <!-- pypi-doc -->
-`pyjanitor` is a Python implementation of the R package [`janitor`][janitor]. 
+`pyjanitor` is a Python implementation of the R package [`janitor`][janitor].
 It provides a clean user-friendly API for extending pandas with powerful and readable data-cleaning functions .
 
 [janitor]: https://github.com/sfirke/janitor


### PR DESCRIPTION
Addresses #1476
Summary: reintroduces and extends filter_column_isin in filter.py.
Supports Single-column, multi-column, and dict-based filtering
Adds complement flag for inverse filtering.