### PR TITLE
[ENH] expand_column: add drop_first option (#368)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+-   [ENH] `expand_column` now supports a `drop_first=True` argument that drops the first dummy column to avoid collinearity, mirroring `pandas.get_dummies`. - Issue #368 @jbbqqf
 -   [ENH] Add `include_join_positions` parameter to `conditional_join`; added limited support for join aggregations via the `join_agg` function. - Issue #1497 @samukweku
 -   [ENH] Added `rle_id` function for run-length encoding IDs - Issue #1435 @emmanuel-ferdman
 -   [ENH] Add `scale_mad` for robust median/MAD scaling. - PR #1530 @ShachiMistry

--- a/janitor/functions/expand_column.py
+++ b/janitor/functions/expand_column.py
@@ -15,6 +15,7 @@ def expand_column(
     column_name: Hashable,
     sep: str = "|",
     concat: bool = True,
+    drop_first: bool = False,
 ) -> pd.DataFrame:
     """Expand a categorical column with multiple labels into dummy-coded columns.
 
@@ -61,6 +62,24 @@ def expand_column(
         2     E, F     3  0  0  0  0  1  1
         3  A, E, F     4  1  0  0  0  1  1
 
+        Drop the first dummy column to avoid multicollinearity in
+        downstream regressions, mirroring `pandas.get_dummies(drop_first=True)`:
+
+        >>> import pandas as pd
+        >>> import janitor
+        >>> df = pd.DataFrame(
+        ...     {
+        ...         "col1": ["A, B", "B, C, D", "E, F", "A, E, F"],
+        ...         "col2": [1, 2, 3, 4],
+        ...     }
+        ... ).expand_column(column_name="col1", sep=", ", drop_first=True)
+        >>> df
+              col1  col2  B  C  D  E  F
+        0     A, B     1  1  0  0  0  0
+        1  B, C, D     2  1  1  1  0  0
+        2     E, F     3  0  0  0  1  1
+        3  A, E, F     4  0  0  0  1  1
+
     Args:
         df: A pandas DataFrame.
         column_name: Which column to expand.
@@ -69,11 +88,25 @@ def expand_column(
         concat: Whether to return the expanded column concatenated to
             the original dataframe (`concat=True`), or to return it standalone
             (`concat=False`).
+        drop_first: If `True`, drop the first dummy column to avoid the
+            collinearity that results from a full one-hot encoding (a
+            common preprocessing step before linear regression). Mirrors
+            the `drop_first` argument on `pandas.get_dummies`. Note that
+            `pandas.Series.str.get_dummies` (the underlying call) does
+            not yet expose this argument, so we drop the first column
+            after the fact. See issue #368.
 
     Returns:
         A pandas DataFrame with an expanded column.
     """  # noqa: E501
     expanded_df = df[column_name].str.get_dummies(sep=sep)
+    if drop_first and not expanded_df.empty:
+        # ``pandas.Series.str.get_dummies`` does not expose ``drop_first``
+        # (only ``pandas.get_dummies`` does), so we drop the first column
+        # after the fact. Columns coming back from ``str.get_dummies`` are
+        # sorted lexicographically, so this is deterministic across calls.
+        # Issue #368.
+        expanded_df = expanded_df.iloc[:, 1:]
     if concat:
         return df.join(expanded_df)
     return expanded_df

--- a/tests/functions/test_expand_column.py
+++ b/tests/functions/test_expand_column.py
@@ -37,3 +37,54 @@ def test_sep_default_parameter():
     result = df.expand_column("col1")
 
     assert result.shape[1] == 8
+
+
+@pytest.mark.functions
+def test_expand_column_drop_first_concat_false():
+    """``drop_first=True`` drops the first (lex-sorted) dummy column.
+
+    Mirrors ``pandas.get_dummies(drop_first=True)``. Useful before linear
+    regression to avoid the dummy-variable trap. See issue #368.
+    """
+    data = {
+        "col1": ["A, B", "B, C, D", "E, F", "A, E, F"],
+        "col2": [1, 2, 3, 4],
+    }
+    df = pd.DataFrame(data)
+    expanded = df.expand_column(
+        column_name="col1", sep=", ", concat=False, drop_first=True
+    )
+    # Pre-fix: would have 6 columns; with drop_first the leading "A" goes.
+    assert expanded.shape[1] == 5
+    assert "A" not in expanded.columns
+    assert list(expanded.columns) == ["B", "C", "D", "E", "F"]
+
+
+@pytest.mark.functions
+def test_expand_column_drop_first_concat_true():
+    """drop_first composes with concat=True (the default)."""
+    data = {
+        "col1": ["A, B", "B, C, D", "E, F", "A, E, F"],
+        "col2": [1, 2, 3, 4],
+    }
+    df = pd.DataFrame(data).expand_column(
+        column_name="col1", sep=", ", drop_first=True
+    )
+    # original 2 columns + 5 dummies (one dropped)
+    assert df.shape[1] == 7
+    assert "A" not in df.columns
+
+
+@pytest.mark.functions
+def test_expand_column_drop_first_default_off():
+    """``drop_first`` defaults to ``False`` so existing callers see no change."""
+    data = {
+        "col1": ["A, B", "B, C, D", "E, F", "A, E, F"],
+        "col2": [1, 2, 3, 4],
+    }
+    df = pd.DataFrame(data)
+    default = df.expand_column(column_name="col1", sep=", ", concat=False)
+    explicit = df.expand_column(
+        column_name="col1", sep=", ", concat=False, drop_first=False
+    )
+    pd.testing.assert_frame_equal(default, explicit)


### PR DESCRIPTION
<!-- [ENH] -->

## PR Description

- Adds a `drop_first: bool = False` argument to `janitor.functions.expand_column.expand_column`. When `True`, drops the first (lex-sorted) dummy column to avoid the dummy-variable trap.
- Mirrors `pandas.get_dummies(drop_first=True)`. The underlying `pandas.Series.str.get_dummies` does not expose this argument, so we drop the first column post-hoc.
- Defaults to `False`, so existing callers see no change.
- Three regression tests cover the new flag (with `concat=True`, `concat=False`, and "default off"); pre-existing tests still pass.

**This PR resolves #368.**

## Context

`expand_column` wraps `pandas.Series.str.get_dummies`, which (unlike the more general `pandas.get_dummies`) does not yet have `drop_first`. The original requester wanted `expand_column` to expose the same flag because dropping one dummy is standard preprocessing before any non-regularised linear model. Doing this manually after `expand_column` is mildly fiddly; an explicit flag is the natural fit.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone https://github.com/pyjanitor-devs/pyjanitor.git /tmp/repro-368 && cd /tmp/repro-368
curl -fsSL https://pixi.sh/install.sh | bash
export PATH=$HOME/.pixi/bin:$PATH
pixi install --quiet

# --- BEFORE (origin/dev) ---
git checkout origin/dev
pixi run python -c "
import pandas as pd, janitor
df = pd.DataFrame({'col1': ['A, B', 'B, C, D', 'E, F', 'A, E, F'], 'col2': [1,2,3,4]})
try:
    out = df.expand_column(column_name='col1', sep=', ', concat=False, drop_first=True)
    print('OK:', out.shape, list(out.columns))
except TypeError as e:
    print('TypeError:', e)
"
# Expected: TypeError: ... unexpected keyword argument 'drop_first'

# --- AFTER (this PR) ---
git fetch https://github.com/jbbqqf/pyjanitor.git feat/368-expand-column-drop-first
git checkout FETCH_HEAD
pixi run python -c "
import pandas as pd, janitor
df = pd.DataFrame({'col1': ['A, B', 'B, C, D', 'E, F', 'A, E, F'], 'col2': [1,2,3,4]})
out = df.expand_column(column_name='col1', sep=', ', concat=False, drop_first=True)
print('OK:', out.shape, list(out.columns))
"
# Expected: OK: (4, 5) ['B', 'C', 'D', 'E', 'F']
```

## What I ran locally

- `pixi run pytest tests/functions/test_expand_column.py -v` → 6/6 passed (3 pre-existing + 3 new).
- `pixi run pytest --doctest-modules janitor/functions/expand_column.py -v` → 1/1 passed (covers both the new doctest example and the existing ones).

## Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | `drop_first=True`, `concat=False` | 4 rows × 6 unique tokens | 5 dummy columns, leading `"A"` dropped | `test_expand_column_drop_first_concat_false` |
| 2 | `drop_first=True`, `concat=True` | same | 7 columns total (2 originals + 5 dummies) | `test_expand_column_drop_first_concat_true` |
| 3 | `drop_first=False` (default) | same | identical to omitting the kwarg | `test_expand_column_drop_first_default_off` |
| 4 | All other call shapes | various | unchanged | pre-existing `test_expand_column`, `test_expand_and_concat`, `test_sep_default_parameter` |

## Risk / blast radius

Strictly additive — `drop_first` defaults to `False`. Existing callers see byte-identical output. The "drop the first column" path only fires when `drop_first=True` is set explicitly.

## Release note

```release-note
`expand_column` gained a `drop_first` option that mirrors `pandas.get_dummies(drop_first=True)`, dropping the first dummy column to avoid the dummy-variable trap.
```

## PR Checklist

1. [x] PR in from a fork off your branch (`jbbqqf:feat/368-expand-column-drop-first`).
2. [x] CHANGELOG entry under `[Unreleased]`.

## Relevant Reviewers

- @ericmjl
- @samukweku

---

*PR drafted with assistance from Claude Code. The reproducer block above is the same one used during development.*
