### PR TITLE
docs: make API module headings linkable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -541,6 +541,13 @@ If not installed, use `pixi global install markdownlint-cli`.
 **Recommendation**: After pushing to the branch, create the PR using the GitHub
 CLI.
 
+### [2026-08-06] Build Documentation in the Docs Environment
+
+**Context**: Validating a documentation-only change.
+**Learning**: `pixi run docs` selects the default environment, which does not
+include MkDocs. The documentation task is available in the `docs` environment.
+**Recommendation**: Run `pixi run -e docs build-docs` to build documentation.
+
 ---
 
 ## Version History

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,12 +68,15 @@ plugins:
               trim_doctest_flags: true
             show_if_no_docstring: false
             show_root_toc_entry: false
-            show_root_heading: false
+            # Display module roots so their API names are linkable in the docs.
+            show_root_heading: true
             show_submodules: true
             show_source: true
             members_order: alphabetical
 
 markdown_extensions:
+  - toc:
+      permalink: true
   - admonition
   - pymdownx.highlight:
       use_pygments: true


### PR DESCRIPTION
## Summary

- display root API module headings, including `janitor.functions` and the biology, chemistry, and finance modules
- add permanent links to documentation headings
- document the docs-specific Pixi build command for agent contributors

## Validation

- `pixi run -e docs build-docs`
- `markdownlint AGENTS.md` (reports existing MD060 table-style violations outside this change)

Closes #381