### PR TITLE
perf: remove redundant explicit reverse range length

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -548,6 +548,23 @@ CLI.
 include MkDocs. The documentation task is available in the `docs` environment.
 **Recommendation**: Run `pixi run -e docs build-docs` to build documentation.
 
+### [2026-08-27] Document the Reverse Aggregation Boundary Contract
+
+**Context**: Coordinating pyjanitor with janitor-rs reverse aggregation kernels.
+**Learning**: Reverse match kernels consume a flattened candidate tape. Direct
+Rust callers must provide a non-empty tape with the expected shape. Pyjanitor
+owns the producer invariant that match values are 0 or 1. A batch whose every
+candidate range is zero-width is valid at the Python level, so pyjanitor must
+return the typed empty aggregation result before calling Rust. Individual
+zero-width rows remain valid when the overall tape is non-empty.
+**Recommendation**: Keep this contract documented and tested at both
+boundaries: Rust rejects malformed direct inputs, while pyjanitor short-circuits
+legitimate no-candidate batches. Treat `length` as a legacy compatibility
+argument only when supporting an older janitor-rs wheel.
+**ELI5**: Python builds one roll of candidate tickets and Rust checks its shape.
+If there are no tickets, Python returns the empty answer instead of handing an
+empty roll to Rust.
+
 ---
 
 ## Version History

--- a/janitor/functions/_conditional_join/_agg_functions.py
+++ b/janitor/functions/_conditional_join/_agg_functions.py
@@ -1,5 +1,27 @@
+import inspect
+
 import janitor_rs
 import numpy as np
