### PR TITLE
Fix trailing space in dtype docstring parameter

### DIFF
--- a/janitor/functions/change_index_dtype.py
+++ b/janitor/functions/change_index_dtype.py
@@ -96,7 +96,7 @@ def change_index_dtype(
 
     Args:
         df: A pandas DataFrame.
-        dtype : Use a str or dtype to cast the entire Index
+        dtype: Use a str or dtype to cast the entire Index
             to the same type.
             Alternatively, use a dictionary to change the MultiIndex
             to new dtypes.


### PR DESCRIPTION
## Summary

- Fix trailing space in `dtype` parameter docstring in `change_index_dtype.py`

This was causing a griffe warning during docs build:
```
WARNING - griffe: janitor/functions/change_index_dtype.py:99: No type or annotation for parameter 'dtype '
```

The space before the colon (`dtype :`) was being interpreted as part of the parameter name.