### PR TITLE
[ENH] strip_whitespace parameter for clean_names function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 -   [ENH] `summarise` deprecated. - Issue #1045 @samukweku
 -   [ENH] Add `assign` method to groupby object. - Issue #1467 @samukweku
 -   [ENH] Add `pd.col` support - Issue #1590 @samukweku
+-   [ENH] Add `strip_whitespace` to `clean_names` function. - Issue #1385
 
 ## [v0.32.3] - 2025-12-11
 

--- a/janitor/functions/clean_names.py
+++ b/janitor/functions/clean_names.py
@@ -21,6 +21,7 @@ def clean_names(
     axis: str = "columns",
     column_names: str | list = None,
     strip_underscores: str | bool = None,
+    strip_whitespace: bool = True,
     case_type: str = "lower",
     remove_special: bool = False,
     strip_accents: bool = True,
@@ -79,6 +80,8 @@ def clean_names(
             Values can be either 'left', 'right' or 'both'
             or the respective shorthand 'l',
             'r' and True.
+        strip_whitespace: Whether or not to strip whitespace from the ends of
+            column names/values. Default True.
         case_type: Whether to make columns lower or uppercase.
             Current case may be preserved with 'preserve',
             while snake case conversion (from CamelCase or camelCase only)
@@ -113,7 +116,7 @@ def clean_names(
         column_names = get_index_labels(arg=column_names, df=df, axis="columns")
         if is_scalar(column_names):
             column_names = [column_names]
-        df = df.copy()
+        df = df[:]
         for column_name in column_names:
             df[column_name] = _clean_names(
                 obj=df[column_name],
@@ -123,11 +126,12 @@ def clean_names(
                 strip_accents=strip_accents,
                 strip_underscores=strip_underscores,
                 truncate_limit=truncate_limit,
+                strip_whitespace=strip_whitespace,
             )
         return df
 
     assert axis in {"index", "columns"}
-    df = df.copy()
+    df = df[:]
     target_axis = getattr(df, axis)
     if isinstance(target_axis, pd.MultiIndex):
         target_axis = [
@@ -143,6 +147,7 @@ def clean_names(
                 strip_accents=strip_accents,
                 strip_underscores=strip_underscores,
                 truncate_limit=truncate_limit,
+                strip_whitespace=strip_whitespace,
             )
             for obj in target_axis
         ]
@@ -159,6 +164,7 @@ def clean_names(
             strip_accents=strip_accents,
             strip_underscores=strip_underscores,
             truncate_limit=truncate_limit,
+            strip_whitespace=strip_whitespace,
         )
     # Store the original column names, if enabled by user
     if preserve_original_labels:
@@ -170,6 +176,7 @@ def clean_names(
 def _clean_names(
     obj: pd.Index | pd.Series,
     strip_underscores: str | bool,
+    strip_whitespace: bool,
     case_type: str,
     remove_special: bool,
     strip_accents: bool,
@@ -181,6 +188,8 @@ def _clean_names(
     """
     if enforce_string and not _is_str_or_cat(obj):
         obj = obj.astype(str)
+    if strip_whitespace:
+        obj = obj.str.strip()
     obj = _change_case(obj=obj, case_type=case_type)
     obj = _normalize_1(obj=obj)
     if remove_special:

--- a/tests/functions/test_clean_names.py
+++ b/tests/functions/test_clean_names.py
@@ -187,6 +187,48 @@ def test_clean_names_truncate_limit(dataframe):
 
 
 @pytest.mark.functions
+def test_clean_names_whitespace():
+    """Tests clean_names removes leading/trailing whitespace from column names."""
+    df = pd.DataFrame(
+        {
+            "  Hello World  ": [1, 2],
+            "\tFoo Bar\t": [3, 4],
+            "\nBaz Qux\n": [5, 6],
+        }
+    )
+    result = df.clean_names(strip_underscores=True, case_type="lower")
+
+    assert result.columns.tolist() == [
+        "hello_world",
+        "foo_bar",
+        "baz_qux",
+    ]
+
+
+@pytest.mark.functions
+def test_clean_names_does_not_mutate_dataframe(dataframe):
+    """Tests clean_names returns a new DataFrame and does not mutate input."""
+    original = dataframe.copy()
+    result = original.clean_names(remove_special=True)
+
+    assert result is not original
+    assert list(original.columns) == [
+        "a",
+        "Bell__Chart",
+        "decorated-elephant",
+        "animals@#$%^",
+        "cities",
+    ]
+    assert list(result.columns) == [
+        "a",
+        "bell_chart",
+        "decorated_elephant",
+        "animals",
+        "cities",
+    ]
+
+
+@pytest.mark.functions
 def test_charac():
     """Ensure non standard characters and spaces have been cleaned up."""
 


### PR DESCRIPTION
## PR Description

Please describe the changes proposed in the pull request:

- Add `strip_whitespace` parameter to `clean_names`
- specific to pandas
- Avoid deep copy (rely on pandas' copy on write)

**This PR relates to #1385 .**

Please tag maintainers to review.

- @ericmjl
