### PR TITLE
[PERF] Speed up balanced NumPy pivot_longer reshapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 -   [PERF] Speed up balanced homogeneous NumPy `pivot_longer` reshapes by
-    slicing value groups positionally. - Issue #1656
+    slicing value groups positionally. - Issue #1656, PR #1668 @samukweku
 -   [ENH] Avoid copying column data during `conditional_join` input
     validation. - Issue #1645, PR #1642 @samukweku
 -   [ENH] Speed up `conditional_join` with an unsorted right join key and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+-   [PERF] Speed up balanced homogeneous NumPy `pivot_longer` reshapes by
+    slicing value groups positionally. - Issue #1656
 -   [ENH] Avoid copying column data during `conditional_join` input
     validation. - Issue #1645, PR #1642 @samukweku
 -   [ENH] Speed up `conditional_join` with an unsorted right join key and

--- a/janitor/functions/pivot.py
+++ b/janitor/functions/pivot.py
@@ -1772,27 +1772,45 @@ def _stack_dot_value_multiple_labels(
         df = df.sort_index(axis=1)
     contents = {}
     indexer = None
-    for label in range(_value.size):
-        frame = df.loc[:, [label]]
-        any_extension_array = (
-            frame.dtypes.map(is_extension_array_dtype).any(axis=None).item()
-        )
-        if sort_by_appearance and any_extension_array:
-            frame = _build_content_extension_array(df=frame)
-            if indexer is None:
-                indexer = _build_indexer_reorder_contents(
-                    length=len_df,
-                    reps=reps,
-                )
-            frame = frame.take(indexer)
-        elif any_extension_array:
-            frame = _build_content_extension_array(df=frame)
-        elif sort_by_appearance:
-            frame = frame._values.ravel(order="C")
-        else:
-            frame = frame._values.ravel(order="F")
-        label = _value[label]
-        contents[label] = frame
+    balanced = _index.size == max_count
+    # A balanced single-block NumPy frame is already laid out in contiguous
+    # value groups, so positional slices avoid repeated DataFrame selection
+    # and dtype inspection. Keep fragmented and extension-backed frames on
+    # the dtype-preserving path below.
+    manager = df._mgr
+    homogeneous_numpy = balanced and manager.is_single_block
+    homogeneous_numpy = homogeneous_numpy and not is_extension_array_dtype(
+        manager.blocks[0].dtype
+    )
+    if homogeneous_numpy:
+        values = df._values
+        order = "C" if sort_by_appearance else "F"
+        for position, label in enumerate(_value):
+            start = position * reps
+            stop = start + reps
+            contents[label] = values[:, start:stop].ravel(order=order)
+    else:
+        for label in range(_value.size):
+            frame = df.loc[:, [label]]
+            any_extension_array = (
+                frame.dtypes.map(is_extension_array_dtype).any(axis=None).item()
+            )
+            if sort_by_appearance and any_extension_array:
+                frame = _build_content_extension_array(df=frame)
+                if indexer is None:
+                    indexer = _build_indexer_reorder_contents(
+                        length=len_df,
+                        reps=reps,
+                    )
+                frame = frame.take(indexer)
+            elif any_extension_array:
+                frame = _build_content_extension_array(df=frame)
+            elif sort_by_appearance:
+                frame = frame._values.ravel(order="C")
+            else:
+                frame = frame._values.ravel(order="F")
+            label = _value[label]
+            contents[label] = frame
     nulls = _build_nulls(contents=contents, dropna=dropna)
     index = _build_index(
         index=index,

--- a/tests/functions/test_pivot_longer.py
+++ b/tests/functions/test_pivot_longer.py
@@ -1753,3 +1753,42 @@ def test_dropna_sort_by_appearance():
     )
 
     assert_frame_equal(actual, expected)
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    ["int64", "float64", "bool", "datetime64[ns]", "timedelta64[ns]"],
+)
+@pytest.mark.parametrize("sort_by_appearance", [False, True])
+def test_balanced_homogeneous_numpy_multiple_values(dtype, sort_by_appearance):
+    """Preserve order and dtype for balanced homogeneous NumPy values."""
+    values = np.arange(12).reshape(3, 4)
+    if dtype == "bool":
+        values = values % 2 == 0
+    elif dtype == "datetime64[ns]":
+        values = values.astype("timedelta64[D]") + np.datetime64("2020-01-01")
+    else:
+        values = values.astype(dtype)
+    df = pd.DataFrame(values, columns=["x_1", "x_2", "y_1", "y_2"])
+
+    actual = df.pivot_longer(
+        names_to=(".value", "position"),
+        names_sep="_",
+        sort_by_appearance=sort_by_appearance,
+    )
+
+    order = "C" if sort_by_appearance else "F"
+    positions = np.array(["1", "2"])
+    if sort_by_appearance:
+        positions = np.tile(positions, len(df))
+    else:
+        positions = positions.repeat(len(df))
+    expected = pd.DataFrame(
+        {
+            "position": positions,
+            "x": df.loc[:, ["x_1", "x_2"]]._values.ravel(order=order),
+            "y": df.loc[:, ["y_1", "y_2"]]._values.ravel(order=order),
+        }
+    )
+
+    assert_frame_equal(actual, expected)


### PR DESCRIPTION
## PR Description

- Add a narrow fast path for balanced multi-value `pivot_longer` specifications backed by one homogeneous NumPy block.
- Slice already-contiguous value groups positionally instead of repeatedly selecting DataFrames and rescanning their dtypes.
- Preserve the existing path for extension arrays, mixed or fragmented blocks, and imbalanced specifications.
- Add exact ordering and dtype coverage for integers, floats, booleans, datetimes, and timedeltas in both appearance-order modes.

Representative median results on pandas 3.0.5:

| Input | Before | After | Change |
| --- | ---: | ---: | ---: |
| 2,500,000 rows x 20 columns | 79.7 ms | 68.3 ms | 14% faster |
| 10,000 rows x 1,000 columns | 20.5 ms | 18.1 ms | 12% faster |
| 1 row x 100,000 columns | 69.4 ms | 31.4 ms | 2.2x faster |
| 1 row x 100,000 columns, 1,000 value groups | 252.8 ms | 33.4 ms | 7.6x faster |

Peak Python allocation was unchanged. Nullable, mixed, and imbalanced fallback cases remained within approximately 1% of the baseline.

Correctness was compared against `dev` over 720 generated combinations spanning empty, tiny, tall, and wide frames; balanced, interleaved, and imbalanced specifications; both ordering modes; `dropna` and `ignore_index`; and NumPy, object, categorical, nullable, string, and timezone-aware dtypes. All results matched element-for-element, including indexes and dtypes.

This PR contributes to #1656 without closing the profiling umbrella issue.

## PR Checklist

1. [x] Changes are on the focused `issue-1656-stack-fast-paths` branch.
2. [x] Added an entry under `CHANGELOG.md`'s Unreleased section.

## Verification

- `pixi run pytest tests/functions/test_pivot_longer.py`: 103 passed, 6 xfailed, 1 xpassed
- Full suite: 1,351 passed, 5 skipped, 48 xfailed, 17 xpassed
- Focused Ruff check and format check passed
- `git diff --check` passed

## Relevant Reviewers

- @ericmjl
