### PR TITLE
deprecate mutate

### DIFF
--- a/janitor/functions/mutate.py
+++ b/janitor/functions/mutate.py
@@ -26,7 +26,7 @@ def ungroup(
 
     !!! info "New in version 0.32.0"
 
-    !!! warning "This function is deprecated. Use `jn.get_columns` instead."
+    !!!warning "This function is deprecated. Use `jn.get_columns` instead."
 
     Ungroups a GroupBy object into a DataFrame.
 
@@ -86,7 +86,7 @@ def mutate(
 
     !!! info "New in version 0.31.0"
 
-    !!! warning "This function is deprecated. Use `pd.DataFrame.assign` instead."
+    !!!warning "This function is deprecated. Use `pd.DataFrame.assign` instead."
 
     !!!note
 

--- a/janitor/functions/mutate.py
+++ b/janitor/functions/mutate.py
@@ -26,6 +26,8 @@ def ungroup(
 
     !!! info "New in version 0.32.0"
 
+    !!! warning "This function is deprecated. Use `jn.get_columns` instead."
+
     Ungroups a GroupBy object into a DataFrame.
 
     Examples:
@@ -83,6 +85,8 @@ def mutate(
     """
 
     !!! info "New in version 0.31.0"
+
+    !!! warning "This function is deprecated. Use `pd.DataFrame.assign` instead."
 
     !!!note
 

--- a/janitor/functions/mutate.py
+++ b/janitor/functions/mutate.py
@@ -84,9 +84,9 @@ def mutate(
 ) -> pd.DataFrame | DataFrameGroupBy:
     """
 
-    !!! info "New in version 0.31.0"
-
     !!!warning "This function is deprecated. Use `pd.DataFrame.assign` instead."
+    
+    !!! info "New in version 0.31.0"
 
     !!!note
 

--- a/janitor/functions/mutate.py
+++ b/janitor/functions/mutate.py
@@ -70,6 +70,12 @@ def ungroup(
 
 @pf.register_dataframe_groupby_method
 @pf.register_dataframe_method
+@refactored_function(
+    message=(
+        "This function is deprecated. "
+        "Please use `pd.DataFrame.assign` instead."
+    )
+)
 def mutate(
     df: pd.DataFrame | DataFrameGroupBy,
     *args: tuple[dict | tuple],

--- a/janitor/functions/mutate.py
+++ b/janitor/functions/mutate.py
@@ -24,9 +24,9 @@ def ungroup(
 ) -> pd.DataFrame:
     """
 
-    !!! info "New in version 0.32.0"
-
     !!!warning "This function is deprecated. Use `jn.get_columns` instead."
+    
+    !!! info "New in version 0.32.0"
 
     Ungroups a GroupBy object into a DataFrame.
 
@@ -85,7 +85,7 @@ def mutate(
     """
 
     !!!warning "This function is deprecated. Use `pd.DataFrame.assign` instead."
-    
+
     !!! info "New in version 0.31.0"
 
     !!!note


### PR DESCRIPTION
## PR Description

Please describe the changes proposed in the pull request:

- deprecate `mutate`
- `pd.col` in combination with assign makes `mutate` unnecessary.


**This PR resolves #1045 **

Examples: 

with `mutate`: 

```py
In [3]: df.mutate({"col4": ("col1", np.log10), "col1": np.log10})
Out[3]:
       col1  col2  col3      col4
0  0.698970     3    10  0.698970
1  1.000000     6   100  1.000000
2  1.176091     9  1000  1.176091
```

with the new `pd.col` :
```py
In [6]: df.assign(col4=pd.col('col1').transform(np.log10), col1=pd.col('col1').transform(np.log10))
Out[6]:
       col1  col2  col3      col4
0  0.698970     3    10  0.698970
1  1.000000     6   100  1.000000
2  1.176091     9  1000  1.176091
```

Please tag maintainers to review.

- @ericmjl
