### PR TITLE
[ENH] switch to register_dataframe_groupby_method

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -116,3 +116,4 @@ Contributors
 - [@lbeltrame](https://github.com/lbeltrame) | [contributions](https://github.com/pyjanitor-devs/pyjanitor/pull/1401)
 - [@derekpowell](https://github.com/derekpowell) | [contributions](https://github.com/pyjanitor-devs/pyjanitor/issues?q=is%3Aclosed+mentions%3Aderekpowell)
 - [@emmanuel-ferdman](https://github.com/emmanuel-ferdman) | [contributions](https://github.com/pyjanitor-devs/pyjanitor/issues?q=is%3Aclosed+mentions%3Aemmanuel-ferdman)
+- [@tomjemmett](https://github.com/tomjemmett) | [contributions](https://github.com/pyjanitor-devs/pyjanitor/issues?q=is%3Aclosed+mentions%3Atomjemmett)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+-   [ENH] switch to register_dataframe_groupby_method - Issue #1534 @bryanpmayfield
+
 ## [v0.32.1] - 2025-11-06
 
 -   [ENH] update `pypa/gh-action-pypi-publish` from master to release/v1 - Issue #1524 @samukweku

--- a/janitor/functions/mutate.py
+++ b/janitor/functions/mutate.py
@@ -13,7 +13,7 @@ from pandas.core.groupby.generic import DataFrameGroupBy
 from janitor.functions.select import get_index_labels
 
 
-@pf.register_groupby_method
+@pf.register_dataframe_groupby_method
 def ungroup(
     df: DataFrameGroupBy,
 ) -> pd.DataFrame:
@@ -58,7 +58,7 @@ def ungroup(
     return df.obj
 
 
-@pf.register_groupby_method
+@pf.register_dataframe_groupby_method
 @pf.register_dataframe_method
 def mutate(
     df: pd.DataFrame | DataFrameGroupBy,

--- a/janitor/functions/select.py
+++ b/janitor/functions/select.py
@@ -344,8 +344,9 @@ def select_rows(
     return _select(df, rows=list(args), invert=invert)
 
 
-@pf.register_groupby_method
+@pf.register_dataframe_groupby_method
 @pf.register_dataframe_method
+@pf.register_series_groupby_method
 @pf.register_series_method
 @deprecated_alias(rows="index")
 def select(

--- a/janitor/functions/summarise.py
+++ b/janitor/functions/summarise.py
@@ -14,7 +14,7 @@ from pandas.core.groupby.generic import DataFrameGroupBy
 from janitor.functions.select import get_index_labels
 
 
-@pf.register_groupby_method
+@pf.register_dataframe_groupby_method
 @pf.register_dataframe_method
 def summarise(
     df: pd.DataFrame | DataFrameGroupBy,


### PR DESCRIPTION
## PR Description

This PR resolves #1534 by switching from register_groupby_method to register_dataframe_groupby_method and register_series_groupby_method, as the former has been removed in pandas-flavor 0.8.1.

## PR Checklist

<!-- This checklist exists for newcomers who are not yet familiar with our requirements. If you are experienced with
the project, please feel free to delete this section. -->

Please ensure that you have done the following:

1. [x] PR in from a fork off your branch. Do not PR from `<your_username>`:`dev`, but rather from `<your_username>`:`<feature-branch_name>`.
<!-- Doing this helps us keep the commit history much cleaner than it would otherwise be. -->
2. [x] If you're not on the contributors list, add yourself to `AUTHORS.md`.
<!-- We'd like to acknowledge your contributions! -->
3. [x] Add a line to `CHANGELOG.md` under the latest version header (i.e. the one that is "on deck") describing the contribution.
    - Do use some discretion here; if there are multiple PRs that are related, keep them in a single line.

## Relevant Reviewers

- @ericmjl
