### PR TITLE
Add automated patch releases on every merge to dev

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,11 +1,22 @@
 name: Auto-release
 
 on:
-  # The below workflow_dispatch section is for a "manual" kick off of the
-  # auto-release script. To cut a new release, navigate to the Actions section
-  # of the repo and select this workflow (Auto-release) on the right hand side.
-  # Then, click "Run workflow" and you will be prompted to input the new
-  # version (which should be major, minor, or patch).
+  # Automatic patch release after tests pass on dev branch.
+  # This triggers whenever the "pyjanitor tests" workflow completes.
+  # The job-level `if` condition ensures we only release when:
+  # 1. Tests passed (conclusion == 'success')
+  # 2. It was a push event (not a PR) - i.e., code was merged to dev
+  workflow_run:
+    workflows: ["pyjanitor tests"]
+    types:
+      - completed
+    branches:
+      - dev
+
+  # Manual release for minor/major versions.
+  # To cut a new release, navigate to the Actions section of the repo
+  # and select this workflow (Auto-release) on the right hand side.
+  # Then, click "Run workflow" and select major, minor, or patch.
   workflow_dispatch:
     inputs:
       version_name:
@@ -28,6 +39,13 @@ jobs:
   release:
     name: Create a new release
     runs-on: ubuntu-latest
+    # Run if:
+    # 1. Manual trigger (workflow_dispatch), OR
+    # 2. Automatic trigger where tests passed AND it was a push (not PR)
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push')
 
     defaults:
       run:
@@ -45,15 +63,32 @@ jobs:
           git checkout dev
           git pull
 
+      - name: Check if already released
+        id: check_release
+        run: |
+          CURRENT_COMMIT=$(git rev-parse HEAD)
+          echo "Current commit: $CURRENT_COMMIT"
+          if git tag --points-at $CURRENT_COMMIT | grep -q "^v"; then
+            echo "already_released=true" >> $GITHUB_OUTPUT
+            echo "This commit already has a release tag. Will skip release."
+            git tag --points-at $CURRENT_COMMIT
+          else
+            echo "already_released=false" >> $GITHUB_OUTPUT
+            echo "No release tag found. Proceeding with release."
+          fi
+
       - name: Setup Python environment
+        if: steps.check_release.outputs.already_released == 'false'
         uses: actions/setup-python@v6
         with:
           python-version: 3.13
 
       - name: Install uv
+        if: steps.check_release.outputs.already_released == 'false'
         uses: astral-sh/setup-uv@v7
 
       - name: Setup Pixi Environment
+        if: steps.check_release.outputs.already_released == 'false'
         uses: prefix-dev/setup-pixi@v0.9.3
         with:
           pixi-version: latest
@@ -61,40 +96,51 @@ jobs:
           cache-write: true
 
       - name: Set up Python tools
+        if: steps.check_release.outputs.already_released == 'false'
         run: uv tool install bump2version
 
       - name: Set version name
+        if: steps.check_release.outputs.already_released == 'false'
         run: echo "VERSION_NAME=${{ github.event.inputs.version_name || env.DEFAULT_VERSION_NAME }}" >> $GITHUB_ENV
 
       - name: Dry run bump2version
+        if: steps.check_release.outputs.already_released == 'false'
         run: bump2version --dry-run ${{ env.VERSION_NAME }} --allow-dirty --verbose
 
       - name: Store new version number
+        if: steps.check_release.outputs.already_released == 'false'
         run: echo "version_number=$(bump2version --dry-run --list ${{ env.VERSION_NAME }} | grep new_version | sed -r 's/^.*=//')" >> $GITHUB_ENV
 
       - name: Display new version number
+        if: steps.check_release.outputs.already_released == 'false'
         run: |
           echo "version_name: ${{ env.VERSION_NAME }}"
           echo "version_number: v${{ env.version_number }}"
 
       - name: Ensure repo status is clean
+        if: steps.check_release.outputs.already_released == 'false'
         run: git status
 
       - name: Configure Git
+        if: steps.check_release.outputs.already_released == 'false'
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
 
       - name: Run bump2version
+        if: steps.check_release.outputs.already_released == 'false'
         run: bump2version ${{ env.VERSION_NAME }} --verbose
 
       - name: Ensure tag creation
+        if: steps.check_release.outputs.already_released == 'false'
         run: git tag | grep ${{ env.version_number }}
 
       - name: Install llamabot package
