### PR TITLE
[ENH] Implement mixed-format date/datetime parsing and SAS/Excel converters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -534,6 +534,13 @@ consistent formatting and catch issues like long lines.
 **Recommendation**: After editing any markdown file, run `markdownlint <file>`.
 If not installed, use `pixi global install markdownlint-cli`.
 
+### [2026-02-07] Open PRs with GitHub CLI
+
+**Context**: User requested opening a PR after pushing changes.
+**Learning**: Use `gh pr create` to open PRs when requested.
+**Recommendation**: After pushing to the branch, create the PR using the GitHub
+CLI.
+
 ---
 
 ## Version History

--- a/janitor/functions/__init__.py
+++ b/janitor/functions/__init__.py
@@ -39,7 +39,11 @@ from .conditional_join import conditional_join, get_join_indices, join_agg
 from .convert_date import (
     convert_excel_date,
     convert_matlab_date,
+    convert_to_date,
+    convert_to_datetime,
     convert_unix_date,
+    excel_time_to_numeric,
+    sas_numeric_to_date,
 )
 from .count_cumulative_unique import count_cumulative_unique
 from .currency_column_to_numeric import currency_column_to_numeric
@@ -128,7 +132,11 @@ __all__ = [
     "conditional_join",
     "convert_excel_date",
     "convert_matlab_date",
+    "convert_to_date",
+    "convert_to_datetime",
     "convert_unix_date",
+    "excel_time_to_numeric",
+    "sas_numeric_to_date",
     "count_cumulative_unique",
     "currency_column_to_numeric",
     "deconcatenate_column",

--- a/janitor/functions/convert_date.py
+++ b/janitor/functions/convert_date.py
@@ -50,7 +50,8 @@ def _apply_timezone(timestamp: pd.Timestamp, tz: str | None) -> pd.Timestamp:
 
 
 def _excel_numeric_to_timestamp(value: float) -> pd.Timestamp:
-    return pd.to_datetime(value, unit="D", origin="1899-12-30")
+    timestamp = pd.to_datetime(value, unit="D", origin="1899-12-30")
+    return timestamp.round("s")
 
 
 def _looks_like_time(value: str) -> bool:

--- a/janitor/functions/convert_date.py
+++ b/janitor/functions/convert_date.py
@@ -12,11 +12,11 @@ from pandas.errors import OutOfBoundsDatetime
 from janitor.utils import deprecated_alias, find_stack_level, refactored_function
 
 _EXCEL_EPOCH = datetime(1899, 12, 30)
-_EXCEL_DATE_PATTERN = re.compile(r"^[0-9]{5}(?:\\.[0-9]*)?$")
-_TIME_NUMBER_PATTERN = re.compile(r"^0(?:\\.[0-9]*)?$")
+_EXCEL_DATE_PATTERN = re.compile(r"^[0-9]{5}(?:\.[0-9]*)?$")
+_TIME_NUMBER_PATTERN = re.compile(r"^0(?:\.[0-9]*)?$")
 _TIME_SCI_NUMBER_PATTERN = re.compile(r"^[1-9](?:\\.[0-9]*)?E-[0-9]+$", re.IGNORECASE)
 _TIME_12HR_PATTERN = re.compile(
-    r"^([0]?[1-9]|1[0-2]):([0-5][0-9])(?::([0-5][0-9]))?\\s*([AP]M)$",
+    r"^([0]?[1-9]|1[0-2]):([0-5][0-9])(?::([0-5][0-9]))?\s*([AP]M)$",
     re.IGNORECASE,
 )
 _TIME_24HR_PATTERN = re.compile(

--- a/janitor/functions/convert_date.py
+++ b/janitor/functions/convert_date.py
@@ -1,10 +1,80 @@
-from typing import Hashable, Union
+import numbers
+import re
+import warnings
+from datetime import date, datetime, time, timedelta
+from typing import Any, Callable, Hashable, List, Tuple, Union
 
 import pandas as pd
 import pandas_flavor as pf
+from pandas.api.types import is_list_like, is_scalar
 from pandas.errors import OutOfBoundsDatetime
 
-from janitor.utils import deprecated_alias, refactored_function
+from janitor.utils import deprecated_alias, find_stack_level, refactored_function
+
+_EXCEL_EPOCH = datetime(1899, 12, 30)
+_EXCEL_DATE_PATTERN = re.compile(r"^[0-9]{5}(?:\\.[0-9]*)?$")
+_TIME_NUMBER_PATTERN = re.compile(r"^0(?:\\.[0-9]*)?$")
+_TIME_SCI_NUMBER_PATTERN = re.compile(r"^[1-9](?:\\.[0-9]*)?E-[0-9]+$", re.IGNORECASE)
+_TIME_12HR_PATTERN = re.compile(
+    r"^([0]?[1-9]|1[0-2]):([0-5][0-9])(?::([0-5][0-9]))?\\s*([AP]M)$",
+    re.IGNORECASE,
+)
+_TIME_24HR_PATTERN = re.compile(
+    r"^([0-1]?[0-9]|2[0-3]):([0-5][0-9])(?::([0-5][0-9]))?$"
+)
+_TIME_POSIX_PATTERN = re.compile(
+    r"^1899-12-31 (?:([0-1]?[0-9]|2[0-3]):([0-5][0-9])(?::([0-5][0-9]))?)?.*$"
+)
+
+
+def _prepare_input(
+    values: Any,
+) -> Tuple[List[Any], Callable[[List[Any]], Any]]:
+    if isinstance(values, pd.Series):
+        return values.tolist(), lambda result: pd.Series(
+            result, index=values.index, name=values.name
+        )
+    if is_scalar(values):
+        return [values], lambda result: result[0]
+    if is_list_like(values):
+        return list(values), lambda result: result
+    return [values], lambda result: result[0]
+
+
+def _apply_timezone(timestamp: pd.Timestamp, tz: str | None) -> pd.Timestamp:
+    if tz is None:
+        return timestamp
+    if timestamp.tzinfo is None:
+        return timestamp.tz_localize(tz)
+    return timestamp.tz_convert(tz)
+
+
+def _excel_numeric_to_timestamp(value: float) -> pd.Timestamp:
+    return pd.to_datetime(value, unit="D", origin="1899-12-30")
+
+
+def _looks_like_time(value: str) -> bool:
+    return bool(
+        _TIME_NUMBER_PATTERN.match(value)
+        or _TIME_SCI_NUMBER_PATTERN.match(value)
+        or _TIME_12HR_PATTERN.match(value)
+        or _TIME_24HR_PATTERN.match(value)
+        or _TIME_POSIX_PATTERN.match(value)
+    )
+
+
+def _format_failed_strings(values: List[str], out_class: str) -> str:
+    unique_values = sorted(set(values))
+    if len(unique_values) > 10:
+        preview = ", ".join(f'"{val}"' for val in unique_values[:9])
+        remainder = len(unique_values) - 9
+        not_converted_values = f"{preview} ... and {remainder} other values."
+    else:
+        not_converted_values = ", ".join(f'"{val}"' for val in unique_values)
+    return (
+        "Not all character strings converted to class "
+        f"{out_class}. Values not converted were: {not_converted_values}"
+    )
 
 
 @pf.register_dataframe_method
@@ -98,6 +168,543 @@ def convert_matlab_date(
     }
 
     return df.assign(**dictionary)
+
+
+def excel_time_to_numeric(time_value: Any, round_seconds: bool = True) -> Any:
+    """Convert Excel time representations to numeric seconds.
+
+    The returned values represent the number of seconds between 0 and 86400.
+
+    Examples:
+        >>> import janitor as jn
+        >>> jn.excel_time_to_numeric("0.5")
+        43200
+        >>> jn.excel_time_to_numeric("12:30 PM")
+        45000
+        >>> jn.excel_time_to_numeric("14:30:15")
+        52215
+
+    Args:
+        time_value: A scalar or list-like of time values to convert.
+        round_seconds: Whether to round output seconds to integers.
+
+    Returns:
+        Numeric seconds (scalar or list) corresponding to `time_value`.
+
+    Raises:
+        ValueError: If numeric values are outside the 0-1 range or strings
+            do not match supported time formats.
+        TypeError: If `time_value` contains unsupported types.
+    """
+    if not isinstance(round_seconds, bool):
+        raise TypeError("round_seconds should be a boolean.")
+
+    values, finalize = _prepare_input(time_value)
+    results: List[Any] = []
+    invalid_strings: List[str] = []
+
+    for value in values:
+        if pd.isna(value):
+            results.append(None)
+            continue
+
+        if isinstance(value, bool):
+            raise TypeError("If given as a boolean, all values must be missing.")
+
+        if isinstance(value, numbers.Number):
+            numeric_value = float(value)
+            if not (0 <= numeric_value < 1):
+                raise ValueError(
+                    "When numeric, all `time_value`s must be between 0 and 1 "
+                    "(exclusive of 1)."
+                )
+            seconds = numeric_value * 86400
+            if round_seconds:
+                seconds = int(round(seconds))
+            results.append(seconds)
+            continue
+
+        if isinstance(value, (pd.Timestamp, datetime)):
+            seconds = (
+                value.hour * 3600
+                + value.minute * 60
+                + value.second
+                + value.microsecond / 1_000_000
+            )
+            if round_seconds:
+                seconds = int(round(seconds))
+            results.append(seconds)
+            continue
+
+        if isinstance(value, time):
+            seconds = (
+                value.hour * 3600
+                + value.minute * 60
+                + value.second
+                + value.microsecond / 1_000_000
+            )
+            if round_seconds:
+                seconds = int(round(seconds))
+            results.append(seconds)
+            continue
+
+        if isinstance(value, str):
+            text = value.strip()
+            if _TIME_NUMBER_PATTERN.match(text) or _TIME_SCI_NUMBER_PATTERN.match(
+                text
+            ):
+                numeric_value = float(text)
+                if not (0 <= numeric_value < 1):
+                    raise ValueError(
+                        "When numeric, all `time_value`s must be between 0 and 1 "
+                        "(exclusive of 1)."
+                    )
+                seconds = numeric_value * 86400
+            elif _TIME_POSIX_PATTERN.match(text):
+                match = _TIME_POSIX_PATTERN.match(text)
+                hours = match.group(1) or "0"
+                minutes = match.group(2) or "0"
+                seconds = match.group(3) or "0"
+                seconds = (
+                    int(hours) * 3600 + int(minutes) * 60 + int(seconds)
+                )
+            elif _TIME_12HR_PATTERN.match(text):
+                match = _TIME_12HR_PATTERN.match(text)
+                hours = int(match.group(1))
+                minutes = int(match.group(2))
+                seconds = int(match.group(3) or 0)
+                meridiem = match.group(4).lower()
+                if hours == 12:
+                    hours = 0
+                if meridiem == "pm":
+                    hours += 12
+                seconds = hours * 3600 + minutes * 60 + seconds
+            elif _TIME_24HR_PATTERN.match(text):
+                match = _TIME_24HR_PATTERN.match(text)
+                hours = int(match.group(1))
+                minutes = int(match.group(2))
+                seconds = int(match.group(3) or 0)
+                seconds = hours * 3600 + minutes * 60 + seconds
+            else:
+                invalid_strings.append(value)
+                results.append(None)
+                continue
+
+            if round_seconds:
+                seconds = int(round(seconds))
+            results.append(seconds)
+            continue
+
+        raise TypeError("time_value entries must be numeric, time-like, or strings.")
+
+    if invalid_strings:
+        invalid_values = ", ".join(sorted(set(invalid_strings)))
+        raise ValueError(
+            "The following character strings did not match an interpretable "
+            f"character format for time conversion: {invalid_values}"
+        )
+
+    return finalize(results)
+
+
+def _coerce_character_result(
+    value: Any, out_class: str
+) -> date | pd.Timestamp:
+    if out_class == "date":
+        if isinstance(value, pd.Timestamp):
+            return value.date()
+        if isinstance(value, datetime):
+            return value.date()
+        if isinstance(value, date):
+            return value
+    else:
+        if isinstance(value, pd.Timestamp):
+            return value
+        if isinstance(value, datetime):
+            return pd.Timestamp(value)
+        if isinstance(value, date):
+            return pd.Timestamp(datetime.combine(value, time.min))
+    raise TypeError(
+        "`character_fun` must return date or datetime objects for string inputs."
+    )
+
+
+def _timestamp_to_output(
+    timestamp: pd.Timestamp, out_class: str, tz: str | None
+) -> Any:
+    if out_class == "date":
+        return timestamp.date()
+    timestamp = _apply_timezone(timestamp, tz)
+    return timestamp.to_pydatetime()
+
+
+def _convert_string_value(
+    value: str,
+    out_class: str,
+    tz: str | None,
+    character_fun: Callable[[str], Any],
+    failed_strings: List[str],
+) -> Any:
+    text = value.strip()
+    if _EXCEL_DATE_PATTERN.match(text):
+        try:
+            timestamp = _excel_numeric_to_timestamp(float(text))
+        except (OutOfBoundsDatetime, ValueError):
+            failed_strings.append(value)
+            return None
+        return _timestamp_to_output(timestamp, out_class, tz)
+
+    if _looks_like_time(text):
+        if out_class == "date":
+            failed_strings.append(value)
+            return None
+        try:
+            seconds = excel_time_to_numeric(text, round_seconds=True)
+        except ValueError:
+            failed_strings.append(value)
+            return None
+        timestamp = pd.Timestamp(_EXCEL_EPOCH + timedelta(seconds=seconds))
+        return _timestamp_to_output(timestamp, out_class, tz)
+
+    try:
+        converted = character_fun(text)
+    except Exception:
+        failed_strings.append(value)
+        return None
+
+    if pd.isna(converted):
+        failed_strings.append(value)
+        return None
+
+    coerced = _coerce_character_result(converted, out_class)
+    if out_class == "date":
+        return coerced
+    return _timestamp_to_output(coerced, out_class, tz)
+
+
+def _convert_value(
+    value: Any,
+    out_class: str,
+    tz: str | None,
+    character_fun: Callable[[str], Any],
+    failed_strings: List[str],
+) -> Any:
+    if pd.isna(value):
+        return None
+
+    if isinstance(value, (pd.Timestamp, datetime)):
+        return _timestamp_to_output(pd.Timestamp(value), out_class, tz)
+
+    if isinstance(value, date) and not isinstance(value, datetime):
+        if out_class == "date":
+            return value
+        timestamp = pd.Timestamp(datetime.combine(value, time.min))
+        return _timestamp_to_output(timestamp, out_class, tz)
+
+    if isinstance(value, time):
+        if out_class == "date":
+            raise TypeError("time values cannot be converted to dates.")
+        timestamp = pd.Timestamp(datetime.combine(_EXCEL_EPOCH.date(), value))
+        return _timestamp_to_output(timestamp, out_class, tz)
+
+    if isinstance(value, numbers.Number) and not isinstance(value, bool):
+        timestamp = _excel_numeric_to_timestamp(float(value))
+        return _timestamp_to_output(timestamp, out_class, tz)
+
+    if isinstance(value, str):
+        return _convert_string_value(
+            value,
+            out_class=out_class,
+            tz=tz,
+            character_fun=character_fun,
+            failed_strings=failed_strings,
+        )
+
+    raise TypeError(f"Unsupported value type: {type(value).__name__}")
+
+
+def _convert_to_date_or_datetime(
+    x: Any,
+    out_class: str,
+    tz: str | None,
+    character_fun: Callable[[str], Any] | None,
+    string_conversion_failure: str,
+) -> Any:
+    if string_conversion_failure not in {"error", "warning"}:
+        raise ValueError(
+            "string_conversion_failure must be one of 'error' or 'warning'."
+        )
+
+    if character_fun is None:
+        character_fun = lambda value: pd.to_datetime(value, errors="coerce")
+
+    values, finalize = _prepare_input(x)
+    failed_strings: List[str] = []
+    results: List[Any] = []
+
+    for value in values:
+        results.append(
+            _convert_value(
+                value,
+                out_class=out_class,
+                tz=tz,
+                character_fun=character_fun,
+                failed_strings=failed_strings,
+            )
+        )
+
+    if failed_strings:
+        message = _format_failed_strings(failed_strings, out_class)
+        if string_conversion_failure == "error":
+            raise ValueError(message)
+        warnings.warn(message, UserWarning, stacklevel=find_stack_level())
+
+    return finalize(results)
+
+
+def convert_to_date(
+    x: Any,
+    character_fun: Callable[[str], Any] | None = None,
+    string_conversion_failure: str = "error",
+) -> Any:
+    """Parse mixed date formats into Python ``date`` objects.
+
+    Examples:
+        >>> import janitor as jn
+        >>> dates = ["2009-07-06", "40000", "40000.1", None]
+        >>> jn.convert_to_date(dates)  # doctest: +ELLIPSIS
+        [datetime.date(2009, 7, 6), ..., None]
+
+    Args:
+        x: A scalar or list-like of mixed date values.
+        character_fun: Optional function used to parse non-numeric strings.
+        string_conversion_failure: Whether to raise an error or warn when
+            string values fail to parse.
+
+    Returns:
+        Parsed dates as ``datetime.date`` objects, with ``None`` for missing.
+    """
+    return _convert_to_date_or_datetime(
+        x,
+        out_class="date",
+        tz=None,
+        character_fun=character_fun,
+        string_conversion_failure=string_conversion_failure,
+    )
+
+
+def convert_to_datetime(
+    x: Any,
+    tz: str | None = "UTC",
+    character_fun: Callable[[str], Any] | None = None,
+    string_conversion_failure: str = "error",
+) -> Any:
+    """Parse mixed datetime formats into Python ``datetime`` objects.
+
+    Time-only values are anchored to Excel's origin (1899-12-30).
+
+    Examples:
+        >>> import janitor as jn
+        >>> datetimes = ["2009-07-06", "40000.1", "40000", None]
+        >>> jn.convert_to_datetime(datetimes, tz=None)  # doctest: +ELLIPSIS
+        [datetime.datetime(2009, 7, 6, 0, 0), ..., None]
+
+    Args:
+        x: A scalar or list-like of mixed datetime values.
+        tz: Timezone to assign to naive datetime values. Use ``None`` to
+            return naive datetimes.
+        character_fun: Optional function used to parse non-numeric strings.
+        string_conversion_failure: Whether to raise an error or warn when
+            string values fail to parse.
+
+    Returns:
+        Parsed datetimes as ``datetime.datetime`` objects, with ``None`` for missing.
+    """
+    if tz is not None and not isinstance(tz, str):
+        raise TypeError("tz should be a string or None.")
+
+    return _convert_to_date_or_datetime(
+        x,
+        out_class="datetime",
+        tz=tz,
+        character_fun=character_fun,
+        string_conversion_failure=string_conversion_failure,
+    )
+
+
+def sas_numeric_to_date(
+    date_num: Any = None,
+    datetime_num: Any = None,
+    time_num: Any = None,
+    tz: str = "UTC",
+) -> Any:
+    """Convert SAS date, time, or datetime numbers to Python objects.
+
+    Examples:
+        >>> import janitor as jn
+        >>> jn.sas_numeric_to_date(date_num=15639)
+        datetime.date(2002, 10, 26)
+        >>> jn.sas_numeric_to_date(datetime_num=1217083532, tz="UTC")
+        datetime.datetime(1998, 7, 26, 14, 45, 32, tzinfo=...)
+        >>> jn.sas_numeric_to_date(time_num=3600)
+        datetime.time(1, 0)
+
+    Args:
+        date_num: Days since 1960-01-01.
+        datetime_num: Seconds since 1960-01-01.
+        time_num: Seconds since midnight.
+        tz: Timezone for datetime outputs.
+
+    Returns:
+        Date, datetime, or time objects corresponding to SAS numeric values.
+
+    Raises:
+        ValueError: If invalid argument combinations are provided.
+        TypeError: If inputs are non-numeric.
+    """
+    has_date = date_num is not None
+    has_datetime = datetime_num is not None
+    has_time = time_num is not None
+
+    if not isinstance(tz, str):
+        raise TypeError("tz should be a string.")
+    if tz != "UTC":
+        warnings.warn(
+            "SAS may not properly store timezones other than UTC. "
+            "Consider confirming the accuracy of the resulting data.",
+            UserWarning,
+            stacklevel=find_stack_level(),
+        )
+
+    if has_date and has_datetime:
+        raise ValueError("Must not give both `date_num` and `datetime_num`")
+    if has_time and has_datetime:
+        raise ValueError("Must not give both `time_num` and `datetime_num`")
+    if not (has_date or has_datetime or has_time):
+        raise ValueError(
+            "Must give one of `date_num`, `datetime_num`, `time_num`, "
+            "or `date_num` and `time_num`."
+        )
+
+    def _as_series(values: Any, name: str) -> pd.Series:
+        if isinstance(values, pd.Series):
+            return values.copy()
+        if is_scalar(values):
+            return pd.Series([values], name=name)
+        if is_list_like(values):
+            return pd.Series(list(values), name=name)
+        return pd.Series([values], name=name)
+
+    def _numeric_series(values: Any, name: str) -> pd.Series:
+        series = _as_series(values, name)
+        if series.dropna().apply(lambda val: isinstance(val, bool)).any():
+            raise TypeError(f"`{name}` must be numeric.")
+        try:
+            return pd.to_numeric(series, errors="raise")
+        except (TypeError, ValueError) as exc:
+            raise TypeError(f"`{name}` must be numeric.") from exc
+
+    base_index = None
+    if has_date and isinstance(date_num, pd.Series):
+        base_index = date_num.index
+    if base_index is None and has_datetime and isinstance(datetime_num, pd.Series):
+        base_index = datetime_num.index
+    if base_index is None and has_time and isinstance(time_num, pd.Series):
+        base_index = time_num.index
+
+    if has_date and has_time:
+        date_series = _numeric_series(date_num, "date_num")
+        time_series = _numeric_series(time_num, "time_num")
+
+        if len(date_series) != len(time_series):
+            if len(date_series) == 1:
+                time_series = time_series.reindex(
+                    date_series.index, fill_value=time_series.iloc[0]
+                )
+            elif len(time_series) == 1:
+                date_series = date_series.reindex(
+                    time_series.index, fill_value=date_series.iloc[0]
+                )
+            else:
+                raise ValueError(
+                    "`date_num` and `time_num` must be the same length."
+                )
+
+        if not (date_series.isna() == time_series.isna()).all():
+            raise ValueError(
+                "The same values are not NA for both `date_num` and `time_num`"
+            )
+
+        if not ((time_series.isna()) | (time_series >= 0)).all():
+            raise ValueError("`time_num` must be non-negative")
+        if not ((time_series.isna()) | (time_series <= 86400)).all():
+            raise ValueError(
+                "`time_num` must be within the number of seconds in a day (<= 86400)"
+            )
+
+        datetime_series = date_series * 86400 + time_series
+        timestamps = pd.to_datetime(
+            datetime_series, unit="s", origin="1960-01-01"
+        )
+        results = [
+            None
+            if pd.isna(ts)
+            else _timestamp_to_output(pd.Timestamp(ts), "datetime", tz)
+            for ts in timestamps
+        ]
+    elif has_datetime:
+        datetime_series = _numeric_series(datetime_num, "datetime_num")
+        timestamps = pd.to_datetime(
+            datetime_series, unit="s", origin="1960-01-01"
+        )
+        results = [
+            None
+            if pd.isna(ts)
+            else _timestamp_to_output(pd.Timestamp(ts), "datetime", tz)
+            for ts in timestamps
+        ]
+    elif has_date:
+        date_series = _numeric_series(date_num, "date_num")
+        timestamps = pd.to_datetime(date_series, unit="D", origin="1960-01-01")
+        results = [
+            None if pd.isna(ts) else pd.Timestamp(ts).date()
+            for ts in timestamps
+        ]
+    else:
+        time_series = _numeric_series(time_num, "time_num")
+        if not ((time_series.isna()) | (time_series >= 0)).all():
+            raise ValueError("`time_num` must be non-negative")
+        if not ((time_series.isna()) | (time_series <= 86400)).all():
+            raise ValueError(
+                "`time_num` must be within the number of seconds in a day (<= 86400)"
+            )
+        results = []
+        for seconds in time_series:
+            if pd.isna(seconds):
+                results.append(None)
+                continue
+            seconds = float(seconds)
+            if seconds == 86400:
+                seconds = 0
+            hours = int(seconds // 3600)
+            minutes = int((seconds % 3600) // 60)
+            remaining = seconds % 60
+            whole_seconds = int(remaining)
+            microseconds = int(round((remaining - whole_seconds) * 1_000_000))
+            results.append(
+                time(
+                    hour=hours,
+                    minute=minutes,
+                    second=whole_seconds,
+                    microsecond=microseconds,
+                )
+            )
+
+    if base_index is not None:
+        return pd.Series(results, index=base_index)
+    if len(results) == 1:
+        return results[0]
+    return results
 
 
 @pf.register_dataframe_method

--- a/janitor/functions/convert_date.py
+++ b/janitor/functions/convert_date.py
@@ -545,7 +545,7 @@ def sas_numeric_to_date(
         >>> import janitor as jn
         >>> jn.sas_numeric_to_date(date_num=15639)
         datetime.date(2002, 10, 26)
-        >>> jn.sas_numeric_to_date(datetime_num=1217083532, tz="UTC")
+        >>> jn.sas_numeric_to_date(datetime_num=1217083532, tz="UTC")  # doctest: +ELLIPSIS
         datetime.datetime(1998, 7, 26, 14, 45, 32, tzinfo=...)
         >>> jn.sas_numeric_to_date(time_num=3600)
         datetime.time(1, 0)

--- a/tests/functions/test_convert_to_date.py
+++ b/tests/functions/test_convert_to_date.py
@@ -1,0 +1,106 @@
+import datetime as dt
+
+import janitor as jn
+import pytest
+
+
+@pytest.mark.functions
+def test_convert_to_date_list():
+    dates = ["2009-07-06", "40000", "40000.1", None]
+
+    result = jn.convert_to_date(dates)
+
+    expected = [
+        dt.date(2009, 7, 6),
+        dt.date(2009, 7, 6),
+        dt.date(2009, 7, 6),
+        None,
+    ]
+    assert result == expected
+
+
+@pytest.mark.functions
+def test_convert_to_date_string_failure_error():
+    with pytest.raises(ValueError, match="Not all character strings converted"):
+        jn.convert_to_date(["not-a-date"])
+
+
+@pytest.mark.functions
+def test_convert_to_date_string_failure_warning():
+    with pytest.warns(UserWarning, match="Not all character strings converted"):
+        result = jn.convert_to_date(
+            ["not-a-date"], string_conversion_failure="warning"
+        )
+    assert result == [None]
+
+
+@pytest.mark.functions
+def test_convert_to_datetime_list():
+    datetimes = ["2009-07-06", "40000.1", "40000", None]
+
+    result = jn.convert_to_datetime(datetimes, tz=None)
+
+    expected = [
+        dt.datetime(2009, 7, 6, 0, 0),
+        dt.datetime(2009, 7, 6, 2, 24),
+        dt.datetime(2009, 7, 6, 0, 0),
+        None,
+    ]
+    assert result == expected
+
+
+@pytest.mark.functions
+def test_convert_to_datetime_time_strings():
+    result = jn.convert_to_datetime(["12:30 PM", "14:30:15", "0.5"], tz=None)
+
+    expected = [
+        dt.datetime(1899, 12, 30, 12, 30),
+        dt.datetime(1899, 12, 30, 14, 30, 15),
+        dt.datetime(1899, 12, 30, 12, 0),
+    ]
+    assert result == expected
+
+
+@pytest.mark.functions
+def test_convert_to_datetime_timezone():
+    result = jn.convert_to_datetime(["2009-07-06"], tz="UTC")
+    assert result[0].tzinfo is not None
+    assert result[0].utcoffset() == dt.timedelta(0)
+
+
+@pytest.mark.functions
+def test_excel_time_to_numeric_examples():
+    assert jn.excel_time_to_numeric("0.5") == 43200
+    assert jn.excel_time_to_numeric("12:30 PM") == 45000
+    assert jn.excel_time_to_numeric("14:30:15") == 52215
+
+
+@pytest.mark.functions
+def test_excel_time_to_numeric_invalid_string():
+    with pytest.raises(ValueError, match="did not match an interpretable"):
+        jn.excel_time_to_numeric("not a time")
+
+
+@pytest.mark.functions
+def test_sas_numeric_to_date_examples():
+    assert jn.sas_numeric_to_date(date_num=15639) == dt.date(2002, 10, 26)
+
+    datetime_value = jn.sas_numeric_to_date(datetime_num=1217083532, tz="UTC")
+    assert datetime_value.utcoffset() == dt.timedelta(0)
+    assert datetime_value.replace(tzinfo=None) == dt.datetime(
+        1998, 7, 26, 14, 45, 32
+    )
+
+    assert jn.sas_numeric_to_date(time_num=3600) == dt.time(1, 0, 0)
+
+    combined = jn.sas_numeric_to_date(date_num=15639, time_num=3600, tz="UTC")
+    assert combined.replace(tzinfo=None) == dt.datetime(2002, 10, 26, 1, 0, 0)
+
+
+@pytest.mark.functions
+def test_sas_numeric_to_date_invalid_combinations():
+    with pytest.raises(ValueError, match="Must not give both"):
+        jn.sas_numeric_to_date(date_num=1, datetime_num=2)
+
+    with pytest.raises(ValueError, match="same values are not NA"):
+        jn.sas_numeric_to_date(date_num=[1, None], time_num=[None, 1])


### PR DESCRIPTION
[ENH] Implement mixed-format date/datetime parsing and SAS/Excel converters

## PR Description

Please describe the changes proposed in the pull request:

- Implements new functions `convert_to_date` and `convert_to_datetime` for parsing mixed date/datetime formats into Python `date` and `datetime` objects, respectively.
- Introduces `excel_time_to_numeric` to convert Excel time representations (numeric or string) to numeric seconds.
- Adds `sas_numeric_to_date` for converting SAS numeric date, time, or datetime values to corresponding Python objects.
- Includes comprehensive tests for all new functions.

**This PR resolves #1559.**

## PR Checklist

<!-- This checklist exists for newcomers who are not yet familiar with our requirements. If you are experienced with
the project, please feel free to delete this section. -->

Please ensure that you have done the following:

1. [ ] PR in from a fork off your branch. Do not PR from `<your_username>`:`dev`, but rather from `<your_username>`:`<feature-branch_name>`.
<!-- Doing this helps us keep the commit history much cleaner than it would otherwise be. -->
2. [ ] If you're not on the contributors list, add yourself to `AUTHORS.md`.
<!-- We'd like to acknowledge your contributions! -->
3. [ ] Add a line to `CHANGELOG.md` under the latest version header (i.e. the one that is "on deck") describing the contribution.
    - Do use some discretion here; if there are multiple PRs that are related, keep them in a single line.

## Automatic checks

There will be automatic checks run on the PR. These include:

- Building a preview of the docs on Netlify
- Automatically linting the code
- Making sure the code is documented
- Making sure that all tests are passed
- Making sure that code coverage doesn't go down.

## Relevant Reviewers

Please tag maintainers to review.

- @ericmjl

---
<p><a href="https://cursor.com/background-agent?bcId=bc-7bcdd7c7-d00f-4118-8310-69662b0f7aa2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7bcdd7c7-d00f-4118-8310-69662b0f7aa2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

