### PR TITLE
[ENH] Add anti joins to conditional_join

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -577,6 +577,19 @@ mental model in the code documentation as well as technical API details.
 nearby documentation. Do not add redundant ELI5 comments to straightforward
 helpers.
 
+### [2026-08-19] Derive API Documentation Versions from the Release Sequence
+
+**Context**: Adding a `Version Changed` entry for a feature while other
+docstrings referenced a future minor release for deprecation.
+**Learning**: An unrelated deprecation target is not evidence for the version
+that will introduce a new feature. The package version and active release
+sequence determine the annotation.
+**Recommendation**: Before adding `Version Added`, `Version Changed`, or
+deprecation metadata, check the current version in `pyproject.toml` and recent
+release commits. Use the next patch version for ordinary unreleased changes
+unless a maintainer or release plan specifies a minor or major release. If the
+release target remains ambiguous, ask rather than copying another annotation.
+
 ---
 
 ## Version History

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,9 @@ these into the main sections.
   task.
 - **Test-Driven**: Always run tests after making code changes.
 - **Document**: Keep docstrings up-to-date using Google-style format.
+- **Explain Simply**: For complex public behavior, include a concise ELI5
+  section in the docstring or nearby documentation. Explain the user-facing
+  mental model, not line-by-line implementation details. Skip trivial helpers.
 - **Lint Markdown**: Always run `markdownlint` on markdown files after editing.
 
 ---
@@ -114,7 +117,7 @@ pixi run -e <environment> <command>
 
 | Task | Command |
 |------|---------|
-| Run all tests | `pixi run test` |
+| Run all tests | `pixi run -e tests test` |
 | Run specific test | `pixi run pytest tests/functions/test_clean_names.py` |
 | Run tests matching pattern | `pixi run pytest -k "test_clean_names" -v` |
 | Run tests with coverage | `pixi run pytest --cov=janitor` |
@@ -557,6 +560,22 @@ documentation, but they can still be useful to maintainers working on the code.
 arguments, limitations, and examples. Retain implementation-only explanations
 as source comments when they clarify non-obvious code or algorithms for
 maintainers.
+
+### [2026-08-19] Select the Tests Environment for the Full Suite
+
+**Context**: Running the full test suite with `pixi run test`.
+**Learning**: The `test` task exists in multiple pixi environments, so the
+unqualified command is ambiguous.
+**Recommendation**: Run the full suite with `pixi run -e tests test`.
+
+### [2026-08-19] Add ELI5 Explanations for Complex Behavior
+
+**Context**: Documenting a feature with several join modes and edge cases.
+**Learning**: Complex public behavior should include a short, plain-language
+mental model in the code documentation as well as technical API details.
+**Recommendation**: Add an ELI5 section to non-trivial public docstrings or
+nearby documentation. Do not add redundant ELI5 comments to straightforward
+helpers.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@
 -   [ENH] Replace `axis=1` `.apply()` with vectorized operations in `compare_df_cols` for 4-7x performance improvement. - Issue #1630 @Anupam2400
 -   [ENH] Replace `.apply()` with `.map()` in `find_replace` for ~6x performance improvement. - Issue #1422 @Anupam2400
 -   [ENH] Add `drop_first` parameter to `expand_column`. - Issue #368 @manav252
--   [ENH] `conditional_join` now picks the most selective `<`/`<=`/`>`/`>=` predicate as its binary-search anchor (instead of the first one supplied) when `keep` is `'first'` or `'last'`, fixing pathological slowdowns from unfavorable predicate ordering; `keep='all'` output is unaffected. - Issue #1641 @samukweku
--   [BUG] Fix `conditional_join` crash for `keep='last'` joins with a single `<`/`<=` window and multiple non-equi conditions - a missing `counts` argument to the Rust `index_starts_only_keep_last` call. - Issue #1641 @samukweku
+-   [ENH] Add `left_anti` and `right_anti` joins to `conditional_join`. -
+    Issue #1627 @samukweku
 -   [ENH] Add `include_join_positions` parameter to `conditional_join`; added limited support for join aggregations via the `join_agg` function. - Issue #1497 @samukweku
 -   [ENH] Added `rle_id` function for run-length encoding IDs - Issue #1435 @emmanuel-ferdman
 -   [ENH] Add `scale_mad` for robust median/MAD scaling. - PR #1530 @ShachiMistry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 -   [ENH] Replace `.apply()` with `.map()` in `find_replace` for ~6x performance improvement. - Issue #1422 @Anupam2400
 -   [ENH] Add `drop_first` parameter to `expand_column`. - Issue #368 @manav252
 -   [ENH] Add `left_anti` and `right_anti` joins to `conditional_join`. -