+        if: steps.check_release.outputs.already_released == 'false'
         run: pixi run pip install llamabot[cli]
 
       - name: Write release notes
+        if: steps.check_release.outputs.already_released == 'false'
         env:
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -103,22 +149,27 @@ jobs:
           llamabot git write-release-notes
 
       - name: Commit release notes
+        if: steps.check_release.outputs.already_released == 'false'
         run: |
           pixi run pre-commit run --all-files || pixi run pre-commit run --all-files
           git add .
           git commit -m "Add release notes for ${{ env.version_number }}"
 
       - name: Build package
+        if: steps.check_release.outputs.already_released == 'false'
         run: pixi run release
 
       - name: Publish package (trusted publishing)
+        if: steps.check_release.outputs.already_released == 'false'
         run: uv publish --trusted-publishing always
 
       - name: Push changes with tags
+        if: steps.check_release.outputs.already_released == 'false'
         run: |
           git push && git push --tags
 
       - name: Create release in GitHub repo
+        if: steps.check_release.outputs.already_released == 'false'
         uses: ncipollo/release-action@v1
         with:
           bodyFile: "docs/releases/v${{ env.version_number }}.md"
@@ -126,4 +177,5 @@ jobs:
           tag: v${{ env.version_number }}
 
       - name: Ensure complete
+        if: steps.check_release.outputs.already_released == 'false'
         run: echo "Auto-release complete!"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
   - Development:
       - Multi-Python Environments: development/multi_python_environments.md
       - Lazy Imports: development/lazy_imports.md
+      - Automated Releases: development/auto_releases.md
   - Changelog: CHANGELOG.md
 
 plugins:

