### PR TITLE
fix(pivot_longer_spec): reject value-column collisions

### DIFF
--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -498,7 +498,9 @@ def pivot_longer_spec(
     Raises:
         KeyError: If '.name' or '.value' is missing from the spec's columns.
         ValueError: If the spec's columns is not unique,
-            or the labels in spec['.name'] is not unique.
+            the labels in spec['.name'] is not unique,
+            or a label in spec['.value'] collides with an identifier
+            or additional spec column.
 
     Returns:
         A pandas DataFrame.
@@ -532,10 +534,16 @@ def pivot_longer_spec(
     check("df_columns_is_unique", df_columns_is_unique, [bool])
     index = df.columns.difference(spec[".name"], sort=False)
     index = {name: df[name]._values for name in index}
+    others = [label for label in spec if label not in {".name", ".value"}]
+    _check_dot_value_collisions(
+        dot_value=spec[".value"].array,
+        index=index,
+        others=others,
+        source="spec",
+    )
     df = df.loc[:, spec[".name"]]
     if not df_columns_is_unique:
         spec = pd.DataFrame({".name": df.columns}).merge(spec, on=".name", how="inner")
-    others = [label for label in spec if label not in {".name", ".value"}]
     return _pivot_longer_dot_value(
         df=df,
         spec=spec.drop(columns=".name"),
@@ -1313,10 +1321,31 @@ def _dot_value_extra_checks(
     else:
         spec.columns = names_to
     dot_value = spec[".value"].array
-    checks = set(names_to) - {".value"}
-    for word in checks:
+    _check_dot_value_collisions(
+        dot_value=dot_value,
+        index=index,
+        others=others,
+        source="names_to",
+    )
+    return spec, index, others
+
+
+def _check_dot_value_collisions(
+    dot_value: Any,
+    index: dict,
+    others: list,
+    source: str,
+) -> None:
+    """Raise if output value labels collide with other output columns."""
+    for word in others:
         boolean = dot_value == word
         if boolean.any():
+            if source == "spec":
+                raise ValueError(
+                    f"Label '{word}' in the spec's `.value` column already "
+                    "exists as another column label in the spec DataFrame. "
+                    "Kindly provide unique label(s)."
+                )
             raise ValueError(
                 f"Label '{word}' in names_to already exists "
                 "in the new dataframe's columns. "
@@ -1330,7 +1359,6 @@ def _dot_value_extra_checks(
                 "as column labels assigned to the dataframe's "
                 "index parameter. Kindly provide unique label(s)."
             )
-    return spec, index, others
 
 
 def _stack_dot_value_only(

--- a/tests/functions/test_pivot_longer_spec.py
+++ b/tests/functions/test_pivot_longer_spec.py
@@ -100,6 +100,30 @@ def test_spec_columns_index(df_checks):
         df_checks.pipe(pivot_longer_spec, spec=spec.assign(birth=["ht2", "ht2"]))
 
 
+def test_dot_value_collides_with_identifier_column():
+    """Raise ValueError if '.value' collides with an identifier column."""
+    df = pd.DataFrame({"id": [1, 2], "a": [10, 20]})
+    specs = pd.DataFrame({".name": ["a"], ".value": ["id"]})
+
+    with pytest.raises(
+        ValueError,
+        match="Labels \\('id',\\) already exist as column labels.+",
+    ):
+        pivot_longer_spec(df=df, spec=specs)
+
+
+def test_dot_value_collides_with_spec_metadata_column():
+    """Raise ValueError if '.value' collides with a spec metadata column."""
+    df = pd.DataFrame({"a": [10, 20]})
+    specs = pd.DataFrame({".name": ["a"], ".value": ["part"], "part": ["first"]})
+
+    with pytest.raises(
+        ValueError,
+        match="Label 'part' in the spec's `.value` column already exists.+",
+    ):
+        pivot_longer_spec(df=df, spec=specs)
+
+
 def test_sort_by_appearance(df_checks):
     """Raise error if sort_by_appearance is not boolean."""
     with pytest.raises(TypeError, match="sort_by_appearance should be one of.+"):


### PR DESCRIPTION
## Summary

- reject `.value` labels that collide with identifier columns
- reject `.value` labels that collide with additional spec metadata columns
- share collision validation between `pivot_longer` generated specs and `pivot_longer_spec`
- preserve the existing generated-spec validation messages

## Tests

- `pixi run --frozen pytest tests/functions/test_pivot_longer.py tests/functions/test_pivot_longer_spec.py tests/functions/test_pivot_wider.py tests/functions/test_pivot_wider_spec.py -q`
- `pixi run --frozen pytest tests/functions -q`
- relevant pre-commit hooks

## Stack

This PR is stacked on #1639 and targets its `issue-1634` branch. Once #1639 merges, this PR can be retargeted to `dev`.

Resolves #1635.