### PR TITLE
[ENH] replace axis=1 .apply() with vectorized ops in compare_df_cols for performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+-   [ENH] Replace `axis=1` `.apply()` with vectorized operations in `compare_df_cols` for 4-7x performance improvement. - Issue #1630 @Anupam2400
 -   [ENH] Replace `.apply()` with `.map()` in `find_replace` for ~6x performance improvement. - Issue #1422 @Anupam2400
 -   [ENH] Add `drop_first` parameter to `expand_column`. - Issue #368 @manav252
 -   [ENH] Add `include_join_positions` parameter to `conditional_join`; added limited support for join aggregations via the `join_agg` function. - Issue #1497 @samukweku

--- a/janitor/functions/compare_df_cols.py
+++ b/janitor/functions/compare_df_cols.py
@@ -360,21 +360,8 @@ def _column_order(dataframes: Iterable[pd.DataFrame]) -> list[Any]:
 def _match_rows(result: pd.DataFrame, bind_method: str) -> pd.Series:
     data = result.iloc[:, 1:]
     if bind_method == "rbind":
-        return data.apply(_row_matches_rbind, axis=1)
-    return data.apply(_row_matches_bind_rows, axis=1)
-
-
-def _row_matches_rbind(row: pd.Series) -> bool:
-    values = row.to_list()
-    first = values[0]
-    if pd.isna(first):
-        return False
-    return all(value == first for value in values[1:])
-
-
-def _row_matches_bind_rows(row: pd.Series) -> bool:
-    values = [value for value in row.to_list() if not pd.isna(value)]
-    if len(values) <= 1:
-        return True
-    first = values[0]
-    return all(value == first for value in values[1:])
+        first_col = data.iloc[:, 0]
+        return first_col.notna() & data.eq(first_col, axis=0).all(axis=1)
+    notna_mask = data.notna()
+    first_valid = data.bfill(axis=1).iloc[:, 0]
+    return data.eq(first_valid, axis=0).where(notna_mask, True).all(axis=1)


### PR DESCRIPTION
## PR Description
- Replaced `_row_matches_rbind` and `_row_matches_bind_rows` helper functions
  with fully vectorized pandas operations inside `_match_rows`
- Removed 2 helper functions — logic inlined directly, cleaner code overall

**Benchmark on 100k rows x 5 columns:**

| Method | Time | Speedup |
|---|---|---|
| `apply(_row_matches_rbind, axis=1)` | 0.545s | baseline |
| vectorized rbind | 0.074s | **7.3x faster** |
| `apply(_row_matches_bind_rows, axis=1)` | 0.776s | baseline |
| vectorized bind_rows | 0.190s | **4.1x faster** |

All 6 existing tests pass with no modifications needed.

**This PR resolves #1630.**

## PR Checklist
1. [x] PR in from a fork off your branch.
2. [x] Add yourself to `AUTHORS.md`.
3. [x] Add a line to `CHANGELOG.md` under the latest version header.

## Relevant Reviewers
@samukweku