### PR TITLE
docs: explain conditional_join index representations

### DIFF
--- a/janitor/functions/_conditional_join/__init__.py
+++ b/janitor/functions/_conditional_join/__init__.py
@@ -1,0 +1,10 @@
+"""Internal building blocks for :func:`janitor.conditional_join`.
+
+The join kernels communicate with result and aggregation code using compact
+positional representations. ``starts`` and ``ends`` are per-row half-open
+boundaries into right-hand candidates; ``matches`` is a flat survivor mask;
+and ``positions`` is an integer tape indexing ``right_index``. ``left_index``
+and ``right_index`` carry the original dataframe index values (labels), while
+``positions`` entries are positional offsets into the right-side array. Not
+every representation is present for every join shape.
+"""

--- a/janitor/functions/_conditional_join/_get_join_aggs.py
+++ b/janitor/functions/_conditional_join/_get_join_aggs.py
@@ -15,7 +15,9 @@ def _agg_join_left(df: pd.DataFrame, aggfunc: list, indices: dict) -> pd.DataFra
     half-open ``starts``/``ends`` boundaries, a flat ``matches`` mask, or a
     ``positions``
     tape indexing right-side positions. The index arrays retain dataframe
-    labels while the tape is positional indirection.
+    labels while the tape is positional indirection. Input indexes are usually
+    unique, but uniqueness is not required; their monotonic order is not
+    assured, so callers must preserve the supplied ordering explicitly.
     """
     if not indices["left_index"].size:
         dtypes = df.dtypes
@@ -414,7 +416,8 @@ def _agg_join_right(right: pd.DataFrame, aggfunc: list, indices: dict) -> pd.Dat
     The compact ``indices`` contract is the same as ``_agg_join_left`` but the
     output is indexed by right-side dataframe index values and values come from
     the left dataframe. Boundaries are half-open and the positions tape remains
-    positional indirection.
+    positional indirection. Input indexes are usually unique, but uniqueness
+    is not required and monotonic ordering is not assured.
     """
     if not indices["left_index"].size:
         dtypes = right.dtypes

--- a/janitor/functions/_conditional_join/_get_join_aggs.py
+++ b/janitor/functions/_conditional_join/_get_join_aggs.py
@@ -9,8 +9,13 @@ from janitor.functions._conditional_join import _agg_functions, _helpers
 
 
 def _agg_join_left(df: pd.DataFrame, aggfunc: list, indices: dict) -> pd.DataFrame:
-    """
-    Compute aggregation for multiple joins
+    """Aggregate the right side for left-driven compact join indices.
+
+    ``indices`` contains original dataframe index values and may include
+    half-open ``starts``/``ends`` boundaries, a flat ``matches`` mask, or a
+    ``positions``
+    tape indexing right-side positions. The index arrays retain dataframe
+    labels while the tape is positional indirection.
     """
     if not indices["left_index"].size:
         dtypes = df.dtypes
@@ -404,8 +409,12 @@ def _agg_join_left(df: pd.DataFrame, aggfunc: list, indices: dict) -> pd.DataFra
 
 
 def _agg_join_right(right: pd.DataFrame, aggfunc: list, indices: dict) -> pd.DataFrame:
-    """
-    Compute aggregation for multiple joins
+    """Aggregate the left side for right-driven (reverse) joins.
+
+    The compact ``indices`` contract is the same as ``_agg_join_left`` but the
+    output is indexed by right-side dataframe index values and values come from
+    the left dataframe. Boundaries are half-open and the positions tape remains
+    positional indirection.
     """
     if not indices["left_index"].size:
         dtypes = right.dtypes

--- a/janitor/functions/_conditional_join/_helpers.py
+++ b/janitor/functions/_conditional_join/_helpers.py
@@ -556,8 +556,14 @@ def _build_indices_positions(
     starts: np.ndarray | None = None,
     ends: np.ndarray | None = None,
 ):
-    """
-    Build indices for multiple joins
+    """Build public positional indices from compact join candidates.
+
+    ``left_index`` and ``right_index`` contain original dataframe index values.
+    ``starts``/``ends`` are optional half-open candidate boundaries and
+    ``positions`` maps each surviving candidate position into ``right_index``.
+    ``counts_array`` gives the surviving count for each left row; ``total`` is
+    the number of emitted pairs. The index arrays retain labels throughout;
+    only ``positions`` is positional indirection.
     """
     if keep == "all":
         left_index = janitor_rs.repeat_index(
@@ -605,8 +611,13 @@ def build_indices_matches(
     total: int,
     keep: str,
 ) -> dict:
-    """
-    Build indices for multiple joins, where `matches` exist
+    """Build indices while filtering candidates with a flat ``matches`` mask.
+
+    The mask is aligned with the candidate slices delimited by optional
+    ``starts`` and ``ends`` arrays (ends are exclusive). ``counts_array`` and
+    ``total`` describe surviving entries. The index arrays retain dataframe
+    labels while the mask and any positions tape remain positional. Empty
+    slices are valid and emit no pair.
     """
     if (keep == "all") and (starts is not None) and (ends is None):
         left = janitor_rs.repeat_index(

--- a/janitor/functions/conditional_join.py
+++ b/janitor/functions/conditional_join.py
@@ -1385,6 +1385,26 @@ def join_agg(
     represent the positions of the rows from the right dataframe
     that have matches in the left dataframe.
 
+    Internally, join discovery may remain compact until aggregation. A
+    ``starts``/``ends`` pair contains one half-open candidate slice per driving
+    row. ``matches`` is a flat mask aligned with those slices, and ``positions``
+    is an integer tape indexing ``right_index`` rather than a dataframe-label
+    array. ``left_index`` and ``right_index`` carry original dataframe index
+    values (labels); ``positions`` entries are offsets into the right-side
+    array. Depending
+    on join shape, some representations are absent: equality joins may return
+    pairs directly, while range joins commonly retain boundaries until
+    aggregation. Empty ranges have equal boundaries and contribute no matches.
+
+    For example, with ``right_index = ["a", "b", "c", "d"]``,
+    ``positions = [2, 0, 2, 3, 1]``, ``starts = [0, 2, 4]`` and
+    ``ends = [2, 4, 5]``, the three driving rows select ``["c", "a"]``,
+    ``["c", "d"]`` and ``["b"]`` respectively. Simple/equi joins generally
+    return direct pairs; starts-only/ends-only paths represent one-sided
+    inequalities; range and multi-condition joins may retain both boundaries
+    and a mask. ``keep="first"`` or ``keep="last"`` reduces each slice before
+    labels are restored, while ``keep="all"`` emits every surviving position.
+
     !!! info "New in version 0.32.10"
 
     Examples:


### PR DESCRIPTION
## Summary

- Document the compact `starts`/`ends`/`matches`/`positions` representation used by `conditional_join` and `join_agg`.
- Clarify dataframe index labels versus positional offsets and reverse-aggregation orientation.
- Add contracts to the internal representation and aggregation helpers.

## Testing

- `python -m compileall -q janitor` (pass)
- `git diff --check` (pass)
- `pixi run lint` (not run: Pixi is not installed on the host)
- `python -m pytest tests/functions/test_conditional_join.py -q` (not run: pytest is not installed on the host)
- GitHub Actions Python 3.11, 3.12, and 3.13 suites (pass)
- GitHub Actions documentation build (content build passed; preview deployment failed due to repository workflow permission: `github-actions[bot]` received HTTP 403 pushing `gh-pages`)

relates to #1688