### PR TITLE
docs: reorganize conditional_join and join_agg guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -548,6 +548,16 @@ CLI.
 include MkDocs. The documentation task is available in the `docs` environment.
 **Recommendation**: Run `pixi run -e docs build-docs` to build documentation.
 
+### [2026-09-03] Distinguish Public Docs from Maintainer Comments
+
+**Context**: Reorganizing the `conditional_join` and `join_agg` documentation.
+**Learning**: Implementation details are not needed in user-facing generated
+documentation, but they can still be useful to maintainers working on the code.
+**Recommendation**: Keep public docstrings focused on user-visible behavior,
+arguments, limitations, and examples. Retain implementation-only explanations
+as source comments when they clarify non-obvious code or algorithms for
+maintainers.
+
 ---
 
 ## Version History

--- a/janitor/functions/conditional_join.py
+++ b/janitor/functions/conditional_join.py
@@ -115,52 +115,6 @@ def conditional_join(
     will be a MultiIndex; the first level points to the original positions in `df`,
     while the second level points to the original positions in `right`.
 
-    !!! tip "Cumulative-Event Aggregation vs. Range Join Aggregations"
-
-        When computing single additive running totals (e.g., daily sums) over overlapping time intervals,
-        a cumulative-event aggregation (sweep-line algorithm) is often significantly faster than using range join
-        aggregations (`join_agg` / `conditional_join`).
-
-        **Algorithm & Complexity:**
-        For inclusive intervals `[start_date, end_date]`, group values by start and end dates, taking cumulative sums (`cumsum`)
-        reindexed to the target calendar, and subtract the end totals with an appropriate shift (+1 period for inclusive bounds).
-        This operates in $\mathcal{O}(N + K)$ time complexity, where $N$ is the number of interval rows and $K$ is the number of calendar points.
-
-        **When to use `join_agg` / `conditional_join` instead:**
-
-        - Multiple simultaneous aggregations are needed at once.
-        - Non-additive aggregations such as `min`, `max`, or `prod`.
-        - Combining equality conditions with range conditions.
-        - Arbitrary interval/query shapes or standard join semantics.
-
-        **Special Considerations:**
-
-        - **Endpoint Handling:** Ensure inclusive vs. exclusive bounds are shifted properly (e.g., `end_date + pd.Timedelta(days=1)`).
-        - **Precision:** Accumulating floating-point values over long ranges may incur numerical drift; consider rounding or integer representation when exact precision is required.
-        - **Reference:** For details on range aggregation optimizations, see Issue #1648.
-
-        ```python
-        import pandas as pd
-
-        # Example: Daily active totals using cumulative-event aggregation
-        df = pd.DataFrame(
-            {
-                "start_date": pd.to_datetime(["2023-01-01", "2023-01-02"]),
-                "end_date": pd.to_datetime(["2023-01-03", "2023-01-04"]),
-                "val": [10, 20],
-            }
-        )
-        calendar = pd.date_range("2023-01-01", "2023-01-05")
-
-        starts = df.groupby("start_date")["val"].sum()
-        ends = df.groupby(df["end_date"] + pd.Timedelta(days=1))["val"].sum()
-
-        daily_totals = (
-            starts.reindex(calendar, fill_value=0)
-            - ends.reindex(calendar, fill_value=0)
-        ).cumsum()
-        ```
-
     Examples:
         >>> import pandas as pd
         >>> import janitor
@@ -1451,13 +1405,59 @@ def join_agg(
 
     !!! info "New in version 0.32.10"
 
-    !!! tip "Cumulative-Event Aggregation Alternative"
+    !!! tip "Cumulative-Event Aggregation vs. Range Join Aggregations"
 
-        For single additive running totals (such as daily interval sums),
-        computing cumulative start and end events using `groupby` and `cumsum` operates
-        in $\mathcal{O}(N + K)$ time and is often significantly faster than calling
-        `join_agg(..., reverse=True)`. See the [`conditional_join`][janitor.functions.conditional_join.conditional_join]
-        documentation for details and a runnable example.
+        When computing single additive running totals (e.g., daily sums) over
+        overlapping time intervals, a cumulative-event aggregation (sweep-line
+        algorithm) is often significantly faster than using range join
+        aggregations (`join_agg` / `conditional_join`).
+
+        **Algorithm & Complexity:**
+        For inclusive intervals `[start_date, end_date]`, group values by start
+        and end dates, taking cumulative sums (`cumsum`) reindexed to the target
+        calendar, and subtract the end totals with an appropriate shift (+1
+        period for inclusive bounds). This operates in $\\mathcal{O}(N + K)$
+        time complexity, where $N$ is the number of interval rows and $K$ is the
+        number of calendar points.
+
+        **When to use `join_agg` / `conditional_join` instead:**
+
+        - Multiple simultaneous aggregations are needed at once.
+        - Non-additive aggregations such as `min`, `max`, or `prod`.
+        - Combining equality conditions with range conditions.
+        - Arbitrary interval/query shapes or standard join semantics.
+
+        **Special Considerations:**
+
+        - **Endpoint Handling:** Ensure inclusive vs. exclusive bounds are
+          shifted properly (e.g., `end_date + pd.Timedelta(days=1)`).
+        - **Precision:** Accumulating floating-point values over long ranges may
+          incur numerical drift; consider rounding or integer representation
+          when exact precision is required.
+        - **Reference:** For details on range aggregation optimizations, see
+          Issue #1648.
+
+        ```python
+        import pandas as pd
+
+        # Example: Daily active totals using cumulative-event aggregation
+        df = pd.DataFrame(
+            {
+                "start_date": pd.to_datetime(["2023-01-01", "2023-01-02"]),
+                "end_date": pd.to_datetime(["2023-01-03", "2023-01-04"]),
+                "val": [10, 20],
+            }
+        )
+        calendar = pd.date_range("2023-01-01", "2023-01-05")
+
+        starts = df.groupby("start_date")["val"].sum()
+        ends = df.groupby(df["end_date"] + pd.Timedelta(days=1))["val"].sum()
+
+        daily_totals = (
+            starts.reindex(calendar, fill_value=0)
+            - ends.reindex(calendar, fill_value=0)
+        ).cumsum()
+        ```
 
     Examples:
         >>> import pandas as pd

--- a/janitor/functions/conditional_join.py
+++ b/janitor/functions/conditional_join.py
@@ -631,6 +631,26 @@ def _conditional_join_compute(
             keep=keep,
             return_matching_indices=return_building_blocks or aggfunc,
         )
+    # Internally, join discovery may remain compact until aggregation. A
+    # ``starts``/``ends`` pair contains one half-open candidate slice per driving
+    # row. ``matches`` is a flat mask aligned with those slices, and ``positions``
+    # is an integer tape indexing ``right_index`` rather than a dataframe-label
+    # array. ``left_index`` and ``right_index`` carry original dataframe index
+    # values (labels); ``positions`` entries are offsets into the right-side
+    # array. Depending on join shape, some representations are absent: equality
+    # joins may return pairs directly, while range joins commonly retain
+    # boundaries until aggregation. Empty ranges have equal boundaries and
+    # contribute no matches.
+
+    # For example, with ``right_index = ["a", "b", "c", "d"]``,
+    # ``positions = [2, 0, 2, 3, 1]``, ``starts = [0, 2, 4]`` and
+    # ``ends = [2, 4, 5]``, the three driving rows select ``["c", "a"]``,
+    # ``["c", "d"]`` and ``["b"]`` respectively. Simple/equi joins generally
+    # return direct pairs; starts-only/ends-only paths represent one-sided
+    # inequalities; range and multi-condition joins may retain both boundaries
+    # and a mask. ``keep="first"`` or ``keep="last"`` reduces each slice before
+    # labels are restored, while ``keep="all"`` emits every surviving position.
+
     if aggfunc and reverse:
         return _get_join_aggs._agg_join_left(
             df=df,
@@ -1516,26 +1536,6 @@ def join_agg(
     Returns:
         A pandas DataFrame.
     """
-
-    # Internally, join discovery may remain compact until aggregation. A
-    # ``starts``/``ends`` pair contains one half-open candidate slice per driving
-    # row. ``matches`` is a flat mask aligned with those slices, and ``positions``
-    # is an integer tape indexing ``right_index`` rather than a dataframe-label
-    # array. ``left_index`` and ``right_index`` carry original dataframe index
-    # values (labels); ``positions`` entries are offsets into the right-side
-    # array. Depending
-    # on join shape, some representations are absent: equality joins may return
-    # pairs directly, while range joins commonly retain boundaries until
-    # aggregation. Empty ranges have equal boundaries and contribute no matches.
-
-    # For example, with ``right_index = ["a", "b", "c", "d"]``,
-    # ``positions = [2, 0, 2, 3, 1]``, ``starts = [0, 2, 4]`` and
-    # ``ends = [2, 4, 5]``, the three driving rows select ``["c", "a"]``,
-    # ``["c", "d"]`` and ``["b"]`` respectively. Simple/equi joins generally
-    # return direct pairs; starts-only/ends-only paths represent one-sided
-    # inequalities; range and multi-condition joins may retain both boundaries
-    # and a mask. ``keep="first"`` or ``keep="last"`` reduces each slice before
-    # labels are restored, while ``keep="all"`` emits every surviving position.
 
     return _conditional_join_compute(
         df=df,

--- a/janitor/functions/conditional_join.py
+++ b/janitor/functions/conditional_join.py
@@ -1383,26 +1383,6 @@ def join_agg(
     represent the positions of the rows from the right dataframe
     that have matches in the left dataframe.
 
-    Internally, join discovery may remain compact until aggregation. A
-    ``starts``/``ends`` pair contains one half-open candidate slice per driving
-    row. ``matches`` is a flat mask aligned with those slices, and ``positions``
-    is an integer tape indexing ``right_index`` rather than a dataframe-label
-    array. ``left_index`` and ``right_index`` carry original dataframe index
-    values (labels); ``positions`` entries are offsets into the right-side
-    array. Depending
-    on join shape, some representations are absent: equality joins may return
-    pairs directly, while range joins commonly retain boundaries until
-    aggregation. Empty ranges have equal boundaries and contribute no matches.
-
-    For example, with ``right_index = ["a", "b", "c", "d"]``,
-    ``positions = [2, 0, 2, 3, 1]``, ``starts = [0, 2, 4]`` and
-    ``ends = [2, 4, 5]``, the three driving rows select ``["c", "a"]``,
-    ``["c", "d"]`` and ``["b"]`` respectively. Simple/equi joins generally
-    return direct pairs; starts-only/ends-only paths represent one-sided
-    inequalities; range and multi-condition joins may retain both boundaries
-    and a mask. ``keep="first"`` or ``keep="last"`` reduces each slice before
-    labels are restored, while ``keep="all"`` emits every surviving position.
-
     !!! info "New in version 0.32.10"
 
     !!! tip "Cumulative-Event Aggregation vs. Range Join Aggregations"
@@ -1533,6 +1513,27 @@ def join_agg(
     Returns:
         A pandas DataFrame.
     """
+
+    # Internally, join discovery may remain compact until aggregation. A
+    # ``starts``/``ends`` pair contains one half-open candidate slice per driving
+    # row. ``matches`` is a flat mask aligned with those slices, and ``positions``
+    # is an integer tape indexing ``right_index`` rather than a dataframe-label
+    # array. ``left_index`` and ``right_index`` carry original dataframe index
+    # values (labels); ``positions`` entries are offsets into the right-side
+    # array. Depending
+    # on join shape, some representations are absent: equality joins may return
+    # pairs directly, while range joins commonly retain boundaries until
+    # aggregation. Empty ranges have equal boundaries and contribute no matches.
+
+    # For example, with ``right_index = ["a", "b", "c", "d"]``,
+    # ``positions = [2, 0, 2, 3, 1]``, ``starts = [0, 2, 4]`` and
+    # ``ends = [2, 4, 5]``, the three driving rows select ``["c", "a"]``,
+    # ``["c", "d"]`` and ``["b"]`` respectively. Simple/equi joins generally
+    # return direct pairs; starts-only/ends-only paths represent one-sided
+    # inequalities; range and multi-condition joins may retain both boundaries
+    # and a mask. ``keep="first"`` or ``keep="last"`` reduces each slice before
+    # labels are restored, while ``keep="all"`` emits every surviving position.
+
     return _conditional_join_compute(
         df=df,
         right=right,

--- a/janitor/functions/conditional_join.py
+++ b/janitor/functions/conditional_join.py
@@ -1416,6 +1416,9 @@ def join_agg(
           when exact precision is required.
         - **Reference:** For details on range aggregation optimizations, see
           Issue #1648.
+        - **Inspiration:** See this
+          [Stack Overflow discussion](https://stackoverflow.com/questions/69194678/python-fast-aggregation-of-many-observations-to-daily-sum)
+          for the cumulative-sum and reindexing approach.
 
         ```python
         import pandas as pd

--- a/mkdocs/api/functions.md
+++ b/mkdocs/api/functions.md
@@ -19,7 +19,6 @@
         - complete
         - concatenate_columns
         - conditional_join
-        - join_agg
         - convert_date
         - count_cumulative_unique
         - currency_column_to_numeric
@@ -42,6 +41,7 @@
         - impute
         - jitter
         - join_apply
+        - join_agg
         - label_encode
         - limit_column_characters
         - min_max_scale

--- a/mkdocs/api/functions.md
+++ b/mkdocs/api/functions.md
@@ -19,6 +19,7 @@
         - complete
         - concatenate_columns
         - conditional_join
+        - join_agg
         - convert_date
         - count_cumulative_unique
         - currency_column_to_numeric

--- a/mkdocs/api/functions.md
+++ b/mkdocs/api/functions.md
@@ -40,8 +40,8 @@
         - groupby_topk
         - impute
         - jitter
-        - join_apply
         - join_agg
+        - join_apply
         - label_encode
         - limit_column_characters
         - min_max_scale

--- a/pixi.lock
+++ b/pixi.lock
@@ -22775,8 +22775,8 @@ packages:
   timestamp: 1774796815820
 - pypi: ./
   name: pyjanitor
-  version: 0.32.23
-  sha256: 2c551db6e9b84114e74ba359a19fafa89130d1d5ce2b322f906d8b934e72926a
+  version: 0.32.25
+  sha256: f3f2e22383b953248f636a36d9db8154dc784315976b59c96e78c8efcba69fc5
   requires_dist:
   - pandas>=3.0.0
   - natsort>=8.4.0,<9


### PR DESCRIPTION
## Summary

Closes #1708.

- Move the cumulative-event aggregation tip and runnable example from the `conditional_join` docstring to `join_agg`.
- Keep aggregation-specific guidance with the aggregation API.
- Add `join_agg` to the Functions API navigation.
- Add a direct link to the Stack Overflow discussion that inspired the cumulative-sum/reindexing example.
- Keep maintainer-oriented implementation notes as source comments rather than exposing them in generated user documentation.

## Validation

- `pixi run pytest tests/functions/test_conditional_join.py -q` — 278 passed, 1 skipped
- `pixi run pytest --doctest-modules janitor/functions/conditional_join.py -q` — 2 passed
- `pixi run -e docs build-docs` — passed
- `pixi run markdownlint mkdocs/api/functions.md` — passed
- Pre-commit hooks — passed
