### PR TITLE
Fix release build by using uv build

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -157,7 +157,7 @@ jobs:
 
       - name: Build package
         if: steps.check_release.outputs.already_released == 'false'
-        run: pixi run release
+        run: uv build
 
       - name: Publish package (trusted publishing)
         if: steps.check_release.outputs.already_released == 'false'


### PR DESCRIPTION
## Summary

- Fix the auto-release workflow build step that was failing

## Problem

The `pixi run release` command runs `python -m build`, but the `build` package is not installed in the pixi default environment, causing the release to fail with:

```
/home/runner/work/pyjanitor/pyjanitor/.pixi/envs/default/bin/python: No module named build
```

## Solution

Use `uv build` instead, since `uv` is already installed in the workflow and can build Python packages without additional dependencies.