### PR TITLE
[ENH]: Add chisq_test and fisher_test for tabyls

### DIFF
--- a/janitor/functions/__init__.py
+++ b/janitor/functions/__init__.py
@@ -30,6 +30,7 @@ from .bin_numeric import bin_numeric
 from .case_when import case_when
 from .change_index_dtype import change_index_dtype
 from .change_type import change_type
+from .statistical_tests import chisq_test, fisher_test
 from .clean_names import clean_names
 from .coalesce import coalesce
 from .collapse_levels import collapse_levels
@@ -120,6 +121,7 @@ __all__ = [
     "case_when",
     "change_type",
     "change_index_dtype",
+    "chisq_test",
     "clean_names",
     "coalesce",
     "collapse_levels",
@@ -141,6 +143,7 @@ __all__ = [
     "expand_grid",
     "explode_index",
     "factorize_columns",
+    "fisher_test",
     "fill_direction",
     "fill_empty",
     "filter_date",

--- a/janitor/functions/statistical_tests.py
+++ b/janitor/functions/statistical_tests.py
@@ -1,0 +1,237 @@
+"""Statistical test helpers for tabyl frequency tables."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import warnings
+
+import numpy as np
+import pandas as pd
+import pandas_flavor as pf
+from scipy import stats
+
+from janitor.utils import check
+
+
+@dataclass(frozen=True)
+class ChiSqTestResult:
+    """Result container for chi-squared tests on tabyls."""
+
+    statistic: float
+    pvalue: float
+    dof: int
+    expected: pd.DataFrame | np.ndarray
+    observed: pd.DataFrame | np.ndarray
+    residuals: pd.DataFrame | np.ndarray
+    stdres: pd.DataFrame | np.ndarray
+
+
+@dataclass(frozen=True)
+class FisherTestResult:
+    """Result container for Fisher's exact test on tabyls."""
+
+    statistic: float
+    pvalue: float
+
+
+def _identify_totals(df: pd.DataFrame) -> list[str]:
+    removed: list[str] = []
+    if "Total" in df.columns:
+        removed.append("column")
+    first_col = df.columns[0]
+    if df[first_col].eq("Total").any():
+        removed.append("row")
+    return removed
+
+
+def _drop_totals(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.copy()
+    if "Total" in df.columns:
+        df = df.drop(columns=["Total"])
+    first_col = df.columns[0]
+    total_mask = df[first_col].eq("Total")
+    if total_mask.any():
+        df = df.loc[~total_mask].reset_index(drop=True)
+    return df
+
+
+def _validate_two_way_tabyl(df: pd.DataFrame, func_name: str) -> None:
+    if df.shape[1] < 3 or df.shape[0] < 2:
+        raise ValueError(
+            f"`{func_name}` requires a 2-way tabyl with at least two rows and "
+            "two columns of counts."
+        )
+    if {"n", "percent"}.issubset(set(df.columns)):
+        raise ValueError(
+            f"`{func_name}` only supports 2-way tabyls; 1-way tabyls include "
+            "'n' and 'percent' columns."
+        )
+
+    count_cols = df.columns[1:]
+    non_numeric = [
+        col for col in count_cols if not pd.api.types.is_numeric_dtype(df[col])
+    ]
+    if non_numeric:
+        raise TypeError(
+            f"`{func_name}` requires numeric counts in columns: {non_numeric}."
+        )
+    if df[count_cols].isna().any().any():
+        raise ValueError(f"`{func_name}` requires non-null counts.")
+    if (df[count_cols] < 0).any().any():
+        raise ValueError(f"`{func_name}` requires non-negative counts.")
+
+
+def _as_tabyl_frame(
+    values: np.ndarray,
+    row_name: object,
+    row_labels: list[object],
+    col_labels: pd.Index,
+) -> pd.DataFrame:
+    result = pd.DataFrame(values, columns=col_labels)
+    result.insert(0, row_name, row_labels)
+    return result
+
+
+def _warn_if_totals(
+    df: pd.DataFrame, func_name: str, counts_df: pd.DataFrame | None = None
+) -> None:
+    removed = _identify_totals(df)
+    if counts_df is not None and not removed:
+        if counts_df.shape[0] < df.shape[0]:
+            removed.append("row")
+        if counts_df.shape[1] < df.shape[1]:
+            removed.append("column")
+    if not removed:
+        return
+    removed_text = " and ".join(removed)
+    warnings.warn(
+        f"Totals {removed_text} detected in tabyl; removing before running "
+        f"{func_name}.",
+        UserWarning,
+        stacklevel=2,
+    )
+
+
+@pf.register_dataframe_method
+def chisq_test(df: pd.DataFrame, tabyl_results: bool = True) -> ChiSqTestResult:
+    """Apply chi-squared test to a two-way tabyl.
+
+    This method expects a two-way frequency table created via ``tabyl``.
+    If totals are present (via ``adorn_totals``), they are removed with a
+    warning before the test is run.
+
+    Examples:
+        >>> import pandas as pd
+        >>> import janitor
+        >>> df = pd.DataFrame(
+        ...     {"gear": [3, 3, 4, 4], "cyl": [4, 6, 4, 6]}
+        ... )
+        >>> result = df.tabyl("gear", "cyl").chisq_test()
+        >>> result.statistic  # doctest: +SKIP
+        0.0
+
+    Args:
+        df: A two-way tabyl DataFrame.
+        tabyl_results: If True, return observed/expected/residual tables as
+            tabyl-formatted DataFrames. If False, return NumPy arrays.
+
+    Returns:
+        A ChiSqTestResult with the test statistic, p-value, degrees of
+        freedom, and observed/expected/residual tables.
+    """
+    check("tabyl_results", tabyl_results, [bool])
+
+    counts_df = df.attrs.get("_original_counts", df)
+    counts_df = counts_df.copy()
+    _warn_if_totals(df, "chisq_test", counts_df)
+    counts_df = _drop_totals(counts_df)
+    _validate_two_way_tabyl(counts_df, "chisq_test")
+
+    row_name = counts_df.columns[0]
+    col_labels = counts_df.columns[1:]
+    row_labels = counts_df[row_name].tolist()
+
+    observed_values = counts_df[col_labels].to_numpy(dtype=float)
+    total = observed_values.sum()
+    if total == 0:
+        raise ValueError(
+            "`chisq_test` requires counts that sum to a positive value."
+        )
+    result = stats.chi2_contingency(observed_values)
+    expected = getattr(result, "expected_freq", None)
+    if expected is None:
+        expected = result.expected
+
+    with np.errstate(divide="ignore", invalid="ignore"):
+        residuals = (observed_values - expected) / np.sqrt(expected)
+        row_probs = observed_values.sum(axis=1, keepdims=True) / total
+        col_probs = observed_values.sum(axis=0, keepdims=True) / total
+        stdres_denom = np.sqrt(expected * (1 - row_probs) * (1 - col_probs))
+        stdres = np.divide(
+            observed_values - expected,
+            stdres_denom,
+            out=np.full_like(expected, np.nan, dtype=float),
+            where=stdres_denom != 0,
+        )
+
+    if tabyl_results:
+        observed = counts_df.copy()
+        expected = _as_tabyl_frame(expected, row_name, row_labels, col_labels)
+        residuals = _as_tabyl_frame(residuals, row_name, row_labels, col_labels)
+        stdres = _as_tabyl_frame(stdres, row_name, row_labels, col_labels)
+    else:
+        observed = observed_values
+
+    return ChiSqTestResult(
+        statistic=result.statistic,
+        pvalue=result.pvalue,
+        dof=result.dof,
+        expected=expected,
+        observed=observed,
+        residuals=residuals,
+        stdres=stdres,
+    )
+
+
+@pf.register_dataframe_method
+def fisher_test(df: pd.DataFrame) -> FisherTestResult:
+    """Apply Fisher's exact test to a two-way tabyl.
+
+    This method expects a 2x2 frequency table created via ``tabyl``.
+    If totals are present (via ``adorn_totals``), they are removed with a
+    warning before the test is run.
+
+    Examples:
+        >>> import pandas as pd
+        >>> import janitor
+        >>> df = pd.DataFrame(
+        ...     {"gear": [3, 3, 4, 4], "cyl": [4, 6, 4, 6]}
+        ... )
+        >>> result = df.tabyl("gear", "cyl").fisher_test()
+        >>> result.pvalue  # doctest: +SKIP
+        1.0
+
+    Args:
+        df: A two-way tabyl DataFrame.
+
+    Returns:
+        A FisherTestResult with the odds ratio and p-value.
+    """
+    counts_df = df.attrs.get("_original_counts", df)
+    counts_df = counts_df.copy()
+    _warn_if_totals(df, "fisher_test", counts_df)
+    counts_df = _drop_totals(counts_df)
+    _validate_two_way_tabyl(counts_df, "fisher_test")
+
+    if counts_df.shape[0] != 2 or (counts_df.shape[1] - 1) != 2:
+        raise ValueError("`fisher_test` requires a 2x2 tabyl.")
+
+    observed_values = counts_df.iloc[:, 1:].to_numpy()
+    if observed_values.sum() == 0:
+        raise ValueError(
+            "`fisher_test` requires counts that sum to a positive value."
+        )
+    result = stats.fisher_exact(observed_values)
+    statistic = result.statistic if hasattr(result, "statistic") else result[0]
+    pvalue = result.pvalue if hasattr(result, "pvalue") else result[1]
+    return FisherTestResult(statistic=statistic, pvalue=pvalue)

--- a/tests/functions/test_statistical_tests.py
+++ b/tests/functions/test_statistical_tests.py
@@ -1,0 +1,85 @@
+"""Tests for statistical tests on tabyls."""
+
+import numpy as np
+import pandas as pd
+import pytest
+from scipy import stats
+
+import janitor  # noqa: F401 - needed to register DataFrame methods
+
+
+@pytest.fixture
+def simple_df():
+    """Create a simple DataFrame for tabyl statistical tests."""
+    return pd.DataFrame(
+        {
+            "row": ["A", "A", "B", "B"],
+            "col": ["X", "Y", "X", "Y"],
+        }
+    )
+
+
+@pytest.mark.functions
+def test_chisq_test_basic_tabyl_results(simple_df):
+    """Test chi-squared output formatting on a tabyl."""
+    tabyl_df = simple_df.tabyl("row", "col")
+    result = tabyl_df.chisq_test()
+
+    expected = stats.chi2_contingency(np.array([[1, 1], [1, 1]]))
+    assert result.statistic == pytest.approx(expected.statistic)
+    assert result.dof == expected.dof
+    assert result.pvalue == pytest.approx(expected.pvalue)
+
+    expected_table = pd.DataFrame(
+        {"row": ["A", "B"], "X": [1.0, 1.0], "Y": [1.0, 1.0]}
+    )
+    pd.testing.assert_frame_equal(result.expected, expected_table)
+    pd.testing.assert_frame_equal(result.observed, tabyl_df)
+    assert np.allclose(result.residuals[["X", "Y"]].to_numpy(), 0.0)
+    assert np.allclose(result.stdres[["X", "Y"]].to_numpy(), 0.0)
+
+
+@pytest.mark.functions
+def test_chisq_test_with_totals_warns(simple_df):
+    """Test totals are removed with a warning."""
+    tabyl_df = simple_df.tabyl("row", "col").adorn_totals("both")
+    base_result = simple_df.tabyl("row", "col").chisq_test()
+    with pytest.warns(UserWarning, match="Totals"):
+        result = tabyl_df.chisq_test()
+    assert result.statistic == pytest.approx(base_result.statistic)
+
+
+@pytest.mark.functions
+def test_chisq_test_requires_two_way(simple_df):
+    """Test chisq_test raises on a 1-way tabyl."""
+    one_way = simple_df.tabyl("row")
+    with pytest.raises(ValueError, match="2-way tabyl"):
+        one_way.chisq_test()
+
+
+@pytest.mark.functions
+def test_fisher_test_basic(simple_df):
+    """Test Fisher's exact test output."""
+    tabyl_df = simple_df.tabyl("row", "col")
+    result = tabyl_df.fisher_test()
+    expected = stats.fisher_exact(np.array([[1, 1], [1, 1]]))
+    expected_stat = (
+        expected.statistic if hasattr(expected, "statistic") else expected[0]
+    )
+    expected_p = expected.pvalue if hasattr(expected, "pvalue") else expected[1]
+    assert result.statistic == pytest.approx(expected_stat)
+    assert result.pvalue == pytest.approx(expected_p)
+
+
+@pytest.mark.functions
+def test_fisher_test_requires_2x2():
+    """Test fisher_test raises on non-2x2 tables."""
+    df = pd.DataFrame(
+        {
+            "row": ["A", "A", "B", "B", "C", "C"],
+            "col": ["X", "Y", "X", "Y", "X", "Y"],
+        }
+    )
+    tabyl_df = df.tabyl("row", "col")
+    with pytest.raises(ValueError, match="2x2"):
+        tabyl_df.fisher_test()


### PR DESCRIPTION
[ENH]: Add `chisq_test` and `fisher_test` for tabyls

## PR Description

Please describe the changes proposed in the pull request:

- Implemented `chisq_test` as a DataFrame method for two-way tabyls, providing the test statistic, p-value, degrees of freedom, and observed, expected, residual, and standardized residual tables.
- Implemented `fisher_test` as a DataFrame method for 2x2 tabyls, returning the odds ratio and p-value.
- Both methods automatically detect and remove "Total" rows/columns (added via `adorn_totals`) with a warning before performing the statistical test.
- Included robust input validation to ensure the DataFrame is a suitable tabyl for each test.

**This PR resolves #1561.**

## PR Checklist

Please ensure that you have done the following:

1. [x] PR in from a fork off your branch. Do not PR from `<your_username>`:`dev`, but rather from `<your_username>`:`<feature-branch_name>`.
2. [ ] If you're not on the contributors list, add yourself to `AUTHORS.md`.
3. [ ] Add a line to `CHANGELOG.md` under the latest version header (i.e. the one that is "on deck") describing the contribution.
    - Do use some discretion here; if there are multiple PRs that are related, keep them in a single line.

## Automatic checks

There will be automatic checks run on the PR. These include:

- Building a preview of the docs on Netlify
- Automatically linting the code
- Making sure the code is documented
- Making sure that all tests are passed
- Making sure that code coverage doesn't go down.

## Relevant Reviewers

Please tag maintainers to review.

- @ericmjl

---
<p><a href="https://cursor.com/background-agent?bcId=bc-c983460d-cafe-4d79-9804-72d5deb20033"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c983460d-cafe-4d79-9804-72d5deb20033"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

