### PR TITLE
[PERF] Update reverse starts-match min boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -548,6 +548,17 @@ CLI.
 include MkDocs. The documentation task is available in the `docs` environment.
 **Recommendation**: Run `pixi run -e docs build-docs` to build documentation.
 
+### [2026-08-26] Include performance evidence in optimization PRs and issues
+
+**Context**: Performance changes are coordinated with implementation changes
+in janitor-rs.
+**Learning**: Benchmark results are part of the performance change's review
+record, not merely local investigation notes.
+**Recommendation**: Every performance PR and its tracking issue must include a
+properly formatted comparison with the old implementation, covering runtime
+and memory for the agreed tiny, large, very-large, and super-large cases and
+duplicate/unique label distributions. State benchmark limitations explicitly.
+
 ---
 
 ## Version History

--- a/janitor/functions/_conditional_join/_agg_functions.py
+++ b/janitor/functions/_conditional_join/_agg_functions.py
@@ -1356,7 +1356,6 @@ def _min_rev_starts_matches(
     index: np.ndarray,
     matches: np.ndarray,
     booleans: np.ndarray,
-    length: int,
 ) -> tuple:
     """
     Compute min
@@ -1385,7 +1384,6 @@ def _min_rev_starts_matches(
         index=index,
         matches=matches,
         booleans=booleans,
-        length=length,
     )
 
 

--- a/janitor/functions/_conditional_join/_get_join_aggs.py
+++ b/janitor/functions/_conditional_join/_get_join_aggs.py
@@ -180,15 +180,17 @@ def _agg_join_left(df: pd.DataFrame, aggfunc: list, indices: dict) -> pd.DataFra
                 booleans = pd.isna(arr)
                 arr = _helpers._convert_array_to_numpy(array=arr)
                 func = mapping[agg]
-                _index, out = func(
+                kwargs = dict(
                     arr=arr,
                     starts=indices["starts"],
                     index=indices["right_index"],
                     matches=indices["matches"],
                     counts=indices["counts_array"],
                     booleans=booleans,
-                    length=indices["right_index"].size,
                 )
+                if agg != "min":
+                    kwargs["length"] = indices["right_index"].size
+                _index, out = func(**kwargs)
                 if agg in {
                     "sum",
                     "prod",


### PR DESCRIPTION
## Summary

- remove the redundant `length` argument from the starts+matches reverse `min` helper
- pass `length` only to the remaining starts-only reverse aggregations that still require it
- follow the compact-state implementation in [janitor-rs #88](https://github.com/pyjanitor-devs/janitor-rs/pull/88)
- enforce benchmark evidence in performance PRs and tracking issues via `AGENTS.md`

## Performance and memory

The paired Rust implementation was compared with the old two-HashMap kernel:

| Scale | Unique labels | Duplicate labels |
|---|---:|---:|
| Tiny | 0.10 -> 0.05 ms | 0.09 -> 0.05 ms |
| Large | 9.70 -> 5.30 ms | 9.73 -> 5.21 ms |
| Very large | 101.14 -> 52.34 ms | 95.67 -> 51.07 ms |
| Super large | 537.81 -> 282.81 ms | 483.93 -> 254.12 ms |

Allocation bytes for one call:

| Scale | Unique labels | Duplicate labels |
|---|---:|---:|
| Tiny | 4,368 -> 8,232 | 4,368 -> 2,856 |
| Large | 69,648 -> 83,880 | 69,648 -> 35,496 |
| Very large | 139,280 -> 167,848 | 139,280 -> 70,312 |
| Super large | 278,544 -> 532,392 | 278,544 -> 139,944 |

The benchmark uses the same aggregation traversal and a counting allocator; it is not a full PyO3 call benchmark. Unique-label memory increases because compact vectors retain output state; duplicate-label memory decreases substantially.

## Verification

- Python `compileall`
- pre-commit suite: Ruff, Ruff format, pydoclint, and repository checks

Closes #85
Part of #23
