### PR TITLE
Pivot longer function

### DIFF
--- a/janitor/functions/__init__.py
+++ b/janitor/functions/__init__.py
@@ -57,6 +57,7 @@ from .filter import filter_column_isin, filter_date, filter_on, filter_string
 from .find_replace import find_replace
 from .flag_nulls import flag_nulls
 from .get_dupes import get_dupes
+from .get_one_to_one import get_one_to_one
 from .groupby_agg import groupby_agg
 from .groupby_topk import groupby_topk
 from .impute import impute
@@ -67,6 +68,7 @@ from .limit_column_characters import limit_column_characters
 from .min_max_scale import min_max_scale
 from .move import move
 from .mutate import mutate
+from .paste_skip_na import paste_skip_na
 from .pivot import (
     pivot_longer,
     pivot_longer_spec,
@@ -79,6 +81,7 @@ from .remove_empty import remove_empty
 from .rename_columns import rename_column, rename_columns
 from .reorder_columns import reorder_columns
 from .rle_id import rle_id
+from .round_half_up import round_half_up, signif_half_up
 from .round_to_fraction import round_to_fraction
 from .row_to_names import row_to_names
 from .select import (
@@ -90,6 +93,7 @@ from .select import (
     select_rows,
 )
 from .shuffle import shuffle
+from .single_value import single_value
 from .sort_column_value_order import sort_column_value_order
 from .sort_naturally import sort_naturally
 from .summarise import summarise
@@ -98,6 +102,7 @@ from .take_first import take_first
 from .then import then
 from .to_datetime import to_datetime
 from .toset import toset
+from .top_levels import top_levels
 from .transform_columns import transform_column, transform_columns
 from .truncate_datetime import truncate_datetime_dataframe
 from .update_where import update_where
@@ -150,6 +155,7 @@ __all__ = [
     "find_replace",
     "flag_nulls",
     "get_dupes",
+    "get_one_to_one",
     "get_join_indices",
     "groupby_agg",
     "groupby_topk",
@@ -162,6 +168,7 @@ __all__ = [
     "min_max_scale",
     "move",
     "mutate",
+    "paste_skip_na",
     "pivot_longer",
     "pivot_longer_spec",
     "pivot_wider",
@@ -173,12 +180,15 @@ __all__ = [
     "rename_columns",
     "reorder_columns",
     "rle_id",
+    "round_half_up",
     "round_to_fraction",
     "row_to_names",
     "select_columns",
     "select_rows",
     "select",
     "shuffle",
+    "signif_half_up",
+    "single_value",
     "sort_column_value_order",
     "sort_naturally",
     "summarise",
@@ -187,6 +197,7 @@ __all__ = [
     "then",
     "to_datetime",
     "toset",
+    "top_levels",
     "transform_column",
     "transform_columns",
     "truncate_datetime_dataframe",

--- a/janitor/functions/get_one_to_one.py
+++ b/janitor/functions/get_one_to_one.py
@@ -1,0 +1,68 @@
+"""Implementation of `get_one_to_one`."""
+
+from __future__ import annotations
+
+from typing import List
+
+import numpy as np
+import pandas as pd
+
+
+def _get_one_to_one_value_order(series: pd.Series) -> np.ndarray:
+    """Convert series values to ordered integer codes."""
+    codes, _ = pd.factorize(series, sort=False)
+    return codes
+
+
+def get_one_to_one(df: pd.DataFrame) -> List[List[str]]:
+    """Find column groups that map one-to-one with each other.
+
+    Columns are grouped if they share identical value orderings, indicating
+    a one-to-one mapping across rows.
+
+    Examples:
+        >>> import pandas as pd
+        >>> import janitor
+        >>> df = pd.DataFrame(
+        ...     {
+        ...         "Lab_Test_Long": ["Cholesterol, LDL", "Cholesterol, LDL", "Glucose"],
+        ...         "Lab_Test_Short": ["CLDL", "CLDL", "GLUC"],
+        ...         "LOINC": [12345, 12345, 54321],
+        ...         "Person": ["Sam", "Bill", "Sam"],
+        ...     }
+        ... )
+        >>> janitor.get_one_to_one(df)
+        [['Lab_Test_Long', 'Lab_Test_Short', 'LOINC']]
+
+    Args:
+        df: A pandas DataFrame.
+
+    Raises:
+        TypeError: If `df` is not a pandas DataFrame.
+        ValueError: If `df` has no columns or duplicate column names.
+
+    Returns:
+        A list of column name groups that map one-to-one with each other.
+    """
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError("df must be a pandas DataFrame.")
+    if df.shape[1] == 0:
+        raise ValueError("df must have at least one column.")
+    if df.columns.duplicated().any():
+        raise ValueError("df must have unique column names.")
+
+    encoded = {col: _get_one_to_one_value_order(df[col]) for col in df.columns}
+    remaining_cols = list(df.columns)
+    groups: List[List[str]] = []
+
+    while remaining_cols:
+        nm1 = remaining_cols.pop(0)
+        current_group = [nm1]
+        for nm2 in remaining_cols[:]:
+            if np.array_equal(encoded[nm1], encoded[nm2]):
+                current_group.append(nm2)
+                remaining_cols.remove(nm2)
+        if len(current_group) > 1:
+            groups.append(current_group)
+
+    return groups

--- a/janitor/functions/paste_skip_na.py
+++ b/janitor/functions/paste_skip_na.py
@@ -41,6 +41,17 @@ def paste_skip_na(*args, sep: str = " ", collapse: str | None = None):
     Returns:
         A scalar string/None or a list of strings/None values.
     """
+    force_list = any(is_list_like(arg) and not is_scalar(arg) for arg in args)
+    return _paste_skip_na(args, sep=sep, collapse=collapse, force_list=force_list)
+
+
+def _paste_skip_na(
+    args: tuple,
+    *,
+    sep: str,
+    collapse: str | None,
+    force_list: bool,
+):
     if len(args) == 0:
         return ""
 
@@ -52,7 +63,7 @@ def paste_skip_na(*args, sep: str = " ", collapse: str | None = None):
             non_missing = [str(value) for value in values if not pd.isna(value)]
             return collapse.join(non_missing)
 
-        if is_list_like(args[0]) and not is_scalar(args[0]):
+        if force_list:
             return [value if pd.isna(value) else str(value) for value in values]
         return values[0] if pd.isna(values[0]) else str(values[0])
 
@@ -82,5 +93,10 @@ def paste_skip_na(*args, sep: str = " ", collapse: str | None = None):
         else:
             first_two.append(value1)
 
-    new_args = [first_two, *args[2:]]
-    return paste_skip_na(*new_args, sep=sep, collapse=collapse)
+    new_args = (first_two, *args[2:])
+    return _paste_skip_na(
+        new_args,
+        sep=sep,
+        collapse=collapse,
+        force_list=force_list,
+    )

--- a/janitor/functions/paste_skip_na.py
+++ b/janitor/functions/paste_skip_na.py
@@ -1,0 +1,86 @@
+"""Implementation of `paste_skip_na`."""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+import pandas as pd
+from pandas.api.types import is_list_like, is_scalar
+
+
+def _as_listlike(value: Any) -> List[Any]:
+    """Normalize a value to a list-like container."""
+    if is_list_like(value) and not is_scalar(value):
+        return list(value)
+    return [value]
+
+
+def paste_skip_na(*args, sep: str = " ", collapse: str | None = None):
+    """Paste values together while skipping missing entries.
+
+    This mirrors R janitor's `paste_skip_na`, preserving missing values
+    when all entries are missing for a position.
+
+    Examples:
+        >>> import janitor
+        >>> janitor.paste_skip_na("A", None)
+        'A'
+        >>> janitor.paste_skip_na("A", None, ["B", None], sep=",")
+        ['A,B', 'A']
+        >>> janitor.paste_skip_na(None, None, None) is None
+        True
+
+    Args:
+        *args: Values to paste. Scalars will be recycled to match vector lengths.
+        sep: Separator used between values.
+        collapse: If provided, collapse the final vector to a scalar string.
+
+    Raises:
+        ValueError: If arguments have incompatible lengths.
+
+    Returns:
+        A scalar string/None or a list of strings/None values.
+    """
+    if len(args) == 0:
+        return ""
+
+    if len(args) == 1:
+        values = _as_listlike(args[0])
+        if collapse is not None:
+            if all(pd.isna(value) for value in values):
+                return values[0] if values else None
+            non_missing = [str(value) for value in values if not pd.isna(value)]
+            return collapse.join(non_missing)
+
+        if is_list_like(args[0]) and not is_scalar(args[0]):
+            return [value if pd.isna(value) else str(value) for value in values]
+        return values[0] if pd.isna(values[0]) else str(values[0])
+
+    a1 = _as_listlike(args[0])
+    a2 = _as_listlike(args[1])
+
+    if len(a1) != len(a2):
+        if len(a1) == 1:
+            a1 = a1 * len(a2)
+        elif len(a2) == 1:
+            a2 = a2 * len(a1)
+        else:
+            raise ValueError(
+                "Arguments must be the same length or one argument must be a scalar."
+            )
+
+    first_two = []
+    for value1, value2 in zip(a1, a2):
+        missing1 = pd.isna(value1)
+        missing2 = pd.isna(value2)
+        if not missing1 and not missing2:
+            first_two.append(f"{value1}{sep}{value2}")
+        elif missing1 and not missing2:
+            first_two.append(str(value2))
+        elif not missing1 and missing2:
+            first_two.append(str(value1))
+        else:
+            first_two.append(value1)
+
+    new_args = [first_two, *args[2:]]
+    return paste_skip_na(*new_args, sep=sep, collapse=collapse)

--- a/janitor/functions/round_half_up.py
+++ b/janitor/functions/round_half_up.py
@@ -26,7 +26,7 @@ def _prepare_numeric_input(
 
     def wrap(result: np.ndarray):
         if is_scalar:
-            return result[0]
+            return result[0].item()
         return result
 
     return arr, wrap

--- a/janitor/functions/round_half_up.py
+++ b/janitor/functions/round_half_up.py
@@ -1,0 +1,95 @@
+"""Implementation of `round_half_up` and `signif_half_up`."""
+
+from __future__ import annotations
+
+from typing import Callable, Tuple
+
+import numpy as np
+import pandas as pd
+
+
+def _prepare_numeric_input(
+    x,
+) -> Tuple[np.ndarray, Callable[[np.ndarray], object]]:
+    """Convert input to a numeric array and build a wrapper for output."""
+    if isinstance(x, pd.Series):
+        arr = x.to_numpy(dtype=float)
+
+        def wrap(result: np.ndarray):
+            return pd.Series(result, index=x.index, name=x.name)
+
+        return arr, wrap
+
+    arr = np.asarray(x, dtype=float)
+    is_scalar = arr.ndim == 0
+    arr = np.atleast_1d(arr)
+
+    def wrap(result: np.ndarray):
+        if is_scalar:
+            return result[0]
+        return result
+
+    return arr, wrap
+
+
+def round_half_up(x, digits: int = 0):
+    """Round values using "half up" rounding (Excel-style).
+
+    This differs from Python's built-in `round`, which uses bankers rounding.
+
+    Examples:
+        >>> import janitor
+        >>> janitor.round_half_up(12.5)
+        13.0
+        >>> janitor.round_half_up(1.125, digits=2)
+        1.13
+        >>> janitor.round_half_up(-0.5)
+        -1.0
+
+    Args:
+        x: Numeric scalar or array-like.
+        digits: Number of decimal digits to round to.
+
+    Returns:
+        Rounded value(s).
+    """
+    arr, wrap = _prepare_numeric_input(x)
+    factor = 10**digits
+    posneg = np.sign(arr)
+    z = np.abs(arr) * factor
+    z = z + 0.5 + np.sqrt(np.finfo(float).eps)
+    z = np.trunc(z)
+    z = z / factor
+    z = z * posneg
+    return wrap(z)
+
+
+def signif_half_up(x, digits: int = 6):
+    """Round values to the specified number of significant digits.
+
+    Uses "half up" rounding for midpoint values.
+
+    Examples:
+        >>> import janitor
+        >>> janitor.signif_half_up(12.5, digits=2)
+        13.0
+        >>> janitor.signif_half_up(1.125, digits=3)
+        1.13
+        >>> janitor.signif_half_up(-2.5, digits=1)
+        -3.0
+
+    Args:
+        x: Numeric scalar or array-like.
+        digits: Number of significant digits.
+
+    Returns:
+        Rounded value(s).
+    """
+    arr, wrap = _prepare_numeric_input(x)
+    z = arr.astype(float, copy=True)
+    mask = (z != 0) & np.isfinite(z)
+    if mask.any():
+        y = np.zeros_like(z)
+        y[mask] = 10 ** (digits - np.ceil(np.log10(np.abs(z[mask]))))
+        z[mask] = round_half_up(z[mask] * y[mask]) / y[mask]
+    return wrap(z)

--- a/janitor/functions/single_value.py
+++ b/janitor/functions/single_value.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Iterable, Sequence
 import warnings
 
+import numpy as np
 import pandas as pd
 from pandas.api.types import is_list_like, is_scalar
 
@@ -57,9 +58,9 @@ def single_value(
     if isinstance(x, pd.Series):
         series = x.copy()
     elif is_list_like(x) and not is_scalar(x):
-        series = pd.Series(list(x))
+        series = pd.Series(list(x), dtype="object")
     else:
-        series = pd.Series([x])
+        series = pd.Series([x], dtype="object")
 
     missing_values = _normalize_missing(missing)
     contains_na = any(pd.isna(value) for value in missing_values)
@@ -83,7 +84,10 @@ def single_value(
     if len(found_values) == 0:
         return missing_values[0] if missing_values else None
     if len(found_values) == 1:
-        return found_values[0]
+        value = found_values[0]
+        if isinstance(value, np.generic):
+            return value.item()
+        return value
 
     values_str = ", ".join(map(str, found_values))
     message = f"More than one ({len(found_values)}) value found ({values_str})"

--- a/janitor/functions/single_value.py
+++ b/janitor/functions/single_value.py
@@ -1,0 +1,92 @@
+"""Implementation of `single_value`."""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+import warnings
+
+import pandas as pd
+from pandas.api.types import is_list_like, is_scalar
+
+from janitor.utils import find_stack_level
+
+
+def _normalize_missing(missing) -> list:
+    """Normalize missing values into a list."""
+    if missing is None:
+        return [None]
+    if is_list_like(missing) and not is_scalar(missing):
+        return list(missing)
+    return [missing]
+
+
+def single_value(
+    x: Iterable,
+    missing: Sequence | None = None,
+    warn_if_all_missing: bool = False,
+    info: str | None = None,
+):
+    """Ensure that a vector contains only a single unique value.
+
+    Missing values are excluded from the uniqueness check. If all values
+    are missing, the first entry in `missing` is returned.
+
+    Examples:
+        >>> import janitor
+        >>> janitor.single_value([1, 1, 1, None])
+        1
+        >>> janitor.single_value([None, "a"], missing=["a", None])
+        'a'
+        >>> janitor.single_value([1, 2, 3])  # doctest: +IGNORE_EXCEPTION_DETAIL
+        Traceback (most recent call last):
+            ...
+        ValueError: More than one (3) value found (1, 2, 3)
+
+    Args:
+        x: Vector-like input (list, tuple, numpy array, or pandas Series).
+        missing: Values to consider missing in `x`. Defaults to None.
+        warn_if_all_missing: Whether to warn if all values are missing.
+        info: Extra context to append to error messages.
+
+    Raises:
+        ValueError: If more than one unique non-missing value is found.
+
+    Returns:
+        The single unique value, or the first missing value if all missing.
+    """
+    if isinstance(x, pd.Series):
+        series = x.copy()
+    elif is_list_like(x) and not is_scalar(x):
+        series = pd.Series(list(x))
+    else:
+        series = pd.Series([x])
+
+    missing_values = _normalize_missing(missing)
+    contains_na = any(pd.isna(value) for value in missing_values)
+    missing_values_clean = [value for value in missing_values if not pd.isna(value)]
+
+    mask_missing = pd.Series(False, index=series.index)
+    if contains_na:
+        mask_missing = series.isna()
+    if missing_values_clean:
+        mask_missing = mask_missing | series.isin(missing_values_clean)
+
+    mask_found = ~mask_missing
+    if warn_if_all_missing and not mask_found.any():
+        warnings.warn(
+            "All values are missing",
+            UserWarning,
+            stacklevel=find_stack_level(),
+        )
+
+    found_values = pd.unique(series[mask_found])
+    if len(found_values) == 0:
+        return missing_values[0] if missing_values else None
+    if len(found_values) == 1:
+        return found_values[0]
+
+    values_str = ", ".join(map(str, found_values))
+    message = f"More than one ({len(found_values)}) value found ({values_str})"
+    if info is not None:
+        message = f"{message}: {info}"
+    raise ValueError(message)

--- a/janitor/functions/top_levels.py
+++ b/janitor/functions/top_levels.py
@@ -1,0 +1,131 @@
+"""Implementation of `top_levels`."""
+
+from __future__ import annotations
+
+from numbers import Real
+from typing import Dict, List
+
+import pandas as pd
+
+
+def _get_level_groups(
+    levels: List[str],
+    n: int,
+    num_levels: int,
+) -> Dict[str, str | None]:
+    """Return grouped level labels for top, middle, and bottom categories."""
+    top_levels = ", ".join(map(str, levels[:n]))
+    bottom_levels = ", ".join(map(str, levels[num_levels - n : num_levels]))
+
+    if num_levels > 2 * n:
+        middle_levels = ", ".join(map(str, levels[n : num_levels - n]))
+    else:
+        middle_levels = None
+
+    if middle_levels is not None and len(middle_levels) > 30:
+        middle_levels = f"<<< Middle Group ({num_levels - 2 * n} categories) >>>"
+    if len(top_levels) > 30:
+        top_levels = f"{top_levels[:27]}..."
+    if len(bottom_levels) > 30:
+        bottom_levels = f"{bottom_levels[:27]}..."
+
+    return {"top": top_levels, "mid": middle_levels, "bot": bottom_levels}
+
+
+def top_levels(
+    input_vec: pd.Series | pd.Categorical,
+    n: int = 2,
+    show_na: bool = False,
+) -> pd.DataFrame:
+    """Generate a grouped frequency table for a categorical variable.
+
+    Groups levels into top-n, middle, and bottom-n categories by level order.
+
+    Examples:
+        >>> import pandas as pd
+        >>> import janitor
+        >>> s = pd.Categorical(["A", "B", "C", "D", "E", "A", "B", "C"])
+        >>> janitor.top_levels(s, n=2)
+            level  n  percent
+        0    A, B  4     0.50
+        1  C  ...     ...  # doctest: +SKIP
+        2    D, E  3     0.375
+
+    Args:
+        input_vec: A pandas Categorical or Series with categorical dtype.
+        n: Number of levels in each of the top and bottom groups.
+        show_na: Whether to include NA values in the output.
+
+    Raises:
+        ValueError: If input is not categorical or `n` is invalid.
+
+    Returns:
+        A DataFrame with grouped counts and percentages.
+    """
+    if isinstance(input_vec, pd.Series):
+        series = input_vec
+    elif isinstance(input_vec, pd.Categorical):
+        series = pd.Series(input_vec)
+    elif isinstance(input_vec, pd.Index):
+        series = pd.Series(input_vec)
+    else:
+        raise ValueError("factor_vec is not of type 'factor'")
+
+    if not isinstance(series.dtype, pd.CategoricalDtype):
+        raise ValueError("factor_vec is not of type 'factor'")
+
+    num_levels = len(series.cat.categories)
+
+    if num_levels <= 2:
+        raise ValueError("input factor variable must have at least 3 levels")
+
+    if not isinstance(n, Real) or n < 1 or n % 1 != 0:
+        raise ValueError("n must be a whole number at least 1")
+
+    n = int(n)
+    if num_levels < 2 * n:
+        raise ValueError(
+            "there are "
+            f"{num_levels} levels in the variable and {n} levels in each of the "
+            "top and bottom groups.\nSince 2 * "
+            f"{n} = {2 * n} is greater than {num_levels}, "
+            "there would be overlap in the top and bottom groups and some "
+            "records will be double-counted."
+        )
+    var_name = series.name or "level"
+    levels = list(series.cat.categories)
+    groups = _get_level_groups(levels, n, num_levels)
+
+    codes = series.cat.codes
+    grouped = pd.Series(pd.NA, index=series.index, dtype="object")
+    valid = codes != -1
+
+    grouped.loc[valid & (codes < n)] = groups["top"]
+    grouped.loc[valid & (codes >= num_levels - n)] = groups["bot"]
+
+    if groups["mid"] is not None:
+        middle_mask = valid & (codes >= n) & (codes < num_levels - n)
+        grouped.loc[middle_mask] = groups["mid"]
+
+    if groups["mid"] is None:
+        categories = [groups["top"], groups["bot"]]
+    else:
+        categories = [groups["top"], groups["mid"], groups["bot"]]
+
+    grouped = pd.Categorical(grouped, categories=categories, ordered=True)
+
+    from .tabyl import _tabyl_one
+
+    result = _tabyl_one(
+        pd.DataFrame({var_name: grouped}),
+        var_name,
+        show_na=show_na,
+        show_missing_levels=True,
+    )
+
+    if show_na and result[var_name].isna().any():
+        non_na = result[~result[var_name].isna()]
+        na_rows = result[result[var_name].isna()]
+        result = pd.concat([non_na, na_rows], ignore_index=True)
+
+    return result

--- a/janitor/functions/top_levels.py
+++ b/janitor/functions/top_levels.py
@@ -46,10 +46,10 @@ def top_levels(
         >>> import janitor
         >>> s = pd.Categorical(["A", "B", "C", "D", "E", "A", "B", "C"])
         >>> janitor.top_levels(s, n=2)
-            level  n  percent
-        0    A, B  4     0.50
-        1  C  ...     ...  # doctest: +SKIP
-        2    D, E  3     0.375
+          level  n  percent
+        0  A, B  4     0.50
+        1     C  2     0.25
+        2  D, E  2     0.25
 
     Args:
         input_vec: A pandas Categorical or Series with categorical dtype.

--- a/tests/functions/test_get_one_to_one.py
+++ b/tests/functions/test_get_one_to_one.py
@@ -1,0 +1,38 @@
+import pandas as pd
+import pytest
+
+import janitor
+
+
+@pytest.mark.functions
+def test_get_one_to_one_basic():
+    df = pd.DataFrame(
+        {
+            "Lab_Test_Long": ["Cholesterol, LDL", "Cholesterol, LDL", "Glucose"],
+            "Lab_Test_Short": ["CLDL", "CLDL", "GLUC"],
+            "LOINC": [12345, 12345, 54321],
+            "Person": ["Sam", "Bill", "Sam"],
+        }
+    )
+    assert janitor.get_one_to_one(df) == [
+        ["Lab_Test_Long", "Lab_Test_Short", "LOINC"]
+    ]
+
+
+@pytest.mark.functions
+def test_get_one_to_one_no_matches():
+    df = pd.DataFrame({"a": [1, 2, 1], "b": [1, 2, 2]})
+    assert janitor.get_one_to_one(df) == []
+
+
+@pytest.mark.functions
+def test_get_one_to_one_duplicate_columns_error():
+    df = pd.DataFrame([[1, 2]], columns=["a", "a"])
+    with pytest.raises(ValueError, match="unique column names"):
+        janitor.get_one_to_one(df)
+
+
+@pytest.mark.functions
+def test_get_one_to_one_empty_dataframe_error():
+    with pytest.raises(ValueError, match="at least one column"):
+        janitor.get_one_to_one(pd.DataFrame())

--- a/tests/functions/test_paste_skip_na.py
+++ b/tests/functions/test_paste_skip_na.py
@@ -1,0 +1,33 @@
+import pytest
+
+import janitor
+
+
+@pytest.mark.functions
+def test_paste_skip_na_basic():
+    assert janitor.paste_skip_na("A", None) == "A"
+    assert janitor.paste_skip_na("A", None, ["B", None], sep=",") == ["A,B", "A"]
+
+
+@pytest.mark.functions
+def test_paste_skip_na_all_missing():
+    assert janitor.paste_skip_na(None, None, None) is None
+
+
+@pytest.mark.functions
+def test_paste_skip_na_length_mismatch_error():
+    with pytest.raises(
+        ValueError,
+        match="Arguments must be the same length or one argument must be a scalar.",
+    ):
+        janitor.paste_skip_na(["A", "B"], ["C", "D", "E"])
+
+
+@pytest.mark.functions
+def test_paste_skip_na_collapse():
+    assert janitor.paste_skip_na(["A", None, "B"], collapse=",") == "A,B"
+
+
+@pytest.mark.functions
+def test_paste_skip_na_recycles_scalar():
+    assert janitor.paste_skip_na("A", ["B", "C"], sep="-") == ["A-B", "A-C"]

--- a/tests/functions/test_round_half_up.py
+++ b/tests/functions/test_round_half_up.py
@@ -1,0 +1,43 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+import janitor
+
+
+@pytest.mark.functions
+def test_round_half_up_scalar():
+    assert janitor.round_half_up(12.5) == 13.0
+    assert janitor.round_half_up(1.125, digits=2) == pytest.approx(1.13)
+    assert janitor.round_half_up(-0.5) == -1.0
+
+
+@pytest.mark.functions
+def test_round_half_up_array():
+    result = janitor.round_half_up([0.5, 1.5, 2.5])
+    assert np.allclose(result, [1.0, 2.0, 3.0])
+
+
+@pytest.mark.functions
+def test_round_half_up_series_preserves_index():
+    series = pd.Series([0.5, 1.5], name="vals")
+    result = janitor.round_half_up(series)
+    assert isinstance(result, pd.Series)
+    assert result.name == "vals"
+    assert result.tolist() == [1.0, 2.0]
+
+
+@pytest.mark.functions
+def test_signif_half_up_scalar():
+    assert janitor.signif_half_up(12.5, digits=2) == 13.0
+    assert janitor.signif_half_up(1.125, digits=3) == pytest.approx(1.13)
+    assert janitor.signif_half_up(-2.5, digits=1) == -3.0
+
+
+@pytest.mark.functions
+def test_signif_half_up_array_with_nan_inf():
+    values = np.array([0.0, np.nan, np.inf, 123.4])
+    result = janitor.signif_half_up(values, digits=2)
+    assert result[0] == 0
+    assert np.isnan(result[1])
+    assert np.isinf(result[2])

--- a/tests/functions/test_single_value.py
+++ b/tests/functions/test_single_value.py
@@ -1,0 +1,37 @@
+import pandas as pd
+import pytest
+
+import janitor
+
+
+@pytest.mark.functions
+def test_single_value_basic():
+    assert janitor.single_value([1, 1, 1, None]) == 1
+
+
+@pytest.mark.functions
+def test_single_value_all_missing_returns_first_missing():
+    result = janitor.single_value([None, "a"], missing=["a", None])
+    assert result == "a"
+
+
+@pytest.mark.functions
+def test_single_value_warns_if_all_missing():
+    with pytest.warns(UserWarning, match="All values are missing"):
+        result = janitor.single_value([None, None], warn_if_all_missing=True)
+    assert result is None
+
+
+@pytest.mark.functions
+def test_single_value_with_series_input():
+    series = pd.Series([1, 1, pd.NA])
+    assert janitor.single_value(series) == 1
+
+
+@pytest.mark.functions
+def test_single_value_info_in_error():
+    with pytest.raises(
+        ValueError,
+        match=r"More than one \(2\) value found \(1, 2\): group A=1",
+    ):
+        janitor.single_value([1, 2], info="group A=1")

--- a/tests/functions/test_top_levels.py
+++ b/tests/functions/test_top_levels.py
@@ -1,0 +1,132 @@
+import pandas as pd
+import pytest
+
+import janitor
+from janitor.functions.top_levels import _get_level_groups
+
+
+@pytest.fixture
+def fac():
+    levels = list("abcdef")[::-1]
+    values = ["a", "b", "c", "d", "e", "f", "f"]
+    return pd.Categorical(values, categories=levels, ordered=True)
+
+
+@pytest.mark.functions
+def test_top_levels_values(fac):
+    result = janitor.top_levels(fac)
+    assert result["n"].tolist() == [3, 2, 2]
+    assert result["percent"].tolist() == pytest.approx([3 / 7, 2 / 7, 2 / 7])
+
+    result_n3 = janitor.top_levels(fac, n=3)
+    assert result_n3["n"].tolist() == [4, 3]
+    assert result_n3["percent"].tolist() == pytest.approx([4 / 7, 3 / 7])
+
+
+@pytest.mark.functions
+def test_top_levels_odd_levels():
+    levels = list("abcde")[::-1]
+    values = ["a", "b", "c", "d", "e", "f", "f"]
+    fac_odd = pd.Categorical(values, categories=levels, ordered=True)
+
+    result = janitor.top_levels(fac_odd)
+    assert result["n"].tolist() == [2, 1, 2]
+    assert result["percent"].tolist() == pytest.approx([0.4, 0.2, 0.4])
+
+    result_n1 = janitor.top_levels(fac_odd, n=1)
+    assert result_n1["n"].tolist() == [1, 3, 1]
+    assert result_n1["percent"].tolist() == pytest.approx([0.2, 0.6, 0.2])
+
+
+@pytest.mark.functions
+def test_top_levels_missing_levels():
+    values = list("abc")
+    levels = list("abcde")
+    categorical = pd.Categorical(values, categories=levels, ordered=True)
+    result = janitor.top_levels(categorical)
+    assert result["n"].tolist() == [2, 1, 0]
+
+
+@pytest.mark.functions
+def test_top_levels_na_handling(fac):
+    values = list(fac)
+    values[-1] = None
+    fac_na = pd.Categorical(values, categories=fac.categories, ordered=True)
+
+    result = janitor.top_levels(fac_na, show_na=True)
+    assert result["n"].tolist() == [2, 2, 2, 1]
+    assert result["percent"].tolist() == pytest.approx(
+        [2 / 7, 2 / 7, 2 / 7, 1 / 7]
+    )
+    assert result["valid_percent"].iloc[:3].tolist() == pytest.approx(
+        [1 / 3] * 3
+    )
+    assert pd.isna(result["valid_percent"].iloc[3])
+
+
+@pytest.mark.functions
+def test_top_levels_column_name(fac):
+    series = pd.Series(fac, name="fac")
+    result = janitor.top_levels(series)
+    assert result.columns[0] == "fac"
+
+
+@pytest.mark.functions
+def test_top_levels_type_errors():
+    with pytest.raises(ValueError, match="factor_vec is not of type 'factor'"):
+        janitor.top_levels([0, 1])
+    with pytest.raises(ValueError, match="factor_vec is not of type 'factor'"):
+        janitor.top_levels(pd.Series([0, 1]))
+
+
+@pytest.mark.functions
+def test_top_levels_invalid_n(fac):
+    with pytest.raises(ValueError, match="double-counted"):
+        janitor.top_levels(fac, n=4)
+    with pytest.raises(ValueError, match="n must be a whole number at least 1"):
+        janitor.top_levels(fac, n=0)
+    with pytest.raises(ValueError, match="n must be a whole number at least 1"):
+        janitor.top_levels(fac, n=1.5)
+
+    small = pd.Categorical(["a", "b"], categories=["a", "b"], ordered=True)
+    with pytest.raises(
+        ValueError, match="input factor variable must have at least 3 levels"
+    ):
+        janitor.top_levels(small)
+
+
+@pytest.mark.functions
+def test_get_level_groups_short_labels():
+    levels = list("abcdef")[::-1]
+    groups = _get_level_groups(levels, 1, len(levels))
+    assert groups == {"top": "f", "mid": "e, d, c, b", "bot": "a"}
+
+    groups_n2 = _get_level_groups(levels, 2, len(levels))
+    assert groups_n2 == {"top": "f, e", "mid": "d, c", "bot": "b, a"}
+
+    groups_n3 = _get_level_groups(levels, 3, len(levels))
+    assert groups_n3 == {"top": "f, e, d", "mid": None, "bot": "c, b, a"}
+
+
+@pytest.mark.functions
+def test_get_level_groups_truncation():
+    levels = [
+        "dddddddddddddddd",
+        "aaaaaaaaaaaaaaaa",
+        "cccccccccccccccccccc",
+        "bbbbbbbbbbbbbbbbb",
+        "hhhhhhhhhhhhhhhh",
+    ]
+    groups_n1 = _get_level_groups(levels, 1, len(levels))
+    assert groups_n1 == {
+        "top": "dddddddddddddddd",
+        "mid": "<<< Middle Group (3 categories) >>>",
+        "bot": "hhhhhhhhhhhhhhhh",
+    }
+
+    groups_n2 = _get_level_groups(levels, 2, len(levels))
+    assert groups_n2["top"] == "dddddddddddddddd, aaaaaaaaa..."
+    assert groups_n2["mid"] == "cccccccccccccccccccc"
+    assert groups_n2["bot"] == "bbbbbbbbbbbbbbbbb, hhhhhhhh..."
+    assert len(groups_n2["top"]) == 30
+    assert len(groups_n2["bot"]) == 30


### PR DESCRIPTION
[ENH] Implement R-janitor utility functions

## PR Description

This PR implements several utility functions inspired by R's janitor package:

- **`single_value`**: Ensures a vector contains only one unique non-missing value.
- **`get_one_to_one`**: Identifies groups of columns that have a one-to-one mapping based on value ordering.
- **`round_half_up` / `signif_half_up`**: Provides "half up" rounding (Excel-style) for specified decimal places or significant digits.
- **`paste_skip_na`**: Concatenates values, skipping `NA` entries, similar to R's `paste`.
- **`top_levels`**: Generates a grouped frequency table for categorical variables, showing top-N, middle, and bottom-N levels.

These functions are integrated into the public API and include comprehensive test coverage.

**This PR resolves #1560.**

## PR Checklist

1. [x] PR in from a fork off your branch. Do not PR from `<your_username>`:`dev`, but rather from `<your_username>`:`<feature-branch_name>`.
2. [ ] If you're not on the contributors list, add yourself to `AUTHORS.md`.
3. [ ] Add a line to `CHANGELOG.md` under the latest version header (i.e. the one that is "on deck") describing the contribution.

## Automatic checks

There will be automatic checks run on the PR. These include:

- Building a preview of the docs on Netlify
- Automatically linting the code
- Making sure the code is documented
- Making sure that all tests are passed
- Making sure that code coverage doesn't go down.

## Relevant Reviewers

Please tag maintainers to review.

- @ericmjl

---
<p><a href="https://cursor.com/background-agent?bcId=bc-bb0ba1c8-108f-4c70-bca6-e489598477f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bb0ba1c8-108f-4c70-bca6-e489598477f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