-    Issue #1627 @samukweku
+    Issue #1627, PR #1633 @samukweku
 -   [ENH] Add `include_join_positions` parameter to `conditional_join`; added limited support for join aggregations via the `join_agg` function. - Issue #1497 @samukweku
 -   [ENH] Added `rle_id` function for run-length encoding IDs - Issue #1435 @emmanuel-ferdman
 -   [ENH] Add `scale_mad` for robust median/MAD scaling. - PR #1530 @ShachiMistry

--- a/janitor/functions/_conditional_join/_get_indices_single_join.py
+++ b/janitor/functions/_conditional_join/_get_indices_single_join.py
@@ -23,6 +23,7 @@ def _single_join(
     condition: tuple,
     keep: str,
     return_matching_indices: bool,
+    existence_only: bool = False,
 ) -> dict:
     """
     Compute indices for a single join
@@ -49,4 +50,5 @@ def _single_join(
             left=df[left_on],
             right=right[right_on],
             keep=keep,
+            existence_only=existence_only,
         )

--- a/janitor/functions/_conditional_join/_not_equal_indices.py
+++ b/janitor/functions/_conditional_join/_not_equal_indices.py
@@ -1,6 +1,7 @@
 # helper functions for !=
 import numpy as np
 import pandas as pd
+from pandas.api.types import is_extension_array_dtype
 
 from janitor.functions._conditional_join import _binary_search
 from janitor.functions._conditional_join._helpers import (
@@ -15,10 +16,14 @@ def _not_equal_indices(
     left: pd.Series,
     right: pd.Series,
     keep: str,
+    existence_only: bool = False,
 ) -> dict | None:
     """
     Use binary search to get indices where
     `left` is exactly  not equal to `right`.
+
+    With ``existence_only=True``, return only the left rows having at least
+    one match, without materializing the pair stream.
 
     It is a combination of strictly less than
     and strictly greater than indices.
