### PR TITLE
[DOC] Explain when cumulative-event aggregation is preferable to join_agg (#1702)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- [DOC] Add documentation explaining when cumulative-event aggregation is preferable to range join aggregations. - Issue #1702 @sumangouda
 -   [PERF] Reduce peak memory in `_build_indexer_reorder_contents` for wide frames (reps >= 8) using single NumPy allocation; tall frames with few repetitions retain the original reshape path. - Issue #1655 @Anupam2400
 -   [ENH] `conditional_join` now picks the most selective `<`/`<=`/`>`/`>=` predicate as its binary-search anchor (instead of the first one supplied) when `keep` is `'first'` or `'last'`, fixing pathological slowdowns from unfavorable predicate ordering; the choice is estimated from a fixed-size sample so the selection cost no longer scales with input size; `keep='all'` output is unaffected. - Issue #1641 @samukweku
 -   [BUG] Fix `conditional_join` crash for `keep='last'` joins with a single `<`/`<=` window and multiple non-equi conditions - a missing `counts` argument to the Rust `index_starts_only_keep_last` call. - Issue #1641 @samukweku

--- a/janitor/functions/conditional_join.py
+++ b/janitor/functions/conditional_join.py
@@ -115,7 +115,51 @@ def conditional_join(
     will be a MultiIndex; the first level points to the original positions in `df`,
     while the second level points to the original positions in `right`.
 
+    !!! tip "Cumulative-Event Aggregation vs. Range Join Aggregations"
 
+        When computing single additive running totals (e.g., daily sums) over overlapping time intervals, 
+        a cumulative-event aggregation (sweep-line algorithm) is often significantly faster than using range join 
+        aggregations (`join_agg` / `conditional_join`). 
+
+        **Algorithm & Complexity:**
+        For inclusive intervals `[start_date, end_date]`, group values by start and end dates, taking cumulative sums (`cumsum`) 
+        reindexed to the target calendar, and subtract the end totals with an appropriate shift (+1 period for inclusive bounds). 
+        This operates in $\mathcal{O}(N + K)$ time complexity, where $N$ is the number of interval rows and $K$ is the number of calendar points.
+
+        **When to use `join_agg` / `conditional_join` instead:**
+        
+        - Multiple simultaneous aggregations are needed at once.
+        - Non-additive aggregations such as `min`, `max`, or `prod`.
+        - Combining equality conditions with range conditions.
+        - Arbitrary interval/query shapes or standard join semantics.
+
+        **Special Considerations:**
+        
+        - **Endpoint Handling:** Ensure inclusive vs. exclusive bounds are shifted properly (e.g., `end_date + pd.Timedelta(days=1)`).
+        - **Precision:** Accumulating floating-point values over long ranges may incur numerical drift; consider rounding or integer representation when exact precision is required.
+        - **Reference:** For details on range aggregation optimizations, see Issue #1648.
+
+        ```python
+        import pandas as pd
+
+        # Example: Daily active totals using cumulative-event aggregation
+        df = pd.DataFrame(
+            {
+                "start_date": pd.to_datetime(["2023-01-01", "2023-01-02"]),
+                "end_date": pd.to_datetime(["2023-01-03", "2023-01-04"]),
+                "val": [10, 20],
+            }
+        )
+        calendar = pd.date_range("2023-01-01", "2023-01-05")
+
+        starts = df.groupby("start_date")["val"].sum()
+        ends = df.groupby(df["end_date"] + pd.Timedelta(days=1))["val"].sum()
+
+        daily_totals = (
+            starts.reindex(calendar, fill_value=0)
+            - ends.reindex(calendar, fill_value=0)
+        ).cumsum()
+        ```
 
     Examples:
         >>> import pandas as pd
@@ -1386,6 +1430,14 @@ def join_agg(
     that have matches in the left dataframe.
 
     !!! info "New in version 0.32.10"
+    
+    !!! tip "Cumulative-Event Aggregation Alternative"
+
+        For single additive running totals (such as daily interval sums), 
+        computing cumulative start and end events using `groupby` and `cumsum` operates 
+        in $\mathcal{O}(N + K)$ time and is often significantly faster than calling 
+        `join_agg(..., reverse=True)`. See the [`conditional_join`][janitor.functions.conditional_join.conditional_join] 
+        documentation for details and a runnable example.
 
     Examples:
         >>> import pandas as pd


### PR DESCRIPTION
## PR Description

Please describe the changes proposed in the pull request:

- Added user-facing documentation in `janitor/functions/conditional_join.py` explaining when cumulative-event aggregation (sweep-line algorithm) is preferable to range join aggregations (`join_agg`/`conditional_join`).
- Included a runnable Python example demonstrating the O(N + K) cumulative event pattern using pandas `groupby` and `cumsum`.
- Updated `CHANGELOG.md` to record the documentation addition.

**This PR resolves #1702.**

## PR Checklist

Please ensure that you have done the following:

1. [x] PR in from a fork off your branch. Do not PR from `<your_username>`:`dev`, but rather from `<your_username>`:`<feature-branch_name>`.
2. [x] Add a line to `CHANGELOG.md` under the latest version header (i.e. the one that is "on deck") describing the contribution.

## Automatic checks

There will be automatic checks run on the PR. These include:

- Building a preview of the docs on Netlify
- Automatically linting the code
- Making sure the code is documented
- Making sure that all tests are passed
- Making sure that code coverage doesn't go down.

## Relevant Reviewers

Please tag maintainers to review.

- @ericmjl