### PR TITLE
perf(pivot_longer): reduce temporary allocations

### DIFF
--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -1862,14 +1862,13 @@ def _build_index(index: dict, len_df: int, reps: int, sort_by_appearance: bool) 
     index_ = {}
     indexer = None
     for arr_name, arr in index.items():
-        if is_extension_array_dtype(arr) and sort_by_appearance:
+        if is_extension_array_dtype(arr):
             if indexer is None:
                 indexer = np.arange(len_df)
-                indexer = indexer.repeat(reps)
-            arr = arr[indexer]
-        elif is_extension_array_dtype(arr):
-            indexer = np.arange(len_df)
-            indexer = np.tile(indexer, reps)
+                if sort_by_appearance:
+                    indexer = indexer.repeat(reps)
+                else:
+                    indexer = np.tile(indexer, reps)
             arr = arr[indexer]
         elif sort_by_appearance:
             arr = arr.repeat(reps)
@@ -1901,8 +1900,10 @@ def _build_nulls(contents: dict, dropna: bool) -> np.ndarray | None:
     """Build nulls array"""
     if not dropna:
         return None
-    nulls = [pd.isna(arr) for _, arr in contents.items()]
-    nulls = np.logical_and.reduce(nulls)
+    arrays = iter(contents.values())
+    nulls = pd.isna(next(arrays)).copy()
+    for arr in arrays:
+        np.logical_and(nulls, pd.isna(arr), out=nulls)
     if not nulls.any():
         return None
     return nulls

--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -1901,6 +1901,7 @@ def _build_nulls(contents: dict, dropna: bool) -> np.ndarray | None:
     if not dropna:
         return None
     arrays = iter(contents.values())
+    # Own the first mask because subsequent reductions mutate it in place.
     nulls = pd.isna(next(arrays)).copy()
     for arr in arrays:
         np.logical_and(nulls, pd.isna(arr), out=nulls)

--- a/tests/functions/test_pivot_longer.py
+++ b/tests/functions/test_pivot_longer.py
@@ -1663,6 +1663,58 @@ def test_preserve_extension_types():
     assert_frame_equal(expected, actual)
 
 
+@pytest.mark.parametrize("sort_by_appearance", [False, True])
+def test_multiple_extension_index_columns(sort_by_appearance):
+    """Preserve multiple extension-typed identifier columns and row order."""
+    df = pd.DataFrame(
+        {
+            "integer": pd.array([1, 2], dtype="Int64"),
+            "string": pd.array(["a", "b"], dtype="string"),
+            "category": pd.Categorical(["x", "y"]),
+            "first": [10, 20],
+            "second": [30, 40],
+        }
+    )
+    index = ["integer", "string", "category"]
+    expected = df.melt(id_vars=index)
+    if sort_by_appearance:
+        expected = expected.iloc[[0, 2, 1, 3]].reset_index(drop=True)
+
+    actual = df.pivot_longer(index=index, sort_by_appearance=sort_by_appearance)
+
+    assert_frame_equal(actual, expected)
+
+
+def test_dropna_multiple_extension_value_columns():
+    """Drop rows only when every extension-typed value column is null."""
+    df = pd.DataFrame(
+        {
+            "id": [1, 2, 3],
+            "x_1": pd.array([1, pd.NA, pd.NA], dtype="Int64"),
+            "y_1": pd.array([pd.NA, 2, pd.NA], dtype="Int64"),
+            "x_2": pd.array([3, pd.NA, pd.NA], dtype="Int64"),
+            "y_2": pd.array([4, pd.NA, pd.NA], dtype="Int64"),
+        }
+    )
+    expected = pd.DataFrame(
+        {
+            "id": [1, 2, 1],
+            "set": ["1", "1", "2"],
+            "x": pd.array([1, pd.NA, 3], dtype="Int64"),
+            "y": pd.array([pd.NA, 2, 4], dtype="Int64"),
+        }
+    )
+
+    actual = df.pivot_longer(
+        index="id",
+        names_to=[".value", "set"],
+        names_sep="_",
+        dropna=True,
+    )
+
+    assert_frame_equal(actual, expected)
+
+
 def test_dropna_sort_by_appearance():
     """
     Test output when `dropna=True` and


### PR DESCRIPTION
## Summary

- lazily build and reuse the extension-array row indexer across identifier columns
- combine null masks incrementally in place instead of retaining every mask
- preserve the NumPy identifier fast path without allocating an indexer
- add coverage for nullable integer, string, and categorical identifiers in both ordering modes
- add multi-value nullable `dropna=True` coverage

## Benchmarks

Same-process medians comparing the parent implementation with this branch:

| Workload | Parent | This PR | Result |
| --- | ---: | ---: | ---: |
| `_build_index`, 8 nullable IDs, 200k rows, 20 repetitions | 52.77 ms | 41.72 ms | 1.26x faster |
| End-to-end, 8 nullable IDs, 50k rows, 20 value columns | 17.47 ms | 14.91 ms | 1.17x faster |
| `_build_nulls`, 8 arrays of 1M values | 0.445 ms | 0.300 ms | 1.48x faster |
| End-to-end multi-value `dropna=True`, interleaved runs | 12.53 ms | 12.13 ms | 3.2% faster |

Peak traced memory for the null-mask helper dropped from 16.22 MiB to 1.91 MiB.

## Tests

- `pixi run --frozen pytest tests/functions/test_pivot_longer.py tests/functions/test_pivot_longer_spec.py tests/functions/test_pivot_wider.py tests/functions/test_pivot_wider_spec.py -q`
- `pixi run --frozen pytest tests/functions -q`
- relevant pre-commit hooks

## Stack

This PR is stacked on #1640 and targets its `issue-1635` branch. After #1639 and #1640 merge, retarget this PR to `dev`.

Resolves #1636.