### PR TITLE
Remove invalid noqa directives

### DIFF
--- a/janitor/ml.py
+++ b/janitor/ml.py
@@ -66,7 +66,7 @@ def get_features_targets(
     if feature_column_names:
         X = df[feature_column_names]
     else:
-        if isinstance(target_column_names, (list, tuple)):  # noqa: W503
+        if isinstance(target_column_names, (list, tuple)):
             xcols = [c for c in df.columns if c not in target_column_names]
         else:
             xcols = [c for c in df.columns if target_column_names != c]

--- a/janitor/spark/functions.py
+++ b/janitor/spark/functions.py
@@ -77,7 +77,7 @@ def clean_names(
     if remove_special:
         cols = [_remove_special(col) for col in cols]
 
-    cols = [re.sub("_+", "_", col) for col in cols]  # noqa: PD005
+    cols = [re.sub("_+", "_", col) for col in cols]
 
     cols = [_strip_underscores_func(col, strip_underscores) for col in cols]
 

--- a/tests/functions/test_factorize_columns.py
+++ b/tests/functions/test_factorize_columns.py
@@ -29,7 +29,7 @@ def test_single_column_fail_factorize_columns():
     with pytest.raises(ValueError):
         pd.DataFrame(
             {"a": ["hello", "hello", "sup"], "b": [1, 2, 3]}
-        ).factorize_columns(column_names="c")  # noqa: 841
+        ).factorize_columns(column_names="c")
 
 
 @pytest.mark.functions

--- a/tests/functions/test_label_encode.py
+++ b/tests/functions/test_label_encode.py
@@ -15,7 +15,7 @@ def test_single_column_fail_label_encode():
     with pytest.raises(ValueError):
         pd.DataFrame({"a": ["hello", "hello", "sup"], "b": [1, 2, 3]}).label_encode(
             column_names="c"
-        )  # noqa: 841
+        )
 
 
 @pytest.mark.functions


### PR DESCRIPTION
## Summary

- Remove invalid `# noqa` directives that were causing linting warnings

## Changes

- `janitor/ml.py`: Remove `# noqa: W503` - W503 is a flake8-only code not in ruff
- `janitor/spark/functions.py`: Remove `# noqa: PD005` - PD005 is for pandas, but this is `re.sub`
- `tests/functions/test_factorize_columns.py`: Remove `# noqa: 841` - invalid format (should be F841)
- `tests/functions/test_label_encode.py`: Remove `# noqa: 841` - invalid format (should be F841)

These comments were unnecessary and causing warnings during lint runs.