### PR TITLE
Groupby topk adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 -   [ENH] Add `include_join_positions` parameter to `conditional_join`; added limited support for join aggregations via the `join_agg` function. - Issue #1497 @samukweku
 -   [ENH] Added `rle_id` function for run-length encoding IDs - Issue #1435 @emmanuel-ferdman
+-   [ENH] Add `scale_mad` for robust median/MAD scaling. - PR #1530 @ShachiMistry
 
 ## [v0.32.3] - 2025-12-11
 

--- a/janitor/functions/__init__.py
+++ b/janitor/functions/__init__.py
@@ -81,6 +81,7 @@ from .reorder_columns import reorder_columns
 from .rle_id import rle_id
 from .round_to_fraction import round_to_fraction
 from .row_to_names import row_to_names
+from .scale_mad import scale_mad
 from .select import (
     DropLabel,
     get_columns,
@@ -175,6 +176,7 @@ __all__ = [
     "rle_id",
     "round_to_fraction",
     "row_to_names",
+    "scale_mad",
     "select_columns",
     "select_rows",
     "select",

--- a/janitor/functions/scale_mad.py
+++ b/janitor/functions/scale_mad.py
@@ -1,0 +1,161 @@
+"""Implementation of the `scale_mad` function."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import Hashable, Literal
+
+import pandas as pd
+import pandas_flavor as pf
+from pandas.api.types import is_numeric_dtype
+
+from janitor.utils import check, check_column
+
+ZeroMadStrategy = Literal["skip", "center", "raise", "one"]
+
+MAD_SCALE_FACTOR = 1.4826
+ZERO_MAD_STRATEGIES: set[str] = {"skip", "center", "raise", "one"}
+
+
+def _median_absolute_deviation(series: pd.Series) -> float:
+    """Return the median absolute deviation for a pandas Series."""
+    median = series.median(skipna=True)
+    return series.sub(median).abs().median(skipna=True)
+
+
+def _normalize_columns(
+    df: pd.DataFrame,
+    columns: Iterable[Hashable]
+    | Callable[[pd.DataFrame], Iterable[Hashable]]
+    | None,
+) -> list[Hashable]:
+    """Normalize columns input into a list of column labels."""
+    if columns is None:
+        return list(df.select_dtypes(include=["number"]).columns)
+
+    if callable(columns):
+        columns = columns(df)
+        if columns is None:
+            raise TypeError("`columns` callable must return column names.")
+
+    if isinstance(columns, pd.Index):
+        columns = list(columns)
+    elif isinstance(columns, tuple) and columns in df.columns:
+        columns = [columns]
+    elif isinstance(columns, str) or not isinstance(columns, Iterable):
+        columns = [columns]
+    else:
+        columns = list(columns)
+
+    return list(dict.fromkeys(columns))
+
+
+@pf.register_dataframe_method
+def scale_mad(
+    df: pd.DataFrame,
+    columns: Iterable[Hashable]
+    | Callable[[pd.DataFrame], Iterable[Hashable]]
+    | None = None,
+    clip: float | None = None,
+    zero_mad: ZeroMadStrategy = "skip",
+    suffix: str | None = None,
+) -> pd.DataFrame:
+    """Robustly scale numeric columns using median and MAD.
+
+    The median absolute deviation (MAD) is scaled by 1.4826 to make it
+    comparable to the standard deviation under a normal distribution.
+
+    This method does not mutate the original DataFrame.
+
+    Examples:
+        >>> import pandas as pd
+        >>> import janitor
+        >>> df = pd.DataFrame({"x": [1, 2, 3, 4], "y": [10, 10, 10, 10]})
+        >>> df.scale_mad().round(3)
+               x     y
+        0 -1.012  10.0
+        1 -0.337  10.0
+        2  0.337  10.0
+        3  1.012  10.0
+
+        Create a new column and clip the results.
+
+        >>> df.scale_mad(columns=["x"], suffix="_mad", clip=3).round(3)
+           x   y  x_mad
+        0  1  10 -1.012
+        1  2  10 -0.337
+        2  3  10  0.337
+        3  4  10  1.012
+
+    Args:
+        df: A pandas DataFrame.
+        columns: Columns to scale. Can be an iterable of column names or a
+            callable that takes the DataFrame and returns column names.
+            Defaults to all numeric columns.
+        clip: Optional symmetric clipping threshold. If provided, values are
+            clipped to ``[-clip, clip]``.
+        zero_mad: Strategy for columns with zero (or missing) MAD.
+            "skip" leaves the column unchanged, "center" subtracts the median,
+            and "raise" raises a ValueError. "one" is accepted as an alias for
+            "center".
+        suffix: Optional suffix to append to scaled column names. If provided,
+            new columns are created; otherwise, original columns are
+            overwritten.
+
+    Raises:
+        TypeError: If `columns` or `clip` has an invalid type.
+        ValueError: If `clip` is negative or `zero_mad` is invalid.
+        ValueError: If `zero_mad` is "raise" and MAD is zero.
+
+    Returns:
+        A pandas DataFrame with scaled values.
+    """
+    check("df", df, [pd.DataFrame])
+
+    if clip is not None:
+        check("clip", clip, [int, float])
+        if clip < 0:
+            raise ValueError("`clip` must be non-negative.")
+
+    check("zero_mad", zero_mad, [str])
+    zero_mad = zero_mad.lower()
+    if zero_mad not in ZERO_MAD_STRATEGIES:
+        raise ValueError(
+            "zero_mad must be one of 'skip', 'center', 'one', or 'raise'."
+        )
+    if zero_mad == "one":
+        zero_mad = "center"
+
+    if suffix is not None:
+        check("suffix", suffix, [str])
+        if suffix == "":
+            suffix = None
+
+    selected_columns = _normalize_columns(df, columns)
+    if selected_columns:
+        check_column(df, selected_columns)
+
+    result = df.copy()
+    for col in selected_columns:
+        series = result[col]
+        if not is_numeric_dtype(series):
+            continue
+        median = series.median(skipna=True)
+        mad = _median_absolute_deviation(series)
+        if mad == 0 or pd.isna(mad):
+            if zero_mad == "skip":
+                scaled = series
+            elif zero_mad == "center":
+                scaled = series - median
+            else:
+                raise ValueError(f"MAD is zero for column '{col}'.")
+        else:
+            scaled = (series - median) / (mad * MAD_SCALE_FACTOR)
+        if clip is not None:
+            scaled = scaled.clip(lower=-clip, upper=clip)
+        target = f"{col}{suffix}" if suffix is not None else col
+        if suffix is not None:
+            check_column(result, target, present=False)
+        result[target] = scaled
+
+    return result

--- a/mkdocs/api/functions.md
+++ b/mkdocs/api/functions.md
@@ -54,6 +54,7 @@
         - rle_id
         - round_to_fraction
         - row_to_names
+        - scale_mad
         - select
         - shuffle
         - sort_column_value_order

--- a/tests/functions/test_scale_mad.py
+++ b/tests/functions/test_scale_mad.py
@@ -1,0 +1,67 @@
+import numpy as np
+import pandas as pd
+import pytest
+from pandas.testing import assert_series_equal
+
+import janitor  # noqa: F401
+
+
+@pytest.mark.functions
+def test_scale_mad_scales_numeric_columns_default():
+    df = pd.DataFrame(
+        {
+            "x": [1, 2, 3, 4],
+            "y": [10, 10, 10, 10],
+            "label": ["a", "b", "c", "d"],
+        }
+    )
+    original = df.copy()
+
+    result = df.scale_mad()
+
+    assert np.isclose(result["x"].median(), 0.0)
+    assert_series_equal(result["y"], df["y"])
+    assert_series_equal(result["label"], df["label"])
+    assert result is not df
+    assert df.equals(original)
+
+
+@pytest.mark.functions
+def test_scale_mad_zero_mad_center():
+    df = pd.DataFrame({"y": [10, 10, 10, 10]})
+
+    result = df.scale_mad(zero_mad="center")
+
+    assert (result["y"] == 0).all()
+
+
+@pytest.mark.functions
+def test_scale_mad_suffix_and_clip():
+    df = pd.DataFrame({"x": [1, 2, 3, 100]})
+
+    result = df.scale_mad(columns=["x"], clip=3, suffix="_mad")
+
+    assert "x_mad" in result.columns
+    assert "x" in result.columns
+    assert (result["x_mad"].abs() <= 3).all()
+
+
+@pytest.mark.functions
+def test_scale_mad_callable_column_selector():
+    df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+
+    result = df.scale_mad(
+        columns=lambda d: d.select_dtypes(include=["number"]).columns,
+        suffix="_mad",
+    )
+
+    assert "a_mad" in result.columns
+    assert "b" in result.columns
+
+
+@pytest.mark.functions
+def test_scale_mad_zero_mad_raise():
+    df = pd.DataFrame({"y": [1, 1, 1]})
+
+    with pytest.raises(ValueError, match="MAD is zero"):
+        df.scale_mad(columns=["y"], zero_mad="raise")


### PR DESCRIPTION
<!-- Thank you for your PR!

BEFORE YOU CONTINUE! Please add the appropriate three-letter abbreviation to your title.

The abbreviations can be:
- [DOC]: Documentation fixes.
- [ENH]: Code contributions and new features.
- [TST]: Test-related contributions.
- [INF]: Infrastructure-related contributions.

Also, do not forget to tag the relevant issue here as well.

Finally, as commits come in, don't forget to regularly rebase!
-->

## [ENH] Add `scale_mad` for robust median/MAD scaling

## PR Description

Please describe the changes proposed in the pull request:

- Implements a new `scale_mad` function for robust scaling of numeric columns using the median and Median Absolute Deviation (MAD).
- Includes options for handling zero MAD values (`skip`, `center`, `raise`), symmetric clipping of scaled values, and adding suffixes to new columns.
- Integrates `scale_mad` into the `janitor.functions` API, adds unit tests, and updates documentation.

<!-- Doing so provides maintainers with context on what the PR is, and can help us more effectively review your PR. -->

<!-- Please also identify below which issue that has been raised that you are going to close. -->

**This PR resolves #1530.**

<!-- As you go down the PR template, please feel free to delete sections that are irrelevant. -->

## PR Checklist

<!-- This checklist exists for newcomers who are not yet familiar with our requirements. If you are experienced with
the project, please feel free to delete this section. -->

Please ensure that you have done the following:

1. [ ] PR in from a fork off your branch. Do not PR from `<your_username>`:`dev`, but rather from `<your_username>`:`<feature-branch_name>`.
<!-- Doing this helps us keep the commit history much cleaner than it would otherwise be. -->
2. [ ] If you're not on the contributors list, add yourself to `AUTHORS.md`.
<!-- We'd like to acknowledge your contributions! -->
3. [ ] Add a line to `CHANGELOG.md` under the latest version header (i.e. the one that is "on deck") describing the contribution.
    - Do use some discretion here; if there are multiple PRs that are related, keep them in a single line.

## Automatic checks

There will be automatic checks run on the PR. These include:

- Building a preview of the docs on Netlify
- Automatically linting the code
- Making sure the code is documented
- Making sure that all tests are passed
- Making sure that code coverage doesn't go down.

## Relevant Reviewers

<!-- Finally, please tag relevant maintainers to review. -->

Please tag maintainers to review.

- @ericmjl

---
<p><a href="https://cursor.com/background-agent?bcId=bc-88831081-26bd-46a9-86c1-29e8f6623811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-88831081-26bd-46a9-86c1-29e8f6623811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