@@ -28,6 +33,33 @@ def _not_equal_indices(
         return _not_equal_keep_one(left=left, right=right, keep=keep)
 
     dummy = np.array([], dtype=np.intp)
+
+    if existence_only:
+        # Anti joins only need one bit per driving row. Avoid constructing the
+        # potentially quadratic set of != pairs before reducing it to that
+        # existence information.
+        left_nulls = left.isna().to_numpy()
+        right_nulls = right.isna().to_numpy()
+        matched = np.zeros(left.size, dtype=bool)
+        right_non_null = right._values[~right_nulls]
+        unique_right = pd.unique(right_non_null)
+        if unique_right.size:
+            matched[left_nulls] = True
+            if unique_right.size > 1:
+                matched[~left_nulls] = True
+            else:
+                different = left._values != unique_right[0]
+                if is_extension_array_dtype(different):
+                    different = different.fillna(False).to_numpy()
+                matched |= (~left_nulls) & np.asarray(different, dtype=bool)
+        if right_nulls.any():
+            # Match the existing != null handling: a null on the right adds
+            # every left row to the candidate matches.
+            matched[:] = True
+        return {
+            "left_index": left.index._values[matched],
+            "right_index": dummy,
+        }
 
     # deal with nulls
     l1_nulls = dummy

--- a/janitor/functions/conditional_join.py
+++ b/janitor/functions/conditional_join.py
@@ -43,7 +43,9 @@ def conditional_join(
     df: pd.DataFrame,
     right: pd.DataFrame | pd.Series,
     *conditions: tuple,
-    how: Literal["inner", "left", "right", "outer"] = "inner",
+    how: Literal[
+        "inner", "left", "right", "outer", "left_anti", "right_anti"
+    ] = "inner",
     df_columns: Optional[Any] = slice(None),
     right_columns: Optional[Any] = slice(None),
     keep: Literal["first", "last", "all"] = "all",
@@ -93,6 +95,14 @@ def conditional_join(
     For multiple conditions, the and(`&`)
     operator is used to combine the results of the individual conditions.
 
+    !!! info "ELI5"
+
+        Imagine comparing every row on the left with rows on the right using
+        the rules you provide. An inner join keeps successful pairs. Left and
+        right joins also keep unmatched rows from their named side. A
+        `left_anti` join keeps only left rows that never found a successful
+        partner; `right_anti` does the same for right rows.
+
     In some scenarios there might be performance gains if the less than join,
     or the greater than join condition, or the range condition
     is executed before the equi join - pass `force=True` to force this.
@@ -107,7 +117,8 @@ def conditional_join(
 
     For non-equi joins, only numeric, timedelta and date columns are supported.
 
-    `inner`, `left`, `right` and `outer` joins are supported.
+    `inner`, `left`, `right`, `outer`, `left_anti` and `right_anti`
+    joins are supported.
 
     If the columns from `df` and `right` have nothing in common,
     a single index column is returned; else, a MultiIndex column
@@ -243,6 +254,17 @@ def conditional_join(
         9       NaN      12.0      15.0  right_only
         10      NaN       0.0       1.0  right_only
 
+        Return rows from the left dataframe that have no match:
+        >>> df1.conditional_join(
+        ...     df2,
+        ...     ("value_1", "value_2A", ">"),
+        ...     ("value_1", "value_2B", "<"),
+        ...     how="left_anti",
+        ... )
+           value_1  value_2A  value_2B
+        0        7       NaN       NaN
+        1        1       NaN       NaN
+
     !!! abstract "Version Changed"
 
         - 0.24.0
@@ -262,6 +284,8 @@ def conditional_join(
         - 0.32.10
             - Added `include_join_positions` parameter.
             - Added `join_algorithm` parameter.
+        - 0.33.0
+            - Added `left_anti` and `right_anti` joins.
 
     Args:
         df: A pandas DataFrame.
@@ -275,7 +299,10 @@ def conditional_join(
             the and(`&`) operator is used to combine the results
             of the individual conditions.
         how: Indicates the type of join to be performed.
-            It can be one of `inner`, `left`, `right` or `outer`.
+            It can be one of `inner`, `left`, `right`, `outer`,
+            `left_anti` or `right_anti`.
+            `df_columns` cannot be `None` for a `left_anti` join,
+            and `right_columns` cannot be `None` for a `right_anti` join.
         df_columns: Columns to select from `df` in the final output dataframe.
             Column selection is based on the
             [`select_columns`][janitor.functions.select.select_columns] syntax.
@@ -403,8 +430,16 @@ def _conditional_join_preliminary_checks(
 
     check("how", how, [str])
 
-    if how not in {"inner", "left", "right", "outer"}:
-        raise ValueError("'how' should be one of 'inner', 'left', 'right' or 'outer'.")
+    join_types = {"inner", "left", "right", "outer", "left_anti", "right_anti"}
+    if how not in join_types:
+        raise ValueError(
+            "'how' should be one of 'inner', 'left', 'right', 'outer', "
+            "'left_anti' or 'right_anti'."
+        )
+    if (how == "left_anti") and (df_columns is None):
+        raise ValueError("df_columns cannot be None for a left_anti join.")
+    if (how == "right_anti") and (right_columns is None):
+        raise ValueError("right_columns cannot be None for a right_anti join.")
 
     check("keep", keep, [str])
 
@@ -597,12 +632,13 @@ def _conditional_join_compute(
         # return every requested payload column with its original dtype.
         matching_df = df.loc(axis=1)[condition_left_columns]
         matching_right = right.loc(axis=1)[condition_right_columns]
+    match_keep = "all" if how in {"left_anti", "right_anti"} else keep
     if eq_check:
         indices = _multiple_conditional_join_eq(
             df=matching_df,
             right=matching_right,
             conditions=conditions,
-            keep=keep,
+            keep=match_keep,
             use_numba=use_numba,
             force=force,
             return_matching_indices=return_building_blocks or aggfunc,
@@ -613,7 +649,7 @@ def _conditional_join_compute(
             df=matching_df,
             right=matching_right,
             conditions=conditions,
-            keep=keep,
+            keep=match_keep,
             use_numba=use_numba,
             return_matching_indices=return_building_blocks or aggfunc,
             join_algorithm=join_algorithm,
@@ -623,14 +659,14 @@ def _conditional_join_compute(
             df=matching_df,
             right=matching_right,
             conditions=conditions,
-            keep=keep,
+            keep=match_keep,
         )
     else:
         indices = _get_indices_single_join._single_join(
             df=df,
             right=right,
             condition=conditions[0],
-            keep=keep,
+            keep=match_keep,
             return_matching_indices=return_building_blocks or aggfunc,
         )
     # Internally, join discovery may remain compact until aggregation. A
@@ -1006,6 +1042,13 @@ def _create_multiindex_column(df: pd.DataFrame, right: pd.DataFrame) -> tuple:
     return df, right
 
 
+def _get_unmatched_indices(matched_indices: np.ndarray, size: int) -> np.ndarray:
+    """Return row positions that are absent from the matched positions."""
+    unmatched = np.ones(size, dtype=bool)
+    unmatched[matched_indices] = False
+    return unmatched.nonzero()[0]
+
+
 def _create_frame(
     df: pd.DataFrame,
     right: pd.DataFrame,
@@ -1020,6 +1063,8 @@ def _create_frame(
     """
     Create final dataframe
     """
+    df_length = len(df)
+    right_length = len(right)
     # TODO: deprecate df_columns and right_columns
     # user can handle column renaming before the join
     if (df_columns is None) and (right_columns is None):
@@ -1130,9 +1175,7 @@ def _create_frame(
             include_join_positions=include_join_positions,
         )
     if how == "left":
-        indexer = pd.unique(left_index)
-        indexer = pd.Index(indexer).get_indexer(range(len(df)))
-        indexer = (indexer < 0).nonzero()[0]
+        indexer = _get_unmatched_indices(left_index, len(df))
         length = indexer.size
         if not length:
             return _inner(
@@ -1176,9 +1219,7 @@ def _create_frame(
         return pd.DataFrame(dictionary, copy=False)
 
     if how == "right":
-        indexer = pd.unique(right_index)
-        indexer = pd.Index(indexer).get_indexer(range(len(right)))
-        indexer = (indexer < 0).nonzero()[0]
+        indexer = _get_unmatched_indices(right_index, len(right))
         length = indexer.size
         if not length:
             return _inner(
@@ -1220,13 +1261,43 @@ def _create_frame(
             value = concat_compat([arr1, arr2])
             dictionary[name] = value
         return pd.DataFrame(dictionary, copy=False)
+    if how in {"left_anti", "right_anti"}:
+        if how == "left_anti":
+            indexer = _get_unmatched_indices(left_index, df_length)
+        else:
+            indexer = _get_unmatched_indices(right_index, right_length)
+        length = indexer.size
+        dictionary = {}
+        for key, value in df.items():
+            array = value._values
+            if how == "left_anti":
+                value = array[indexer]
+            else:
+                value = construct_1d_array_from_inferred_fill_value(
+                    value=array[:1], length=length
+                )
+            dictionary[key] = value
+        for key, value in right.items():
+            array = value._values
+            if how == "right_anti":
+                value = array[indexer]
+            else:
+                value = construct_1d_array_from_inferred_fill_value(
+                    value=array[:1], length=length
+                )
+            dictionary[key] = value
+        if indicator:
+            name, arr = _add_indicator(
+                indicator=indicator,
+                how="left" if how == "left_anti" else "right",
+                column_length=length,
+                columns=df.columns.union(right.columns),
+            )
+            dictionary[name] = arr
+        return pd.DataFrame(dictionary, copy=False)
     # how == 'outer'
-    left_indexer = pd.unique(left_index)
-    left_indexer = pd.Index(left_indexer).get_indexer(range(len(df)))
-    left_indexer = (left_indexer < 0).nonzero()[0]
-    right_indexer = pd.unique(right_index)
-    right_indexer = pd.Index(right_indexer).get_indexer(range(len(right)))
-    right_indexer = (right_indexer < 0).nonzero()[0]
+    left_indexer = _get_unmatched_indices(left_index, len(df))
+    right_indexer = _get_unmatched_indices(right_index, len(right))
 
     df_nulls_length = left_indexer.size
     right_nulls_length = right_indexer.size

--- a/janitor/functions/conditional_join.py
+++ b/janitor/functions/conditional_join.py
@@ -284,7 +284,7 @@ def conditional_join(
         - 0.32.10
             - Added `include_join_positions` parameter.
             - Added `join_algorithm` parameter.
-        - 0.33.0
+        - 0.32.25
             - Added `left_anti` and `right_anti` joins.
 
     Args:

--- a/janitor/functions/conditional_join.py
+++ b/janitor/functions/conditional_join.py
@@ -632,12 +632,29 @@ def _conditional_join_compute(
         # return every requested payload column with its original dtype.
         matching_df = df.loc(axis=1)[condition_left_columns]
         matching_right = right.loc(axis=1)[condition_right_columns]
-    match_keep = "all" if how in {"left_anti", "right_anti"} else keep
+    anti_join = how in {"left_anti", "right_anti"}
+    match_df = matching_df
+    match_right = matching_right
+    match_conditions = conditions
+    if how == "right_anti":
+        # A right anti join is an existence query from the right side. Swap
+        # the driving side so keep="first" retains one witness per right row,
+        # then restore the result shape below.
+        match_df, match_right = matching_right, matching_df
+        match_conditions = [
+            (right_on, left_on, _reverse_operator[op])
+            for left_on, right_on, op in conditions
+        ]
+    # Anti joins only need to know whether a preserved row has one match.
+    # keep="first" bounds the materialized witnesses to one per driving row
+    # in the normal match paths; single != uses a direct existence mask.
+    # keep is intentionally ignored because matched rows are discarded.
+    match_keep = "first" if anti_join else keep
     if eq_check:
         indices = _multiple_conditional_join_eq(
-            df=matching_df,
-            right=matching_right,
-            conditions=conditions,
+            df=match_df,
+            right=match_right,
+            conditions=match_conditions,
             keep=match_keep,
             use_numba=use_numba,
             force=force,
@@ -646,9 +663,9 @@ def _conditional_join_compute(
         )
     elif (len(conditions) > 1) & le_lt_check:
         indices = _multiple_conditional_join_le_lt(
-            df=matching_df,
-            right=matching_right,
-            conditions=conditions,
+            df=match_df,
+            right=match_right,
+            conditions=match_conditions,
             keep=match_keep,
             use_numba=use_numba,
             return_matching_indices=return_building_blocks or aggfunc,
@@ -656,18 +673,19 @@ def _conditional_join_compute(
         )
     elif len(conditions) > 1:
         indices = _multiple_conditional_join_ne(
-            df=matching_df,
-            right=matching_right,
-            conditions=conditions,
+            df=match_df,
+            right=match_right,
+            conditions=match_conditions,
             keep=match_keep,
         )
     else:
         indices = _get_indices_single_join._single_join(
-            df=df,
-            right=right,
-            condition=conditions[0],
+            df=match_df,
+            right=match_right,
+            condition=match_conditions[0],
             keep=match_keep,
             return_matching_indices=return_building_blocks or aggfunc,
+            existence_only=anti_join,
         )
     # Internally, join discovery may remain compact until aggregation. A
     # ``starts``/``ends`` pair contains one half-open candidate slice per driving
@@ -688,6 +706,19 @@ def _conditional_join_compute(
     # inequalities; range and multi-condition joins may retain both boundaries
     # and a mask. ``keep="first"`` or ``keep="last"`` reduces each slice before
     # labels are restored, while ``keep="all"`` emits every surviving position.
+
+    if anti_join:
+        empty_array = np.array([], dtype=np.intp)
+        if how == "left_anti":
+            indices = {
+                "left_index": indices["left_index"],
+                "right_index": empty_array,
+            }
+        else:
+            indices = {
+                "left_index": empty_array,
+                "right_index": indices["left_index"],
+            }
 
     if aggfunc and reverse:
         return _get_join_aggs._agg_join_left(
@@ -723,6 +754,15 @@ operator_map = {
     _JoinOperator.GREATER_THAN.value: operator.gt,
     _JoinOperator.GREATER_THAN_OR_EQUAL.value: operator.ge,
     _JoinOperator.NOT_EQUAL.value: operator.ne,
+}
+
+_reverse_operator = {
+    _JoinOperator.STRICTLY_EQUAL.value: _JoinOperator.STRICTLY_EQUAL.value,
+    _JoinOperator.LESS_THAN.value: _JoinOperator.GREATER_THAN.value,
+    _JoinOperator.LESS_THAN_OR_EQUAL.value: _JoinOperator.GREATER_THAN_OR_EQUAL.value,
+    _JoinOperator.GREATER_THAN.value: _JoinOperator.LESS_THAN.value,
+    _JoinOperator.GREATER_THAN_OR_EQUAL.value: _JoinOperator.LESS_THAN_OR_EQUAL.value,
+    _JoinOperator.NOT_EQUAL.value: _JoinOperator.NOT_EQUAL.value,
 }
 
 
@@ -1175,7 +1215,7 @@ def _create_frame(
             include_join_positions=include_join_positions,
         )
     if how == "left":
-        indexer = _get_unmatched_indices(left_index, len(df))
+        indexer = _get_unmatched_indices(left_index, df_length)
         length = indexer.size
         if not length:
             return _inner(
@@ -1219,7 +1259,7 @@ def _create_frame(
         return pd.DataFrame(dictionary, copy=False)
 
     if how == "right":
-        indexer = _get_unmatched_indices(right_index, len(right))
+        indexer = _get_unmatched_indices(right_index, right_length)
         length = indexer.size
         if not length:
             return _inner(
@@ -1296,8 +1336,8 @@ def _create_frame(
             dictionary[name] = arr
         return pd.DataFrame(dictionary, copy=False)
     # how == 'outer'
-    left_indexer = _get_unmatched_indices(left_index, len(df))
-    right_indexer = _get_unmatched_indices(right_index, len(right))
+    left_indexer = _get_unmatched_indices(left_index, df_length)
+    right_indexer = _get_unmatched_indices(right_index, right_length)
 
     df_nulls_length = left_indexer.size
     right_nulls_length = right_indexer.size

--- a/janitor/functions/conditional_join.py
+++ b/janitor/functions/conditional_join.py
@@ -352,6 +352,25 @@ def conditional_join(
     )
 
 
+operator_map = {
+    _JoinOperator.STRICTLY_EQUAL.value: operator.eq,
+    _JoinOperator.LESS_THAN.value: operator.lt,
+    _JoinOperator.LESS_THAN_OR_EQUAL.value: operator.le,
+    _JoinOperator.GREATER_THAN.value: operator.gt,
+    _JoinOperator.GREATER_THAN_OR_EQUAL.value: operator.ge,
+    _JoinOperator.NOT_EQUAL.value: operator.ne,
+}
+
+_reverse_operator = {
+    _JoinOperator.STRICTLY_EQUAL.value: _JoinOperator.STRICTLY_EQUAL.value,
+    _JoinOperator.LESS_THAN.value: _JoinOperator.GREATER_THAN.value,
+    _JoinOperator.LESS_THAN_OR_EQUAL.value: _JoinOperator.GREATER_THAN_OR_EQUAL.value,
+    _JoinOperator.GREATER_THAN.value: _JoinOperator.LESS_THAN.value,
+    _JoinOperator.GREATER_THAN_OR_EQUAL.value: _JoinOperator.LESS_THAN_OR_EQUAL.value,
+    _JoinOperator.NOT_EQUAL.value: _JoinOperator.NOT_EQUAL.value,
+}
+
+
 def _check_operator(op: str):
     """
     Check that operator is one of
@@ -717,6 +736,7 @@ def _conditional_join_compute(
         else:
             indices = {
                 "left_index": empty_array,
+                # Remember the sides have been swapped for right_anti.
                 "right_index": indices["left_index"],
             }
 
@@ -745,25 +765,6 @@ def _conditional_join_compute(
         indicator=indicator,
         include_join_positions=include_join_positions,
     )
-
-
-operator_map = {
-    _JoinOperator.STRICTLY_EQUAL.value: operator.eq,
-    _JoinOperator.LESS_THAN.value: operator.lt,
-    _JoinOperator.LESS_THAN_OR_EQUAL.value: operator.le,
-    _JoinOperator.GREATER_THAN.value: operator.gt,
-    _JoinOperator.GREATER_THAN_OR_EQUAL.value: operator.ge,
-    _JoinOperator.NOT_EQUAL.value: operator.ne,
-}
-
-_reverse_operator = {
-    _JoinOperator.STRICTLY_EQUAL.value: _JoinOperator.STRICTLY_EQUAL.value,
-    _JoinOperator.LESS_THAN.value: _JoinOperator.GREATER_THAN.value,
-    _JoinOperator.LESS_THAN_OR_EQUAL.value: _JoinOperator.GREATER_THAN_OR_EQUAL.value,
-    _JoinOperator.GREATER_THAN.value: _JoinOperator.LESS_THAN.value,
-    _JoinOperator.GREATER_THAN_OR_EQUAL.value: _JoinOperator.LESS_THAN_OR_EQUAL.value,
-    _JoinOperator.NOT_EQUAL.value: _JoinOperator.NOT_EQUAL.value,
-}
 
 
 def _generate_indices(

--- a/tests/functions/test_conditional_join.py
+++ b/tests/functions/test_conditional_join.py
@@ -411,6 +411,53 @@ def test_right_anti_ignores_keep(keep):
 
 
 @pytest.mark.parametrize(
+    ("how", "df_columns", "right_columns", "expected_length"),
+    [
+        ("left", None, ["right"], 2),
+        ("right", ["left"], None, 1),
+        ("outer", None, ["right"], 2),
+        ("outer", ["left"], None, 2),
+    ],
+)
+def test_unmatched_positions_use_original_lengths(
+    how, df_columns, right_columns, expected_length
+):
+    """Column projection must not change unmatched-row index boundaries."""
+    left = pd.DataFrame({"left": [1, 2]})
+    right = pd.DataFrame({"right": [2]})
+
+    actual = left.conditional_join(
+        right,
+        ("left", "right", "<"),
+        how=how,
+        df_columns=df_columns,
+        right_columns=right_columns,
+    )
+
+    assert len(actual) == expected_length
+
+
+def test_not_equal_anti_join_uses_existence_not_pair_materialization():
+    """Anti joins preserve != duplicate-label match semantics."""
+    left = pd.DataFrame({"left": [1, 2]})
+    right = pd.DataFrame({"right": [1, 1]})
+
+    left_anti = left.conditional_join(
+        right,
+        ("left", "right", "!="),
+        how="left_anti",
+    )
+    right_anti = left.conditional_join(
+        right,
+        ("left", "right", "!="),
+        how="right_anti",
+    )
+
+    assert left_anti["left"].tolist() == [1]
+    assert right_anti.empty
+
+
+@pytest.mark.parametrize(
     ("how", "df_columns", "right_columns", "match"),
     [
         ("left_anti", None, slice(None), "df_columns cannot be None"),

--- a/tests/functions/test_conditional_join.py
+++ b/tests/functions/test_conditional_join.py
@@ -314,6 +314,124 @@ def test_check_how_value(dummy, series):
         dummy.conditional_join(series, ("id", "B", "<"), how="INNER")
 
 
+def test_left_anti_range_join():
+    """Return left rows that do not match all range conditions."""
+    events = pd.DataFrame({"time": [1, 5, 10]})
+    windows = pd.DataFrame({"start": [0, 6], "end": [2, 8]})
+
+    actual = events.conditional_join(
+        windows,
+        ("time", "start", ">="),
+        ("time", "end", "<="),
+        how="left_anti",
+        indicator=True,
+    )
+
+    expected = pd.DataFrame(
+        {
+            "time": [5, 10],
+            "start": [np.nan, np.nan],
+            "end": [np.nan, np.nan],
+            "_merge": pd.Categorical(
+                ["left_only", "left_only"],
+                categories=["left_only", "right_only", "both"],
+            ),
+        }
+    )
+    assert_frame_equal(expected, actual)
+
+
+def test_right_anti_range_join():
+    """Return right rows that do not match all range conditions."""
+    events = pd.DataFrame({"time": [1, 5, 10]})
+    windows = pd.DataFrame({"start": [0, 6], "end": [2, 8]})
+
+    actual = events.conditional_join(
+        windows,
+        ("time", "start", ">="),
+        ("time", "end", "<="),
+        how="right_anti",
+        indicator="source",
+    )
+
+    expected = pd.DataFrame(
+        {
+            "time": [np.nan],
+            "start": [6],
+            "end": [8],
+            "source": pd.Categorical(
+                ["right_only"], categories=["left_only", "right_only", "both"]
+            ),
+        }
+    )
+    assert_frame_equal(expected, actual)
+
+
+@pytest.mark.parametrize("how", ["left_anti", "right_anti"])
+def test_anti_join_all_rows_match(how):
+    """Return an empty frame with stable columns when every row matches."""
+    left = pd.DataFrame({"left": [1, 2]})
+    right = pd.DataFrame({"right": [2]})
+
+    actual = left.conditional_join(right, ("left", "right", "<="), how=how)
+
+    assert actual.empty
+    assert actual.columns.tolist() == ["left", "right"]
+
+
+def test_left_anti_equi_and_non_equi_join():
+    """Support anti joins with combined equi and non-equi conditions."""
+    left = pd.DataFrame({"group": [1, 1, 2], "value": [1, 5, 3]})
+    right = pd.DataFrame({"group": [1, 2], "limit": [2, 4]})
+
+    actual = left.conditional_join(
+        right,
+        ("group", "group", "=="),
+        ("value", "limit", "<"),
+        how="left_anti",
+        df_columns=["group", "value"],
+        right_columns=None,
+    )
+
+    expected = left.iloc[[1]].reset_index(drop=True)
+    assert_frame_equal(expected, actual)
+
+
+@pytest.mark.parametrize("keep", ["first", "last"])
+def test_right_anti_ignores_keep(keep):
+    """Consider every matching right row when filtering a right anti join."""
+    left = pd.DataFrame({"left": [0]})
+    right = pd.DataFrame({"right": [1, 2]})
+
+    actual = left.conditional_join(
+        right, ("left", "right", "<"), how="right_anti", keep=keep
+    )
+
+    assert actual.empty
+
+
+@pytest.mark.parametrize(
+    ("how", "df_columns", "right_columns", "match"),
+    [
+        ("left_anti", None, slice(None), "df_columns cannot be None"),
+        ("right_anti", slice(None), None, "right_columns cannot be None"),
+    ],
+)
+def test_anti_join_preserved_columns_required(how, df_columns, right_columns, match):
+    """Require output columns from the side preserved by an anti join."""
+    left = pd.DataFrame({"left": [1]})
+    right = pd.DataFrame({"right": [0]})
+
+    with pytest.raises(ValueError, match=match):
+        left.conditional_join(
+            right,
+            ("left", "right", "<"),
+            how=how,
+            df_columns=df_columns,
+            right_columns=right_columns,
+        )
+
+
 def test_check_use_numba_type(dummy, series):
     """
     Raise TypeError if `use_numba` is not a boolean.


### PR DESCRIPTION
## Summary

- add `how="left_anti"` and `how="right_anti"` to `conditional_join`
- preserve pandas-style output columns and optional merge indicators
- make anti-join membership independent of `keep="first"` or `keep="last"`
- require selected columns from the side preserved by an anti join
- consolidate unmatched-position discovery behind a faster NumPy boolean mask
- document the public behavior, including an ELI5 explanation
- record the correct environment-qualified full-suite command

## ELI5

A conditional join asks whether rows from two tables satisfy the supplied rules. A left anti join keeps the left rows that never find a matching right row. A right anti join does the same from the other direction. For example, it can find events that do not fall inside any time window.

## Performance

On a local 200,000-row `_create_frame` microbenchmark, the shared boolean-mask implementation improved unmatched-position handling by approximately 2.2x to 3.5x across left, right, outer, and anti joins. Broader result-materialization work is tracked separately in #1632.

Single-condition `!=` anti-joins use an existence-only path because anti-joins need only determine whether each preserved row has any match. The multi-condition all-`!=` path remains pair-producing and is intentionally out of scope for this PR: it has additional null and predicate-intersection semantics that require a separate design and differential benchmark coverage. That follow-up is tracked in #1710, with representative duplicate-heavy, unique, nullable, high-match, low-match, and no-match examples.

## Validation

- `pixi run -e tests test`: 1334 passed, 5 skipped, 48 xfailed, 17 xpassed
- conditional-join doctests: 2 passed
- focused pre-commit checks: passed
- standalone baseline-aware Markdown lint: passed
- `git diff --check`: passed

Repository-wide pre-commit currently reports existing Ruff failures in example notebooks and `janitor/functions/convert_date.py`; none are in files changed by this PR.

The `pixi.lock` local-package version refresh was generated by the repository `pixi-install` hook after the upstream 0.32.24 version bump.

## Follow-up

See [#1710](https://github.com/pyjanitor-devs/pyjanitor/issues/1710) for optimizing multi-condition all-`!=` anti-joins without materializing the full candidate pair set. The issue links back here and defines correctness, benchmark, and documentation acceptance criteria.

Fixes #1627

Related: #1632
