### PR TITLE
[DOC] Incorrect attribution (previous account name)

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -70,10 +70,10 @@
       ]
     },
     {
-      "login": "BaritoneBeard",
-      "name": "BaritoneBeard",
-      "avatar_url": "https://github.com/identicons/BaritoneBeard.png",
-      "profile": "https://github.com/BaritoneBeard",
+      "login": "Nalmeder",
+      "name": "Nalmeder",
+      "avatar_url": "https://github.com/identicons/Nalmeder.png",
+      "profile": "https://github.com/Nalmeder",
       "contributions": [
         "bug",
         "question"


### PR DESCRIPTION



## PR Description

Contributions attributed to deprecated account name.

Also, I believe I contributed more than a bug fix, but I assume the username change messed up the history there. One thing at a time, though.

Would you like me to add this under changelog.md or is this small enough it shouldn't matter?

- @ericmjl
