### PR TITLE
fix(ci): use uv --short in auto-release to fix version_number parsing

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -101,11 +101,11 @@ jobs:
 
       - name: Dry run uv version bump
         if: steps.check_release.outputs.already_released == 'false'
-        run: uv version --bump ${{ env.VERSION_NAME }} --dry-run
+        run: uv version --bump ${{ env.VERSION_NAME }} --dry-run --short
 
       - name: Store new version number
         if: steps.check_release.outputs.already_released == 'false'
-        run: echo "version_number=$(uv version --bump ${{ env.VERSION_NAME }} --dry-run | tr -d ' \n')" >> $GITHUB_ENV
+        run: echo "version_number=$(uv version --bump ${{ env.VERSION_NAME }} --dry-run --short | tr -d ' \n')" >> $GITHUB_ENV
 
       - name: Display new version number
         if: steps.check_release.outputs.already_released == 'false'


### PR DESCRIPTION
## Problem
Auto-release was failing with:
```
ENOENT: no such file or directory, open 'docs/releases/vpyjanitor0.32.12=>0.32.13.md'
```

`uv version --bump ... --dry-run` now prints a human-readable line like `pyjanitor 0.32.12 => 0.32.13` instead of just the new version. The workflow captured that entire string (after `tr -d ' \n'`) as `version_number`, producing invalid tags and release note paths.

## Fix
Add `--short` to both `uv version --bump ... --dry-run` invocations in `.github/workflows/auto-release.yml`:
- **Dry run uv version bump** step: `--dry-run` → `--dry-run --short`
- **Store new version number** step: same

With `--short`, uv outputs only the new version (e.g. `0.32.14`), so `version_number`, tags, and `docs/releases/v${version}.md` are correct.

Ref: failing run [Auto-release #80](https://github.com/pyjanitor-devs/pyjanitor/actions/runs/21781877589), passing run [Auto-release #70](https://github.com/pyjanitor-devs/pyjanitor/actions/runs/21250959513).

Made with [Cursor](https://cursor.com)