### PR TITLE
Add currency symbol support to accounting cleaning style

### DIFF
--- a/janitor/functions/currency_column_to_numeric.py
+++ b/janitor/functions/currency_column_to_numeric.py
@@ -31,25 +31,25 @@ def currency_column_to_numeric(
         >>> import janitor
         >>> df = pd.DataFrame(
         ...     {
-        ...         "a_col": [" 24.56", "-", "(12.12)", "1,000,000"],
+        ...         "a_col": [" $24.56", "-", "($12.12)", "$1,000,000"],
         ...         "d_col": ["", "foo", "1.23 dollars", "-1,000 yen"],
         ...     }
         ... )
         >>> df  # doctest: +NORMALIZE_WHITESPACE
-               a_col         d_col
-        0      24.56
-        1          -           foo
-        2    (12.12)  1.23 dollars
-        3  1,000,000    -1,000 yen
+                a_col         d_col
+        0      $24.56
+        1           -           foo
+        2   ($12.12)  1.23 dollars
+        3  $1,000,000    -1,000 yen
 
         The default cleaning style.
 
         >>> df.currency_column_to_numeric("d_col")
-               a_col    d_col
-        0      24.56      NaN
-        1          -      NaN
-        2    (12.12)     1.23
-        3  1,000,000 -1000.00
+                a_col    d_col
+        0      $24.56      NaN
+        1           -      NaN
+        2   ($12.12)     1.23
+        3  $1,000,000 -1000.00
 
         The accounting cleaning style.
 
@@ -67,7 +67,8 @@ def currency_column_to_numeric(
     - `None`: Default cleaning is applied. Empty strings are always retained as
         `NaN`. Numbers, `-`, `.` are extracted and the resulting string
         is cast to a float.
-    - `'accounting'`: Replaces numbers in parentheses with negatives, removes commas.
+    - `'accounting'`: Replaces numbers in parentheses with negatives, removes
+        commas and currency symbols ($, €, £, ¥, ₹, ₩, ₽, ₱, ฿, ₺).
 
     Args:
         df: The pandas DataFrame.
@@ -100,6 +101,7 @@ def currency_column_to_numeric(
         outcome = (
             df[column_name]
             .str.strip()
+            .str.replace(r"[$€£¥₹₩₽₱฿₺]", "", regex=True)
             .str.replace(",", "", regex=False)
             .str.replace(")", "", regex=False)
             .str.replace("(", "-", regex=False)

--- a/pixi.lock
+++ b/pixi.lock
@@ -12084,6 +12084,7 @@ packages:
   - pandas-vet ; extra == 'all'
   - py>=1.10.0 ; extra == 'all'
   requires_python: '>=3.6'
+  editable: true
 - conda: https://prefix.dev/conda-forge/noarch/pymdown-extensions-10.19-pyhd8ed1ab_0.conda
   sha256: a3477c99d72a926810f16858fa9e7de87c9238ec75396b61dfb22f1533fc2b23
   md5: 13fd024a09076e225d76a29db7355d67

--- a/tests/functions/test_currency_column_to_numeric.py
+++ b/tests/functions/test_currency_column_to_numeric.py
@@ -56,12 +56,27 @@ def test_accounting_style_with_dollar_sign():
 
 @pytest.mark.functions
 def test_accounting_style_with_various_currency_symbols():
-    """Test accounting style handles various currency symbols."""
+    """Test accounting style handles various currency symbols.
+
+    Tests €, £, ¥, ₹, ₩ symbols.
+    """
     df = pd.DataFrame(
         {"amount": ["€100.50", "£200.75", "¥300", "(€50.25)", "₹1,000", "₩500"]}
     )
     result = df.currency_column_to_numeric("amount", cleaning_style="accounting")
     expected = pd.DataFrame({"amount": [100.50, 200.75, 300.0, -50.25, 1000.0, 500.0]})
+    assert_frame_equal(result, expected)
+
+
+@pytest.mark.functions
+def test_accounting_style_with_additional_currency_symbols():
+    """Test accounting style handles additional currency symbols.
+
+    Tests ₽ (Russian Ruble), ₱ (Philippine Peso), ฿ (Thai Baht), ₺ (Turkish Lira).
+    """
+    df = pd.DataFrame({"amount": ["₽1,500", "(₱250.75)", "฿3,000", "₺750.50"]})
+    result = df.currency_column_to_numeric("amount", cleaning_style="accounting")
+    expected = pd.DataFrame({"amount": [1500.0, -250.75, 3000.0, 750.50]})
     assert_frame_equal(result, expected)
 
 

--- a/tests/functions/test_currency_column_to_numeric.py
+++ b/tests/functions/test_currency_column_to_numeric.py
@@ -46,6 +46,26 @@ def test_accounting_style(currency_df):
 
 
 @pytest.mark.functions
+def test_accounting_style_with_dollar_sign():
+    """Test accounting style handles $ currency symbol."""
+    df = pd.DataFrame({"amount": ["$24.56", "($12.12)", "$1,000,000", "-"]})
+    result = df.currency_column_to_numeric("amount", cleaning_style="accounting")
+    expected = pd.DataFrame({"amount": [24.56, -12.12, 1_000_000.0, 0.0]})
+    assert_frame_equal(result, expected)
+
+
+@pytest.mark.functions
+def test_accounting_style_with_various_currency_symbols():
+    """Test accounting style handles various currency symbols."""
+    df = pd.DataFrame(
+        {"amount": ["€100.50", "£200.75", "¥300", "(€50.25)", "₹1,000", "₩500"]}
+    )
+    result = df.currency_column_to_numeric("amount", cleaning_style="accounting")
+    expected = pd.DataFrame({"amount": [100.50, 200.75, 300.0, -50.25, 1000.0, 500.0]})
+    assert_frame_equal(result, expected)
+
+
+@pytest.mark.functions
 def test_default_cleaning_style(currency_df):
     """Checks that the default cleaning style is correctly applied."""
     result = currency_df.currency_column_to_numeric(


### PR DESCRIPTION
## Summary

- Add support for currency symbols ($, €, £, ¥, ₹, ₩, ₽, ₱, ฿, ₺) in `currency_column_to_numeric` accounting cleaning style
- This enables handling of common Excel accounting formats like `($12.3)` and `$1,000.00`

Fixes #1485