--- a/mkdocs/development/auto_releases.md
+++ b/mkdocs/development/auto_releases.md
@@ -1,0 +1,200 @@
+# Automated release system
+
+This document explains how pyjanitor's automated release system works
+and the design decisions behind it.
+Understanding this system helps maintainers know
+when releases happen and how to control versioning.
+
+## Release philosophy
+
+pyjanitor follows a continuous delivery approach to releases:
+
+- **Patch releases** happen automatically on every merge to `dev`
+- **Minor and major releases** are triggered manually by maintainers
+
+The rationale is straightforward:
+most merges are bug fixes, documentation improvements,
+or small enhancements that don't require human decision-making
+about version numbers.
+By automating patch releases,
+we reduce the friction of getting changes into users' hands
+while preserving human control for significant version bumps.
+
+## How automatic releases work
+
+When code is merged to the `dev` branch, the following sequence occurs:
+
+1. **Tests run first**: The `pyjanitor tests` workflow executes,
+   running the full test suite across Python 3.11, 3.12, and 3.13.
+
+2. **Release triggers on success**: If all tests pass,
+   the `Auto-release` workflow automatically triggers
+   via GitHub's `workflow_run` event.
+
+3. **Duplicate check**: The workflow checks
+   if the current commit already has a release tag.
+   This prevents re-releasing
+   when the workflow's own version bump commits trigger another test run.
+
+4. **Version bump**: If no tag exists,
+   `bump2version` increments the patch version
+   (e.g., 0.32.3 becomes 0.32.4).
+
+5. **Release notes generation**: The `llamabot` CLI generates release notes
+   using an LLM, summarizing changes since the last release.
+
+6. **Build and publish**: The package is built and published to PyPI
+   using trusted publishing.
+
+7. **GitHub release**: A GitHub release is created
+   with the generated release notes.
+
+The entire process is hands-off after merging.
+Maintainers don't need to do anything for patch releases.
+
+## Manual releases for minor and major versions
+
+When a change warrants a minor or major version bump,
+maintainers trigger the release manually:
+
+**When to use minor version (e.g., 0.32.0 to 0.33.0):**
+
+- New features that don't break existing functionality
+- Significant enhancements to existing features
+- New optional dependencies or modules
+
+**When to use major version (e.g., 0.x.x to 1.0.0):**
+
+- Breaking changes to the public API
+- Removal of deprecated features
+- Fundamental changes to how the library works
+
+**How to trigger a manual release:**
+
+1. Go to the [Actions tab][actions] in the repository
+2. Select "Auto-release" from the workflows list
+3. Click "Run workflow"
+4. Choose `major`, `minor`, or `patch` from the dropdown
+5. Click the green "Run workflow" button
+
+[actions]: https://github.com/pyjanitor-devs/pyjanitor/actions
+
+The workflow will run the same steps as an automatic release,
+but with your chosen version bump type.
+
+## Technical implementation
+
+The release system uses GitHub Actions' `workflow_run` trigger,
+which fires when another workflow completes.
+Here's how the triggers work:
+
+```yaml
+on:
+  # Automatic: triggers after tests complete on dev
+  workflow_run:
+    workflows: ["pyjanitor tests"]
+    types:
+      - completed
+    branches:
+      - dev
+
+  # Manual: maintainer-triggered releases
+  workflow_dispatch:
+    inputs:
+      version_name:
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+```
+
+The job only runs when appropriate:
+
+```yaml
+if: |
+  github.event_name == 'workflow_dispatch' ||
+  (github.event.workflow_run.conclusion == 'success' &&
+   github.event.workflow_run.event == 'push')
+```
+
+This condition ensures:
+
+- Manual triggers always run
+- Automatic triggers only run when tests *passed* (not failed)
+- Automatic triggers only run for *push* events (not PR test runs)
+
+## Preventing duplicate releases
+
+When the auto-release workflow runs,
+it creates a version bump commit and pushes it to `dev`.
+This push triggers another test run,
+which could trigger another release.
+To prevent this infinite loop,
+the workflow checks if the current commit already has a release tag:
+
+```yaml
+- name: Check if already released
+  id: check_release
+  run: |
+    CURRENT_COMMIT=$(git rev-parse HEAD)
+    if git tag --points-at $CURRENT_COMMIT | grep -q "^v"; then
+      echo "already_released=true" >> $GITHUB_OUTPUT
+    else
+      echo "already_released=false" >> $GITHUB_OUTPUT
+    fi
+```
+
+If a tag exists, all subsequent release steps are skipped.
+
+## Troubleshooting
+
+### Auto-release didn't trigger after merge
+
+Check these common causes:
+
+1. **Tests failed**: The release only triggers on successful test runs.
+   Check the Actions tab for test failures.
+
+2. **Not a push event**: Releases only trigger for pushes to `dev`,
+   not for pull request test runs. This is intentional.
+
+3. **Already released**: If the commit already has a tag,
+   the release is skipped. Check `git tag --points-at HEAD`.
+
+### Release failed mid-way
+
+If a release fails after bumping the version but before publishing:
+
+1. Check the Actions log to identify the failure point
+2. If the tag was created but not pushed,
+   you may need to manually push it or delete and recreate
+3. If PyPI publish failed,
+   you can re-run the failed job or trigger a manual release
+
+### Wrong version was released
+
+If you need to correct a version:
+
+1. Do not try to overwrite an existing PyPI release
+   (PyPI doesn't allow this)
+2. Instead, create a new patch release with the fix
+3. If the version number itself is wrong,
+   update `.bumpversion.cfg` and `pyproject.toml` manually,
+   commit, and trigger a new release
+
+### How to skip a release for a specific merge
+
+Currently, all merges to `dev` trigger a release.
+If you need to merge something without releasing
+(e.g., CI-only changes), you have two options:
+
+1. Merge to a different branch first,
+   then batch multiple changes into a single merge to `dev`
+2. Cancel the auto-release workflow run manually
+   in the Actions tab before it completes
+
+**Note:** There's an open issue ([#1549][issue])
+to consider adding filters for non-code changes.
+
+[issue]: https://github.com/pyjanitor-devs/pyjanitor/issues/1549


### PR DESCRIPTION
## Summary

- Automate patch releases whenever code is merged to `dev` and tests pass
- Preserve manual control for minor/major releases via workflow_dispatch

## Changes

- **`.github/workflows/auto-release.yml`**: Add `workflow_run` trigger that fires after `pyjanitor tests` completes successfully on `dev`. Includes safeguard to skip if commit already has a release tag (prevents duplicate releases from version bump commits).
- **`mkdocs/development/auto_releases.md`**: New explanation doc covering release philosophy, how automatic releases work, manual releases, technical implementation, and troubleshooting.
- **`mkdocs.yml`**: Add nav entry for the new doc.

## How it works

```
PR merged to dev → tests.yml runs → tests pass → auto-release.yml triggers
                                                         ↓
                                              Already tagged? → Skip
                                                         ↓
                                              Bump patch version → Release to PyPI
```

## Related

- Implements item #2 from #1539
- Created #1549 to track future consideration of filtering non-code changes