+
+
+def _call_explicit_range_kernel(
+    func,
+    *,
+    starts: np.ndarray,
+    ends: np.ndarray,
+    **kwargs,
+) -> tuple:
+    """Call an explicit-range Rust kernel across the length API transition.
+
+    New janitor-rs kernels derive their output size from ``starts`` and
+    ``ends``.  Until that release is available on PyPI, CI and existing users
+    may still have the older kernels that require ``length``.  Inspecting the
+    callable keeps the normal path free of the redundant span calculation and
+    computes the legacy value only for that older API.
+    """
+    if "length" in inspect.signature(func).parameters:
+        kwargs["length"] = int(ends.max() - starts.min()) if starts.size else 0
+    return func(starts=starts, ends=ends, **kwargs)
 
 
 def _sum_starts(
@@ -88,7 +110,12 @@ def _size_rev_starts_ends(
     """
     Compute size_rev
     """
-    return janitor_rs.compute_size_rev_start_end(starts=starts, ends=ends, index=index)
+    return _call_explicit_range_kernel(
+        janitor_rs.compute_size_rev_start_end,
+        starts=starts,
+        ends=ends,
+        index=index,
+    )
 
 
 def _size_rev_ends_matches(
@@ -1233,10 +1260,11 @@ def _prod_rev_starts_ends(
         func = mapping[dtype_name]
     except KeyError:
         raise KeyError(f"Unsupported data type -> {dtype_name}")
-    return func(
-        arr=arr,
+    return _call_explicit_range_kernel(
+        func,
         starts=starts,
         ends=ends,
+        arr=arr,
         index=index,
         booleans=booleans,
     )
@@ -1491,10 +1519,11 @@ def _min_rev_starts_ends(
         func = mapping[dtype_name]
     except KeyError:
         raise KeyError(f"Unsupported data type -> {dtype_name}")
-    return func(
-        arr=arr,
+    return _call_explicit_range_kernel(
+        func,
         starts=starts,
         ends=ends,
+        arr=arr,
         index=index,
         booleans=booleans,
     )
@@ -1749,10 +1778,11 @@ def _max_rev_starts_ends(
         func = mapping[dtype_name]
     except KeyError:
         raise KeyError(f"Unsupported data type -> {dtype_name}")
-    return func(
-        arr=arr,
+    return _call_explicit_range_kernel(
+        func,
         starts=starts,
         ends=ends,
+        arr=arr,
         index=index,
         booleans=booleans,
     )
@@ -2151,10 +2181,11 @@ def _sum_rev_starts_ends(
         func = mapping[dtype_name]
     except KeyError:
         raise KeyError(f"Unsupported data type -> {dtype_name}")
-    return func(
-        arr=arr,
+    return _call_explicit_range_kernel(
+        func,
         starts=starts,
         ends=ends,
+        arr=arr,
         index=index,
         booleans=booleans,
     )

--- a/janitor/functions/_conditional_join/_agg_functions.py
+++ b/janitor/functions/_conditional_join/_agg_functions.py
@@ -1,3 +1,16 @@
+"""Adapters for conditional-join aggregation kernels.
+
+Reverse match kernels receive a flattened candidate tape. Rust intentionally
+rejects an empty tape, while pyjanitor pre-filters an all-zero-width batch and
+returns the normal typed empty result before dispatch. Individual zero-width
+ranges are valid when the overall tape is non-empty. The comparison stage
+owns the invariant that match values are 0 or 1; Rust validates tape shape.
+
+ELI5: Python builds one long roll of candidate tickets and Rust checks that
+the roll has the right shape. If there are no tickets at all, Python answers
+with an empty result instead of handing an empty roll to Rust.
+"""
+
 import inspect
 
 import janitor_rs

--- a/janitor/functions/_conditional_join/_agg_functions.py
+++ b/janitor/functions/_conditional_join/_agg_functions.py
@@ -84,14 +84,11 @@ def _size_rev_starts_ends(
     starts: np.ndarray,
     ends: np.ndarray,
     index: np.ndarray,
-    length: int,
 ) -> tuple:
     """
     Compute size_rev
     """
-    return janitor_rs.compute_size_rev_start_end(
-        starts=starts, ends=ends, index=index, length=length
-    )
+    return janitor_rs.compute_size_rev_start_end(starts=starts, ends=ends, index=index)
 
 
 def _size_rev_ends_matches(
@@ -1215,7 +1212,6 @@ def _prod_rev_starts_ends(
     ends: np.ndarray,
     index: np.ndarray,
     booleans: np.ndarray,
-    length: int,
 ) -> tuple:
     """
     Compute prod
@@ -1243,7 +1239,6 @@ def _prod_rev_starts_ends(
         ends=ends,
         index=index,
         booleans=booleans,
-        length=length,
     )
 
 
@@ -1475,7 +1470,6 @@ def _min_rev_starts_ends(
     ends: np.ndarray,
     index: np.ndarray,
     booleans: np.ndarray,
-    length: int,
 ) -> tuple:
     """
     Compute min
@@ -1503,7 +1497,6 @@ def _min_rev_starts_ends(
         ends=ends,
         index=index,
         booleans=booleans,
-        length=length,
     )
 
 
@@ -1735,7 +1728,6 @@ def _max_rev_starts_ends(
     ends: np.ndarray,
     index: np.ndarray,
     booleans: np.ndarray,
-    length: int,
 ) -> tuple:
     """
     Compute max
@@ -1763,7 +1755,6 @@ def _max_rev_starts_ends(
         ends=ends,
         index=index,
         booleans=booleans,
-        length=length,
     )
 
 
@@ -2139,7 +2130,6 @@ def _sum_rev_starts_ends(
     ends: np.ndarray,
     index: np.ndarray,
     booleans: np.ndarray,
-    length: int,
 ) -> tuple:
     """
     Compute sum
@@ -2167,7 +2157,6 @@ def _sum_rev_starts_ends(
         ends=ends,
         index=index,
         booleans=booleans,
-        length=length,
     )
 
 

--- a/janitor/functions/_conditional_join/_get_join_aggs.py
+++ b/janitor/functions/_conditional_join/_get_join_aggs.py
@@ -312,7 +312,6 @@ def _agg_join_left(df: pd.DataFrame, aggfunc: list, indices: dict) -> pd.DataFra
             "max": _agg_functions._max_rev_starts_ends,
             "prod": _agg_functions._prod_rev_starts_ends,
         }
-        length = indices["ends"].max() - indices["starts"].min()
         for column_name, agg in aggfunc:
             if agg == "size":
                 func = mapping[agg]
@@ -320,7 +319,6 @@ def _agg_join_left(df: pd.DataFrame, aggfunc: list, indices: dict) -> pd.DataFra
                     starts=indices["starts"],
                     ends=indices["ends"],
                     index=indices["right_index"],
-                    length=length,
                 )
             else:
                 ser = df.loc[indices["left_index"], column_name]
@@ -334,7 +332,6 @@ def _agg_join_left(df: pd.DataFrame, aggfunc: list, indices: dict) -> pd.DataFra
                     ends=indices["ends"],
                     index=indices["right_index"],
                     booleans=booleans,
-                    length=length,
                 )
                 if agg in {
                     "sum",

--- a/tests/functions/test_conditional_join.py
+++ b/tests/functions/test_conditional_join.py
@@ -5764,6 +5764,29 @@ def test_single_condition_greater_than_dates_agg(df, right):
     assert_frame_equal(expected, actual)
 
 
+def test_join_agg_drops_equal_explicit_range_bounds():
+    """Rows with no candidates do not create an empty Rust range."""
+    left = pd.DataFrame({"value": [0, 10]})
+    right = pd.DataFrame({"value": [1, 2, 3], "payload": [4, 5, 6]})
+
+    actual = left.join_agg(
+        right,
+        ("value", "value", ">"),
+        aggfunc=[("payload", "sum"), ("payload", "size")],
+    )
+
+    expected = pd.DataFrame(
+        {
+            ("payload", "sum"): [15],
+            ("payload", "size"): [3],
+        },
+        index=pd.Index([1]),
+    )
+    expected.columns = pd.MultiIndex.from_tuples(expected.columns)
+
+    assert_frame_equal(actual, expected)
+
+
 @pytest.mark.turtle
 @settings(deadline=None, max_examples=10)
 @given(df=conditional_df(), right=conditional_right())


### PR DESCRIPTION
## Summary

Closes the pyjanitor side of janitor-rs#107 and contributes to #23.

The Rust explicit reverse starts/ends kernels now derive their own bounded capacity hint and no longer accept a redundant `length` argument. This change removes the corresponding Python-side `ends.max() - starts.min()` computation and stops passing `length` to the size kernel.

ELI5: the Python layer was calculating a size estimate that Rust could calculate more safely from the actual ranges. Removing it keeps one source of truth and avoids reserving based on a potentially misleading span, especially with duplicate labels.

## Performance and memory

The paired janitor-rs PR includes Criterion comparisons against the old HashMap-per-label implementation for unique and duplicate labels at n=32, 10,000, 100,000, and 1,000,000. The compact kernels are generally ~1.5–3x faster for min/max/prod/size and ~15–40% faster for sum, with broadly comparable memory and substantially lower peak live memory in representative duplicate-label cases. The benchmark records allocation count, allocated bytes, and peak live memory.

## Verification

- Python syntax checks passed.
- Pre-commit checks passed except `pixi-install`, which was skipped because dependency resolution was unavailable due to a transient DNS failure; ruff, formatting, pydoclint, interrogate, whitespace, and file checks passed.

Coordinated janitor-rs PR: branch `issue-107-explicit-ranges`.
