### PR TITLE
[INF] Declare pandas>=3 as a runtime dependency (#1597)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+-   [INF] Declare `pandas>=3.0.0` as a runtime dependency in `pyproject.toml` so `pip install pyjanitor` no longer leaves environments with an unsupported pandas. - Issue #1597 @jbbqqf
 -   [ENH] Add `include_join_positions` parameter to `conditional_join`; added limited support for join aggregations via the `join_agg` function. - Issue #1497 @samukweku
 -   [ENH] Added `rle_id` function for run-length encoding IDs - Issue #1435 @emmanuel-ferdman
 -   [ENH] Add `scale_mad` for robust median/MAD scaling. - PR #1530 @ShachiMistry

--- a/pixi.lock
+++ b/pixi.lock
@@ -22422,6 +22422,7 @@ packages:
   version: 0.32.23
   sha256: 3e56a26943d487a5060047b2e99990cb045fd54dfc232227288af00ad1b5690b
   requires_dist:
+  - pandas>=3.0.0
   - natsort>=8.4.0,<9
   - pandas-flavor>=0.8.1,<0.9
   - multipledispatch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,12 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
+    # pandas >=3 is a hard runtime requirement: pyjanitor uses APIs that
+    # only exist in pandas 3 (e.g. ``pd.col``), so a fresh
+    # ``pip install pyjanitor`` against a pandas-2.x environment must
+    # upgrade pandas rather than silently leaving an unusable install.
+    # See issue #1597.
+    "pandas>=3.0.0",
     "natsort>=8.4.0,<9",
     "pandas-flavor>=0.8.1,<0.9",
     "multipledispatch",

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,69 @@
+"""Smoke tests for packaging metadata.
+
+These tests guard the contract that ``pip install pyjanitor`` brings in a
+working set of runtime dependencies. They catch regressions like #1597,
+where pyjanitor relied on pandas APIs (e.g. ``pd.col``) but the
+``pyproject.toml`` did not declare a pandas dependency at all, allowing
+``pip`` to leave the resolved environment with an unsupported pandas (or
+none).
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import requires
+
+from packaging.requirements import Requirement
+
+
+def _runtime_requirements() -> dict[str, Requirement]:
+    """Return the parsed runtime requirements of the installed pyjanitor.
+
+    We filter out PEP 508 ``extra ==`` markers so optional-dependency groups
+    (``dev``, ``docs``, ``biology`` …) don't pollute the runtime view.
+    """
+    raw = requires("pyjanitor") or []
+    runtime: dict[str, Requirement] = {}
+    for line in raw:
+        req = Requirement(line)
+        if req.marker is not None and "extra" in str(req.marker):
+            continue
+        runtime[req.name.lower()] = req
+    return runtime
+
+
+def test_pandas_is_a_runtime_dependency():
+    """pandas must be listed as a runtime dep, not just an optional/dev one.
+
+    Without this, ``pip install pyjanitor`` would silently leave the user's
+    environment with no pandas at all (or with an old pandas the package
+    cannot run against). Issue #1597.
+    """
+    reqs = _runtime_requirements()
+    assert "pandas" in reqs, (
+        "pandas is missing from pyjanitor's runtime dependencies; "
+        "see issue #1597 for context."
+    )
+
+
+def test_pandas_runtime_dependency_pins_to_pandas_3():
+    """The declared pandas range must include >=3.0 (which the code requires).
+
+    pyjanitor's modern code path uses ``pd.col`` and other pandas-3-only
+    APIs (see CHANGELOG entry for #1590), so allowing a resolution of
+    pandas<3 would yield ImportError-like failures at first use.
+    """
+    reqs = _runtime_requirements()
+    pandas_req = reqs.get("pandas")
+    assert pandas_req is not None, "pandas missing from runtime deps (#1597)"
+    # The declared specifier must reject pandas 2.x. Probe the boundary
+    # rather than parse the spec string directly: that way the assertion
+    # tracks intent ("must not allow pandas 2.2.3") instead of the exact
+    # operator/version we happened to write.
+    assert not pandas_req.specifier.contains("2.2.3"), (
+        f"pandas requirement {pandas_req.specifier!s} still admits "
+        "pandas 2.x; pyjanitor needs pandas>=3 (#1597)."
+    )
+    assert pandas_req.specifier.contains("3.0.0"), (
+        f"pandas requirement {pandas_req.specifier!s} excludes pandas 3.0.0, "
+        "which is the minimum supported version (#1597)."
+    )


### PR DESCRIPTION
<!-- [INF] -->

## PR Description

- Adds `pandas>=3.0.0` to `[project.dependencies]` in `pyproject.toml` so a fresh `pip install pyjanitor` no longer leaves the user's environment with the wrong pandas (or none at all).
- Adds `tests/test_packaging.py` to assert the constraint via `importlib.metadata.requires`, so a future regression will fail in CI rather than silently shipping.
- Updates `CHANGELOG.md` with an `[INF]` line under `[Unreleased]`.

**This PR resolves #1597.**

## Context

`[project.dependencies]` in `pyproject.toml` listed `natsort`, `pandas-flavor`, `multipledispatch`, `scipy`, and `janitor-rs`, but **not pandas**. The `[tool.pixi.dependencies]` section pinned `pandas = ">=3.0.0"` for the dev environment, but pip users never saw that constraint. Modern pyjanitor uses pandas-3 APIs such as `pd.col` (added via #1590), so installing pyjanitor against pandas 2.x silently produces a broken environment — exactly the failure mode in #1528.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
python -m venv /tmp/repro-1597 && source /tmp/repro-1597/bin/activate
pip install --quiet "pandas==2.2.3"   # pin a pandas 2.x to expose the bug

# --- BEFORE (origin/dev) ---
pip install --quiet --no-deps "pyjanitor==0.32.23"
python -c "from importlib.metadata import requires; reqs=[r for r in (requires('pyjanitor') or []) if 'extra' not in r]; print('runtime deps:', reqs); assert any(r.lower().startswith('pandas') and 'flavor' not in r.lower() for r in reqs), 'pandas missing!'"
# Expected: AssertionError 'pandas missing!' — pyjanitor publishes no pandas dep

# --- AFTER (this PR) ---
pip install --quiet --no-deps --force-reinstall \
  "git+https://github.com/jbbqqf/pyjanitor.git@feat/1597-enforce-pandas-dep"
python -c "from importlib.metadata import requires; reqs=[r for r in (requires('pyjanitor') or []) if 'extra' not in r]; print('runtime deps:', reqs); assert any(r.lower().startswith('pandas') and 'flavor' not in r.lower() and '>=3' in r for r in reqs), 'pandas>=3 missing!'"
# Expected: prints the deps with `pandas>=3.0.0`, no AssertionError
```

The only things that change between BEFORE and AFTER are the install source and the assertion polarity — the pandas pin and the metadata probe are identical.

## What I ran locally

- `pixi run pytest tests/test_packaging.py -v` → 2/2 passed (both fail on `dev`, both pass on this branch)
- `pixi run pytest tests/functions/test_clean_names.py -v` → 24/24 passed (sanity that the metadata change doesn't break runtime imports)

## Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | Fresh install, no pandas in env | `pip install pyjanitor` | pip pulls in pandas>=3.0 | `test_pandas_is_a_runtime_dependency` |
| 2 | Existing pandas 2.x in env | `pip install pyjanitor` over `pandas==2.2.3` | pip upgrades pandas to 3.x rather than leaving 2.x | `test_pandas_runtime_dependency_pins_to_pandas_3` (probes the boundary at 2.2.3) |
| 3 | Optional extras with `extra ==` markers | `pyjanitor[dev]` requirements | filtered out of the runtime-deps view | `_runtime_requirements()` helper drops `extra ==` markers |

## Risk / blast radius

Additive metadata change. `pip install pyjanitor` users will now see pandas resolved (or upgraded) at install time, which is the documented expectation. No runtime code touched.

## Release note

```release-note
pyjanitor's `pyproject.toml` now declares `pandas>=3.0.0` as a runtime dependency, so a fresh install no longer leaves the environment with an unsupported (or missing) pandas.
```

## PR Checklist

1. [x] PR in from a fork off your branch (`jbbqqf:feat/1597-enforce-pandas-dep`).
2. [x] Will add `jbbqqf` to `AUTHORS.md` if requested (no `AUTHORS.md` currently exists in the repo; happy to create one as part of this PR if maintainers prefer).
3. [x] CHANGELOG entry added under `[Unreleased]`.

## Relevant Reviewers

- @ericmjl (per repo PR template)
- @samukweku (because of the related `pd.col`/#1590 work that triggered the latent bug)

---

*PR drafted with assistance from Claude Code. The change was reviewed manually against pyjanitor's source and the upstream packaging metadata cited above. The reproducer block was used during development; it is the same one a reviewer can paste verbatim.*
